### PR TITLE
Add local Vite proxy for auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,3 @@
-VITE_API_BASE_URL=http://localhost:8080
+# Optional backend base URL for deployed or direct cross-origin API access.
+# Leave unset for local Vite proxy development.
+VITE_API_BASE_URL=

--- a/README.md
+++ b/README.md
@@ -15,25 +15,34 @@ Then open `http://localhost:5173`.
 
 ## Local backend configuration
 
-The registration and login pages submit to:
+For local development, the Vite dev server proxies these backend routes to `http://localhost:8080`:
 
 - `POST /auth/register`
 - `POST /auth/login`
+- `GET /users/me`
+- `/presets/*`
 
-If `VITE_API_BASE_URL` is set, the frontend posts to:
+With the proxy in place, the frontend can keep using same-origin requests such as `/auth/login` while the backend runs separately on port `8080`.
+
+No frontend environment variables are required for this local proxy-based setup.
+
+To run the backend locally, start the backend stack from the `mage-backend` repository with:
+
+```bash
+docker compose up --build
+```
+
+The backend quick-start and local run details are documented in `mage-backend/docs/getting-started.md`.
+
+`VITE_API_BASE_URL` is still supported for deployed or intentionally cross-origin setups. When it is set, the frontend sends requests directly to that origin instead of using the local Vite proxy:
 
 ```text
 ${VITE_API_BASE_URL}/auth/register
 ${VITE_API_BASE_URL}/auth/login
+${VITE_API_BASE_URL}/users/me
 ```
 
-If `VITE_API_BASE_URL` is not set, the pages fall back to same-origin `/auth/register` and `/auth/login`.
-
-For local development with the backend running on port `8080`, create a `.env.local` file:
-
-```bash
-VITE_API_BASE_URL=http://localhost:8080
-```
+Leave `VITE_API_BASE_URL` unset for normal localhost development so the proxy handles auth and current-user requests.
 
 ## Routing
 

--- a/docs/login-page.md
+++ b/docs/login-page.md
@@ -25,6 +25,8 @@ The page reads `VITE_API_BASE_URL` at runtime. When the variable is set, request
 
 When a stored access token exists, the frontend bootstraps auth state by calling `${VITE_API_BASE_URL}/users/me` or same-origin `/users/me`.
 
+For normal localhost development, the Vite dev server proxies same-origin `/auth/login` and `/users/me` requests to `http://localhost:8080`.
+
 ## UI behavior
 
 - Requires email and password before submission

--- a/docs/registration-page.md
+++ b/docs/registration-page.md
@@ -24,6 +24,8 @@ Request body:
 
 The page reads `VITE_API_BASE_URL` at runtime. When the variable is set, requests are sent to `${VITE_API_BASE_URL}/auth/register`. When it is not set, the page uses same-origin `/auth/register`.
 
+For normal localhost development, the Vite dev server proxies same-origin `/auth/register` requests to `http://localhost:8080`.
+
 ## UI behavior
 
 - Requires display name, email, and password before submission

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,27 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react-swc'
 
+const backendProxyTarget = 'http://localhost:8080'
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/auth': {
+        target: backendProxyTarget,
+        changeOrigin: true,
+      },
+      '/users': {
+        target: backendProxyTarget,
+        changeOrigin: true,
+      },
+      '/presets': {
+        target: backendProxyTarget,
+        changeOrigin: true,
+      },
+    },
+  },
   test: {
     css: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Summary

This PR completes the local-development auth integration story for the frontend by adding a Vite dev proxy for backend auth and protected-user routes.

With this change, the React app can register, log in, and restore the current user locally through same-origin frontend requests while the Spring Boot backend runs separately on `http://localhost:8080`.

## Changes

- add a Vite dev proxy for:
  - `/auth`
  - `/users`
  - `/presets`
- route proxied local requests to `http://localhost:8080`
- keep same-origin frontend API usage for local development
- update `.env.example` to treat `VITE_API_BASE_URL` as optional instead of required for localhost
- update frontend README local setup guidance to prefer the Vite proxy workflow
- document proxy-backed local behavior for:
  - registration
  - login
  - current-user bootstrap

## Why This Approach

A local Vite proxy is the better fit for this story because it:
- avoids browser CORS issues during local development
- does not require loosening backend CORS policy for localhost
- keeps frontend code using the same relative API paths it can also use behind a same-origin reverse proxy later

## Verification

- `npm run test`
- `npm run lint`
- `npm run build`

Manual local verification was also completed against the running backend through the frontend dev server:
- `POST /auth/register`
- `POST /auth/login`
- `GET /users/me`

## Notes

- Local `.env.local` remains untracked and was not included in this PR.
- `VITE_API_BASE_URL` is still supported for deployed or intentionally cross-origin setups, but normal localhost development should leave it unset so the Vite proxy is used.
