### PR TITLE
create preset page form

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -18,10 +18,11 @@
 }
 
 .nav-inner {
-  width: min(1100px, 92%);
+  width: min(1200px, 92%);
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 16px;
 }
 
 .logo {
@@ -32,75 +33,207 @@
   color: var(--accent);
 }
 
-.nav-links {
-  display: flex;
-  gap: 26px;
-}
-
-.nav-auth {
+.nav-actions {
+  position: relative;
   display: flex;
   align-items: center;
-  gap: 24px;
+  justify-content: flex-end;
+  gap: 12px;
 }
 
-.nav-links a {
+.nav-create,
+.nav-signin,
+.nav-profile-trigger,
+.nav-status-pill {
+  min-height: 42px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text);
+  transition:
+    border-color 0.18s ease,
+    background-color 0.18s ease,
+    transform 0.18s ease;
+}
+
+.nav-create,
+.nav-signin,
+.nav-profile-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+}
+
+.nav-create {
+  padding: 0 16px 0 12px;
   text-decoration: none;
-  color: var(--muted);
-  font-size: 0.9rem;
-  font-weight: 600;
-  transition: color 0.18s ease;
+  font-size: 0.92rem;
+  font-weight: 700;
 }
 
-.nav-links a:hover {
-  color: var(--accent);
+.nav-signin {
+  padding: 0 16px 0 12px;
+  text-decoration: none;
+  font-size: 0.92rem;
+  font-weight: 700;
 }
 
-.nav-links a[aria-current='page'] {
-  color: var(--accent);
+.nav-profile-trigger {
+  padding: 4px 6px 4px 4px;
 }
 
-.nav-session {
-  display: flex;
+.nav-create:hover,
+.nav-signin:hover,
+.nav-profile-trigger:hover {
+  transform: translateY(-1px);
+  border-color: rgba(99, 240, 214, 0.26);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.nav-create:focus-visible,
+.nav-signin:focus-visible,
+.nav-profile-trigger:focus-visible,
+.nav-menu__item:focus-visible {
+  outline: none;
+  border-color: rgba(99, 240, 214, 0.34);
+  box-shadow: 0 0 0 4px rgba(99, 240, 214, 0.12);
+}
+
+.nav-create__icon,
+.nav-signin__icon,
+.nav-profile-trigger__chevron,
+.nav-menu__icon {
+  display: inline-flex;
   align-items: center;
-  gap: 14px;
+  justify-content: center;
 }
 
-.nav-session-copy {
-  display: grid;
-  gap: 2px;
-  text-align: right;
+.nav-create__icon svg,
+.nav-signin__icon svg,
+.nav-profile-trigger__chevron svg,
+.nav-menu__icon svg {
+  width: 18px;
+  height: 18px;
 }
 
-.nav-session-copy strong {
-  font-size: 0.9rem;
-  color: #f5fbf9;
+.nav-create__icon,
+.nav-signin__icon {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  color: var(--accent);
 }
 
-.nav-session-copy span,
-.nav-status {
+.nav-profile-trigger__chevron {
+  color: var(--muted);
+}
+
+.nav-avatar {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(
+    135deg,
+    rgba(126, 200, 255, 0.88),
+    rgba(99, 240, 214, 0.92)
+  );
+  color: #062125;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.22);
+}
+
+.nav-avatar--large {
+  width: 46px;
+  height: 46px;
+  font-size: 1rem;
+}
+
+.nav-status-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 16px;
   font-size: 0.82rem;
   color: var(--muted);
 }
 
-.nav-logout {
-  min-height: 40px;
-  padding: 0 16px;
-  border-radius: 999px;
+.nav-menu {
+  position: absolute;
+  top: calc(100% + 12px);
+  right: 0;
+  min-width: 250px;
+  padding: 14px 0;
+  border-radius: 24px;
   border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.04);
-  color: var(--text);
-  font-weight: 700;
-  cursor: pointer;
-  transition:
-    border-color 0.18s ease,
-    color 0.18s ease,
-    transform 0.18s ease;
+  background: rgba(16, 23, 26, 0.96);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.42);
+  backdrop-filter: blur(18px);
 }
 
-.nav-logout:hover {
-  color: var(--accent);
-  border-color: rgba(99, 240, 214, 0.28);
-  transform: translateY(-1px);
+.nav-menu__header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 18px 14px;
+}
+
+.nav-menu__identity {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.nav-menu__identity strong {
+  color: #f5fbf9;
+  font-size: 0.95rem;
+  line-height: 1.3;
+}
+
+.nav-menu__identity span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.nav-menu__divider {
+  height: 1px;
+  margin: 0 14px 8px;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.nav-menu__item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 46px;
+  padding: 0 18px;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  text-decoration: none;
+  font-size: 0.94rem;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 0.18s ease;
+}
+
+.nav-menu__item:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.nav-menu__item--button {
+  font: inherit;
+}
+
+.nav-menu__icon {
+  color: #eef5f3;
 }
 
 .app-shell {
@@ -110,20 +243,23 @@
   padding: 110px 24px 24px;
 }
 
-.card {
-  width: min(680px, 100%);
-  padding: 40px 36px;
-  border-radius: 28px;
-  background: var(--panel);
-  border: 1px solid var(--border);
-  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.35);
-  backdrop-filter: blur(12px);
-  text-align: center;
+.surface {
   position: relative;
+  border: 1px solid var(--surface-border, var(--border));
+  background: var(--surface-background, var(--panel));
+  backdrop-filter: blur(var(--surface-blur, 14px));
+  box-shadow: var(--surface-shadow);
+}
+
+.surface--hero,
+.surface--form,
+.surface--page-header,
+.surface--page-panel {
   overflow: hidden;
 }
 
-.card::before {
+.surface--hero::before,
+.surface--form::before {
   content: "";
   position: absolute;
   top: 0;
@@ -132,6 +268,59 @@
   width: 160px;
   height: 2px;
   background: linear-gradient(90deg, transparent, var(--accent), transparent);
+}
+
+.surface--hero {
+  width: min(680px, 100%);
+  padding: 40px 36px;
+  border-radius: 28px;
+  text-align: center;
+}
+
+.surface--hero h1 {
+  margin: 0;
+  font-size: clamp(2.4rem, 7vw, 4.5rem);
+  line-height: 0.95;
+  letter-spacing: -0.05em;
+}
+
+.surface--form {
+  border-radius: 32px;
+  padding: 36px 32px;
+  text-align: left;
+}
+
+.surface--page-header {
+  padding: 32px;
+  border-radius: 28px;
+}
+
+.surface--page-header h1 {
+  margin: 0;
+  font-size: clamp(2.4rem, 6vw, 3.8rem);
+  line-height: 0.96;
+  letter-spacing: -0.05em;
+}
+
+.surface--page-panel {
+  padding: 28px;
+  border-radius: 24px;
+}
+
+.surface--soft {
+  border-radius: 26px;
+  border-color: var(--surface-soft-border);
+  background: var(--surface-soft-bg);
+  backdrop-filter: none;
+  box-shadow: var(--surface-soft-inset);
+}
+
+.surface--nested {
+  border-radius: 22px;
+  border-color: var(--surface-soft-border);
+  background: var(--surface-nested-bg);
+  backdrop-filter: none;
+  box-shadow: none;
 }
 
 .eyebrow {
@@ -148,14 +337,7 @@
   text-transform: uppercase;
 }
 
-.card h1 {
-  margin: 0;
-  font-size: clamp(2.4rem, 7vw, 4.5rem);
-  line-height: 0.95;
-  letter-spacing: -0.05em;
-}
-
-.sub {
+.page-lead {
   max-width: 540px;
   margin: 18px auto 0;
   font-size: 1.05rem;
@@ -199,12 +381,12 @@
   box-shadow: none;
 }
 
-.home-card {
+.home-hero {
   width: min(750px, 100%);
 }
 
-.home-card .sub,
-.home-card .foot {
+.home-hero .page-lead,
+.home-hero .page-footnote {
   max-width: none;
   margin-left: 0;
   margin-right: 0;
@@ -300,13 +482,13 @@
   color: var(--accent);
 }
 
-.foot {
+.page-footnote {
   margin-top: 22px;
   font-size: 0.95rem;
   color: var(--muted);
 }
 
-.brand {
+.page-mark {
   margin-top: 30px;
   font-size: 0.95rem;
   letter-spacing: 0.08em;
@@ -316,27 +498,6 @@
 
 .auth-page {
   width: min(520px, 100%);
-}
-
-.auth-card {
-  position: relative;
-  overflow: hidden;
-  border: 1px solid var(--border);
-  background: var(--panel);
-  backdrop-filter: blur(14px);
-  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.35);
-  border-radius: 32px;
-  padding: 36px 32px;
-  text-align: left;
-}
-
-.auth-card::after {
-  content: '';
-  position: absolute;
-  inset: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 24px;
-  pointer-events: none;
 }
 
 .auth-header,
@@ -381,7 +542,13 @@
   color: #f5fbf9;
 }
 
-.field-group input {
+.field-group input,
+.field-group textarea,
+.field-group select,
+.preset-select,
+.preset-number-input,
+.preset-slider__number,
+.preset-textarea {
   width: 100%;
   min-height: 52px;
   padding: 0 16px;
@@ -395,21 +562,47 @@
     transform 0.18s ease;
 }
 
-.field-group input::placeholder {
+.field-group textarea,
+.preset-textarea {
+  padding: 14px 16px;
+  resize: vertical;
+}
+
+.field-group input::placeholder,
+.field-group textarea::placeholder,
+.preset-textarea::placeholder {
   color: rgba(155, 177, 171, 0.78);
 }
 
-.field-group input:hover {
+.field-group input:hover,
+.field-group textarea:hover,
+.field-group select:hover,
+.preset-select:hover,
+.preset-number-input:hover,
+.preset-slider__number:hover,
+.preset-textarea:hover {
   border-color: rgba(255, 255, 255, 0.18);
 }
 
-.field-group input:focus {
+.field-group input:focus,
+.field-group textarea:focus,
+.field-group select:focus,
+.preset-select:focus,
+.preset-number-input:focus,
+.preset-slider__number:focus,
+.preset-textarea:focus {
   outline: none;
   border-color: var(--accent);
   box-shadow: 0 0 0 4px rgba(99, 240, 214, 0.12);
 }
 
-.field-group input[aria-invalid='true'] {
+.field-group input[aria-invalid="true"],
+.field-group textarea[aria-invalid="true"],
+.field-group select[aria-invalid="true"],
+.preset-select[aria-invalid="true"],
+.preset-number-input[aria-invalid="true"],
+.preset-slider__number[aria-invalid="true"],
+.preset-textarea[aria-invalid="true"] {
   border-color: #ff8c99;
   box-shadow: 0 0 0 4px rgba(255, 140, 153, 0.12);
 }
@@ -463,46 +656,15 @@
   margin-top: 8px;
 }
 
-.preset-page {
+.page-stack {
   width: min(980px, 100%);
   display: grid;
   gap: 24px;
 }
 
-.preset-page-header,
-.preset-page-panel {
-  position: relative;
-  overflow: hidden;
-  border: 1px solid var(--border);
-  background: var(--panel);
-  backdrop-filter: blur(14px);
-  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.35);
-}
-
-.preset-page-header {
-  padding: 32px;
-  border-radius: 28px;
-  background:
-    radial-gradient(circle at 18% 18%, rgba(99, 240, 214, 0.18), transparent 24%),
-    linear-gradient(160deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02)),
-    var(--panel);
-}
-
-.preset-page-header h1 {
-  margin: 0;
-  font-size: clamp(2.4rem, 6vw, 3.8rem);
-  line-height: 0.96;
-  letter-spacing: -0.05em;
-}
-
-.preset-page-header .sub {
+.surface--page-header .page-lead {
   margin: 16px 0 0;
   max-width: 640px;
-}
-
-.preset-page-panel {
-  padding: 28px;
-  border-radius: 24px;
 }
 
 .preset-empty-state {
@@ -564,7 +726,11 @@
   text-align: center;
   color: var(--muted);
   background:
-    linear-gradient(160deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02)),
+    linear-gradient(
+      160deg,
+      rgba(255, 255, 255, 0.06),
+      rgba(255, 255, 255, 0.02)
+    ),
     rgba(255, 255, 255, 0.04);
   border: 1px solid rgba(255, 255, 255, 0.08);
 }
@@ -616,38 +782,679 @@
   transform: none;
 }
 
+.auth-page--wide {
+  width: min(1320px, 100%);
+  align-self: start;
+}
+
+.surface--editor {
+  padding: 40px 30px;
+  overflow: visible;
+}
+
+.surface--editor > .preset-editor-form {
+  margin-top: 30px;
+}
+
+.preset-editor-form,
+.preset-editor-main,
+.preset-advanced-stack {
+  display: grid;
+  gap: 22px;
+}
+
+.preset-editor-toolbar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 14px;
+  align-items: start;
+}
+
+.preset-editor-toolbar__name {
+  margin: 0;
+  max-width: none;
+}
+
+.preset-editor-toolbar__metadata {
+  display: grid;
+  gap: 18px;
+}
+
+.preset-editor-toolbar__controls {
+  display: grid;
+  gap: 14px;
+}
+
+.preset-editor-toolbar__control-group {
+  display: grid;
+  gap: 8px;
+}
+
+.preset-editor-toolbar__control-group--navigation {
+  gap: 12px;
+  padding: 18px;
+  border-radius: 20px;
+  border: 1px solid rgba(99, 240, 214, 0.16);
+  background:
+    linear-gradient(
+      135deg,
+      rgba(15, 48, 44, 0.72),
+      rgba(8, 22, 25, 0.72)
+    );
+}
+
+.preset-editor-toolbar__control-copy {
+  display: grid;
+  gap: 4px;
+}
+
+.preset-editor-toolbar__eyebrow {
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.preset-editor-toolbar__hint {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.preset-editor-toolbar__navigation-shell {
+  position: relative;
+}
+
+.preset-editor-toolbar__navigation-icon {
+  position: absolute;
+  top: 50%;
+  left: 16px;
+  width: 18px;
+  height: 18px;
+  color: var(--accent);
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+.preset-editor-toolbar__navigation-icon svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.preset-editor-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.55fr) minmax(320px, 0.95fr);
+  gap: 24px;
+  align-items: stretch;
+}
+
+.preset-editor-section {
+  padding: 24px;
+}
+
+.preset-editor-section__header {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 18px;
+}
+
+.preset-editor-section__header h2,
+.preset-editor-preview__header h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  letter-spacing: -0.03em;
+}
+
+.preset-editor-section__header p,
+.preset-editor-preview__header p,
+.preset-effect-footnote {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.preset-editor-grid {
+  display: grid;
+  gap: 18px;
+}
+
+.preset-editor-grid--2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.preset-editor-grid--3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.preset-editor-grid__item--full {
+  grid-column: 1 / -1;
+}
+
+.preset-field {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+.preset-field__label {
+  display: inline-block;
+  color: #f5fbf9;
+  font-size: 0.92rem;
+  font-weight: 700;
+}
+
+.preset-field__description {
+  display: none;
+}
+
+.preset-thumbnail-picker {
+  display: grid;
+  gap: 12px;
+}
+
+.preset-thumbnail-input {
+  display: none;
+}
+
+.preset-thumbnail-picker__grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.preset-thumbnail-choice {
+  appearance: none;
+  display: grid;
+  gap: 10px;
+  min-height: 132px;
+  padding: 16px;
+  border-radius: 18px;
+  border: 1px dashed rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    transform 0.18s ease,
+    border-color 0.18s ease,
+    background-color 0.18s ease,
+    box-shadow 0.18s ease;
+}
+
+.preset-thumbnail-choice:hover {
+  transform: translateY(-1px);
+  border-color: rgba(99, 240, 214, 0.34);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.preset-thumbnail-choice.is-selected {
+  border-style: solid;
+  border-color: rgba(99, 240, 214, 0.42);
+  background: rgba(17, 58, 53, 0.42);
+  box-shadow: 0 0 0 4px rgba(99, 240, 214, 0.08);
+}
+
+.preset-thumbnail-choice__eyebrow {
+  color: var(--accent);
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.preset-thumbnail-choice__title {
+  font-size: 1rem;
+  letter-spacing: -0.02em;
+}
+
+.preset-thumbnail-choice__description {
+  color: var(--muted);
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.preset-select {
+  appearance: none;
+  background-image:
+    linear-gradient(45deg, transparent 50%, rgba(99, 240, 214, 0.86) 50%),
+    linear-gradient(135deg, rgba(99, 240, 214, 0.86) 50%, transparent 50%);
+  background-position:
+    calc(100% - 22px) calc(50% - 2px),
+    calc(100% - 16px) calc(50% - 2px);
+  background-size:
+    6px 6px,
+    6px 6px;
+  background-repeat: no-repeat;
+}
+
+.preset-select--navigation {
+  min-height: 56px;
+  padding-left: 46px;
+  border-color: rgba(99, 240, 214, 0.22);
+  background-color: rgba(4, 12, 14, 0.56);
+}
+
+.preset-slider {
+  display: grid;
+  gap: 10px;
+}
+
+.preset-slider__header {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.preset-slider__header strong {
+  font-size: 0.88rem;
+  color: var(--accent);
+}
+
+.preset-slider__controls {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 112px;
+  gap: 12px;
+  align-items: center;
+}
+
+.preset-slider__range {
+  width: 100%;
+  height: 10px;
+  margin: 0;
+  border-radius: 999px;
+  appearance: none;
+  background: linear-gradient(
+    90deg,
+    rgba(99, 240, 214, 0.3),
+    rgba(118, 196, 255, 0.3)
+  );
+  outline: none;
+}
+
+.preset-slider__range::-webkit-slider-thumb {
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 0;
+  background: var(--accent);
+  box-shadow: 0 0 0 4px rgba(99, 240, 214, 0.16);
+}
+
+.preset-slider__range::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 0;
+  background: var(--accent);
+  box-shadow: 0 0 0 4px rgba(99, 240, 214, 0.16);
+}
+
+.preset-vector-field {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.preset-vector-field__axis {
+  display: grid;
+  gap: 8px;
+}
+
+.preset-vector-field__axis span {
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.preset-toggle {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 18px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+  cursor: pointer;
+}
+
+.preset-toggle__copy {
+  display: grid;
+  gap: 4px;
+}
+
+.preset-toggle__copy span {
+  color: #f5fbf9;
+  font-size: 0.94rem;
+  font-weight: 700;
+}
+
+.preset-toggle__copy small {
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.preset-toggle__control {
+  display: inline-flex;
+  align-items: center;
+}
+
+.preset-toggle__input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.preset-toggle__track {
+  position: relative;
+  width: 48px;
+  height: 28px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.16);
+  transition: background-color 0.18s ease;
+}
+
+.preset-toggle__track::after {
+  content: "";
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #f5fbf9;
+  transition: transform 0.18s ease;
+}
+
+.preset-toggle__input:checked + .preset-toggle__track {
+  background: rgba(99, 240, 214, 0.34);
+}
+
+.preset-toggle__input:checked + .preset-toggle__track::after {
+  transform: translateX(20px);
+}
+
+.preset-effects-grid {
+  display: grid;
+  gap: 24px;
+}
+
+.preset-effects-category {
+  display: grid;
+  gap: 14px;
+}
+
+.preset-effects-category__title {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.preset-effects-category__grid {
+  display: grid;
+  gap: 18px;
+}
+
+.effect-card {
+  display: grid;
+  gap: 18px;
+  padding: 20px;
+}
+
+.effect-card.is-disabled {
+  opacity: 0.92;
+}
+
+.effect-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: start;
+}
+
+.effect-card__header h3 {
+  margin: 0 0 6px;
+  font-size: 1.08rem;
+  letter-spacing: -0.02em;
+}
+
+.effect-card__header p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.effect-card__content,
+.effect-card__footer {
+  display: grid;
+  gap: 16px;
+}
+
+.preset-color-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+  min-height: 52px;
+  padding: 10px 14px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(4, 12, 14, 0.72);
+}
+
+.preset-color-field span {
+  color: #f5fbf9;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.preset-color-field__picker {
+  width: 52px;
+  height: 32px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+
+.preset-pass-order {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.preset-pass-order__item {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.preset-pass-order__copy {
+  display: grid;
+  gap: 4px;
+}
+
+.preset-pass-order__copy span {
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.preset-pass-order__actions {
+  display: flex;
+  gap: 8px;
+}
+
+.preset-order-button,
+.preset-secondary-button {
+  min-height: 40px;
+  padding: 0 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(99, 240, 214, 0.18);
+  background: rgba(99, 240, 214, 0.1);
+  color: #f5fbf9;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    transform 0.18s ease,
+    border-color 0.18s ease,
+    background-color 0.18s ease;
+}
+
+.preset-order-button:hover,
+.preset-secondary-button:hover {
+  transform: translateY(-1px);
+  border-color: rgba(99, 240, 214, 0.3);
+  background: rgba(99, 240, 214, 0.16);
+}
+
+.preset-order-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.52;
+  transform: none;
+}
+
+.preset-advanced-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  align-items: start;
+}
+
+.preset-textarea {
+  font-family: "IBM Plex Mono", "Fira Code", monospace;
+  line-height: 1.6;
+}
+
+.preset-textarea--code {
+  min-height: 320px;
+}
+
+.preset-editor-submit {
+  width: auto;
+  min-width: 220px;
+  justify-self: start;
+}
+
+.preset-editor-preview {
+  position: relative;
+  min-height: 100%;
+}
+
+.preset-editor-preview__card {
+  position: sticky;
+  top: 92px;
+  display: grid;
+  gap: 16px;
+  padding: 22px;
+  max-height: calc(100vh - 116px);
+  overflow: auto;
+}
+
+.preset-editor-preview__header {
+  display: grid;
+  gap: 6px;
+}
+
+.preset-editor-preview__player,
+.preset-editor-preview__player.mage-player {
+  width: 100%;
+}
+
+.preset-editor-preview__player .mage-player__viewport {
+  min-height: 360px;
+}
+
+@media (max-width: 1080px) {
+  .preset-editor-layout,
+  .preset-editor-toolbar {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .preset-thumbnail-picker__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .preset-editor-preview__card {
+    position: static;
+  }
+}
+
+@media (max-width: 780px) {
+  .surface--editor {
+    padding: 30px 24px;
+  }
+
+  .preset-editor-grid--2,
+  .preset-editor-grid--3 {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .preset-thumbnail-picker__grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .preset-slider__controls,
+  .preset-vector-field,
+  .preset-advanced-header,
+  .effect-card__header,
+  .preset-pass-order__item {
+    grid-template-columns: minmax(0, 1fr);
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .preset-editor-submit {
+    width: 100%;
+  }
+
+  .preset-pass-order__actions {
+    width: 100%;
+  }
+
+  .preset-order-button {
+    flex: 1;
+  }
+}
+
 @media (max-width: 560px) {
   .nav-inner {
-    width: min(1100px, 100%);
+    width: min(1200px, 100%);
     gap: 14px;
   }
 
-  .nav-links {
-    gap: 18px;
-    overflow-x: auto;
+  .nav-create,
+  .nav-signin {
+    padding-right: 14px;
   }
 
-  .nav-session {
-    flex-direction: column;
-    align-items: flex-end;
-  }
-
-  .nav-auth {
-    flex-direction: column;
-    align-items: flex-end;
-    gap: 14px;
+  .nav-menu {
+    right: -4px;
+    min-width: min(280px, calc(100vw - 2rem));
   }
 
   .app-shell {
     padding: 96px 1rem 1rem;
   }
 
-  .card {
+  .surface--hero {
     padding: 32px 22px;
     border-radius: 22px;
   }
 
-  .sub {
+  .page-lead {
     font-size: 1rem;
   }
 
@@ -659,8 +1466,8 @@
     margin-top: 24px;
   }
 
-  .preset-page-header,
-  .preset-page-panel {
+  .surface--page-header,
+  .surface--page-panel {
     padding: 24px;
   }
 
@@ -673,7 +1480,7 @@
     padding: 22px;
   }
 
-  .auth-card {
+  .surface--form {
     padding: 30px 24px;
     border-radius: 28px;
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,8 @@ import { LoginPage } from './pages/LoginPage'
 import { MyPresetsPage } from './pages/MyPresetsPage'
 import { PresetDetailPage } from './pages/PresetDetailPage'
 import { RegisterPage } from './pages/RegisterPage'
+import { CreatePresetPage } from './pages/CreatePresetPage'
+
 
 function App() {
   return (
@@ -18,6 +20,7 @@ function App() {
           <Route path="/my-presets" element={<MyPresetsPage />} />
           <Route path="/presets/:id" element={<PresetDetailPage />} />
           <Route path="/register" element={<RegisterPage />} />
+          <Route path="/create-preset" element={<CreatePresetPage />} />
           <Route path="*" element={<Navigate replace to="/" />} />
         </Routes>
       </Layout>

--- a/src/components/AuthPage.tsx
+++ b/src/components/AuthPage.tsx
@@ -1,6 +1,8 @@
 import type { PropsWithChildren } from 'react'
 
 type AuthPageProps = PropsWithChildren<{
+  cardClassName?: string
+  className?: string
   titleId: string
 }>
 
@@ -11,10 +13,17 @@ type AuthPageHeaderProps = {
   titleId: string
 }
 
-export function AuthPage({ children, titleId }: AuthPageProps) {
+function buildClassName(...classNames: Array<string | undefined>) {
+  return classNames.filter(Boolean).join(' ')
+}
+
+export function AuthPage({ cardClassName, children, className, titleId }: AuthPageProps) {
   return (
-    <main className="auth-page">
-      <section className="auth-card" aria-labelledby={titleId}>
+    <main className={buildClassName('auth-page', className)}>
+      <section
+        className={buildClassName('surface surface--form', cardClassName)}
+        aria-labelledby={titleId}
+      >
         {children}
       </section>
     </main>

--- a/src/components/Layout.test.tsx
+++ b/src/components/Layout.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Layout } from './Layout'
+
+const logoutMock = vi.fn()
+
+let authState = {
+  accessToken: null as string | null,
+  authenticatedFetch: vi.fn(),
+  completeLoginSession: vi.fn(),
+  isAuthenticated: false,
+  isRestoringSession: false,
+  logout: logoutMock,
+  user: null as null | {
+    authProvider: string
+    displayName: string
+    email: string
+    userId: number | null
+  },
+}
+
+vi.mock('../auth/AuthContext', () => ({
+  useAuth: () => authState,
+}))
+
+function renderLayout() {
+  return render(
+    <MemoryRouter>
+      <Layout>
+        <div>Page content</div>
+      </Layout>
+    </MemoryRouter>,
+  )
+}
+
+describe('Layout', () => {
+  beforeEach(() => {
+    logoutMock.mockReset()
+    authState = {
+      accessToken: null,
+      authenticatedFetch: vi.fn(),
+      completeLoginSession: vi.fn(),
+      isAuthenticated: false,
+      isRestoringSession: false,
+      logout: logoutMock,
+      user: null,
+    }
+  })
+
+  it('shows a compact sign-in action when the user is signed out', () => {
+    renderLayout()
+
+    expect(screen.getByRole('link', { name: /sign in/i })).toHaveAttribute('href', '/login')
+    expect(screen.queryByRole('button', { name: /open account menu/i })).not.toBeInTheDocument()
+  })
+
+  it('shows an account dropdown with Home above My Channel and Sign out for authenticated users', async () => {
+    authState = {
+      ...authState,
+      accessToken: 'token',
+      isAuthenticated: true,
+      user: {
+        authProvider: 'LOCAL',
+        displayName: 'Preset Artist',
+        email: 'artist@example.com',
+        userId: 8,
+      },
+    }
+
+    const user = userEvent.setup()
+
+    renderLayout()
+
+    expect(screen.getByRole('link', { name: /create/i })).toHaveAttribute('href', '/create-preset')
+
+    await user.click(screen.getByRole('button', { name: /open account menu for preset artist/i }))
+
+    const menuItems = screen.getAllByRole('menuitem')
+
+    expect(menuItems[0]).toHaveTextContent(/home/i)
+    expect(menuItems[0]).toHaveAttribute('href', '/')
+    expect(menuItems[1]).toHaveTextContent(/my channel/i)
+    expect(screen.getByRole('menuitem', { name: /my channel/i })).toHaveAttribute(
+      'href',
+      '/my-presets',
+    )
+    expect(screen.getByRole('menuitem', { name: /sign out/i })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('menuitem', { name: /sign out/i }))
+
+    expect(logoutMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,19 +1,135 @@
-import type { PropsWithChildren } from 'react'
-import { Link, NavLink } from 'react-router-dom'
+import { useEffect, useId, useMemo, useRef, useState, type PropsWithChildren } from 'react'
+import { Link } from 'react-router-dom'
 import { useAuth } from '../auth/AuthContext'
 
-const guestNavItems = [
-  { label: 'Register', to: '/register' },
-  { label: 'Login', to: '/login' },
-]
+function UserIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24">
+      <path
+        d="M12 12.2a4.1 4.1 0 1 0 0-8.2 4.1 4.1 0 0 0 0 8.2Zm0 2.1c-4.5 0-8.1 2.4-8.1 5.3 0 .3.2.5.5.5h15.2c.3 0 .5-.2.5-.5 0-2.9-3.6-5.3-8.1-5.3Z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}
 
-const authenticatedNavItems = [
-  { label: 'Home', to: '/' },
-  { label: 'My Presets', to: '/my-presets' },
-]
+function CreateIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24">
+      <path
+        d="M12 4.5a1 1 0 0 1 1 1v5.5h5.5a1 1 0 1 1 0 2H13V18.5a1 1 0 1 1-2 0V13H5.5a1 1 0 1 1 0-2H11V5.5a1 1 0 0 1 1-1Z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}
+
+function ChevronDownIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24">
+      <path
+        d="M6.7 9.3a1 1 0 0 1 1.4 0l3.9 3.9 3.9-3.9a1 1 0 1 1 1.4 1.4l-4.6 4.6a1 1 0 0 1-1.4 0L6.7 10.7a1 1 0 0 1 0-1.4Z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}
+
+function ChannelIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24">
+      <path
+        d="M12 12.3a3.7 3.7 0 1 0 0-7.4 3.7 3.7 0 0 0 0 7.4Zm0 2c-3.8 0-6.8 2-6.8 4.5 0 .4.3.7.7.7h12.2c.4 0 .7-.3.7-.7 0-2.5-3-4.5-6.8-4.5Z"
+        fill="currentColor"
+      />
+      <path
+        d="M4.8 3.8h14.4A1.8 1.8 0 0 1 21 5.6v12.8a1.8 1.8 0 0 1-1.8 1.8H4.8A1.8 1.8 0 0 1 3 18.4V5.6a1.8 1.8 0 0 1 1.8-1.8Zm0 1.5a.3.3 0 0 0-.3.3v12.8c0 .2.1.3.3.3h14.4c.2 0 .3-.1.3-.3V5.6a.3.3 0 0 0-.3-.3H4.8Z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}
+
+function HomeIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24">
+      <path
+        d="M12 4.4a1.5 1.5 0 0 1 1 .4l6.2 5.6a1 1 0 1 1-1.4 1.5L17 11.2v6.3a1.5 1.5 0 0 1-1.5 1.5h-7A1.5 1.5 0 0 1 7 17.5v-6.3l-.8.7a1 1 0 0 1-1.4-1.5L11 4.8a1.5 1.5 0 0 1 1-.4Zm-3 5.5v7.1h6v-7.1l-3-2.7-3 2.7Z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}
+
+function SignOutIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24">
+      <path
+        d="M14.6 7.4a1 1 0 0 1 1.4 0l3.9 3.9a1 1 0 0 1 0 1.4L16 16.6a1 1 0 1 1-1.4-1.4l2.2-2.2H9a1 1 0 1 1 0-2h7.8l-2.2-2.2a1 1 0 0 1 0-1.4Z"
+        fill="currentColor"
+      />
+      <path
+        d="M5 4.5h6.2a1 1 0 1 1 0 2H6.5v11h4.7a1 1 0 1 1 0 2H5A1.5 1.5 0 0 1 3.5 18V6A1.5 1.5 0 0 1 5 4.5Z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}
+
+function getProfileInitials(displayName: string, email: string) {
+  const source = displayName.trim() || email.trim()
+
+  if (!source) {
+    return 'MG'
+  }
+
+  const words = source.split(/\s+/).filter(Boolean)
+
+  if (words.length >= 2) {
+    return `${words[0][0]}${words[1][0]}`.toUpperCase()
+  }
+
+  return source.slice(0, 2).toUpperCase()
+}
 
 export function Layout({ children }: PropsWithChildren) {
   const { accessToken, isAuthenticated, isRestoringSession, logout, user } = useAuth()
+  const [isAccountMenuOpen, setIsAccountMenuOpen] = useState(false)
+  const accountMenuRef = useRef<HTMLDivElement | null>(null)
+  const accountMenuId = useId()
+  const accountMenuTriggerId = useId()
+  const profileName = user?.displayName?.trim() || user?.email?.trim() || 'MAGE User'
+  const profileEmail = user?.email?.trim() || ''
+  const profileInitials = useMemo(
+    () => getProfileInitials(user?.displayName ?? '', user?.email ?? ''),
+    [user?.displayName, user?.email],
+  )
+
+  useEffect(() => {
+    if (!isAccountMenuOpen) {
+      return
+    }
+
+    function handlePointerDown(event: MouseEvent) {
+      if (!accountMenuRef.current?.contains(event.target as Node)) {
+        setIsAccountMenuOpen(false)
+      }
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setIsAccountMenuOpen(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [isAccountMenuOpen])
 
   return (
     <>
@@ -23,36 +139,104 @@ export function Layout({ children }: PropsWithChildren) {
             MAGE
           </Link>
           {isAuthenticated && user ? (
-            <div className="nav-auth">
-              <nav className="nav-links" aria-label="Primary">
-                {authenticatedNavItems.map((item) => (
-                  <NavLink key={item.to} to={item.to}>
-                    {item.label}
-                  </NavLink>
-                ))}
-              </nav>
-              <div className="nav-session">
-                <div className="nav-session-copy">
-                  <strong>{user.displayName}</strong>
-                  <span>{user.email}</span>
+            <div className="nav-actions" ref={accountMenuRef}>
+              <Link className="nav-create" to="/create-preset">
+                <span className="nav-create__icon" aria-hidden="true">
+                  <CreateIcon />
+                </span>
+                <span>Create</span>
+              </Link>
+              <button
+                aria-controls={isAccountMenuOpen ? accountMenuId : undefined}
+                aria-expanded={isAccountMenuOpen}
+                aria-haspopup="menu"
+                aria-label={`Open account menu for ${profileName}`}
+                className="nav-profile-trigger"
+                id={accountMenuTriggerId}
+                onClick={() => setIsAccountMenuOpen((currentValue) => !currentValue)}
+                type="button"
+              >
+                <span className="nav-avatar" aria-hidden="true">
+                  {profileInitials}
+                </span>
+                <span className="nav-profile-trigger__chevron" aria-hidden="true">
+                  <ChevronDownIcon />
+                </span>
+              </button>
+
+              {isAccountMenuOpen ? (
+                <div
+                  aria-labelledby={accountMenuTriggerId}
+                  className="nav-menu"
+                  id={accountMenuId}
+                  role="menu"
+                >
+                  <div className="nav-menu__header">
+                    <span className="nav-avatar nav-avatar--large" aria-hidden="true">
+                      {profileInitials}
+                    </span>
+                    <div className="nav-menu__identity">
+                      <strong>{profileName}</strong>
+                      <span>{profileEmail}</span>
+                    </div>
+                  </div>
+
+                  <div className="nav-menu__divider" />
+
+                  <Link
+                    className="nav-menu__item"
+                    onClick={() => setIsAccountMenuOpen(false)}
+                    role="menuitem"
+                    to="/"
+                  >
+                    <span className="nav-menu__icon">
+                      <HomeIcon />
+                    </span>
+                    <span>Home</span>
+                  </Link>
+
+                  <Link
+                    className="nav-menu__item"
+                    onClick={() => setIsAccountMenuOpen(false)}
+                    role="menuitem"
+                    to="/my-presets"
+                  >
+                    <span className="nav-menu__icon">
+                      <ChannelIcon />
+                    </span>
+                    <span>My Channel</span>
+                  </Link>
+
+                  <button
+                    className="nav-menu__item nav-menu__item--button"
+                    onClick={() => {
+                      setIsAccountMenuOpen(false)
+                      logout()
+                    }}
+                    role="menuitem"
+                    type="button"
+                  >
+                    <span className="nav-menu__icon">
+                      <SignOutIcon />
+                    </span>
+                    <span>Sign out</span>
+                  </button>
                 </div>
-                <button className="nav-logout" type="button" onClick={logout}>
-                  Log out
-                </button>
-              </div>
+              ) : null}
             </div>
           ) : isRestoringSession && accessToken ? (
-            <div className="nav-status" aria-live="polite">
+            <div className="nav-status-pill" aria-live="polite">
               Restoring session...
             </div>
           ) : (
-            <nav className="nav-links" aria-label="Primary">
-              {guestNavItems.map((item) => (
-                <NavLink key={item.to} to={item.to}>
-                  {item.label}
-                </NavLink>
-              ))}
-            </nav>
+            <div className="nav-actions">
+              <Link className="nav-signin" to="/login">
+                <span className="nav-signin__icon" aria-hidden="true">
+                  <UserIcon />
+                </span>
+                <span>Sign in</span>
+              </Link>
+            </div>
           )}
         </div>
       </header>

--- a/src/components/MagePlayer.test.tsx
+++ b/src/components/MagePlayer.test.tsx
@@ -42,17 +42,51 @@ describe('MagePlayer', () => {
     expect(controller.dispose).toHaveBeenCalledTimes(1)
   })
 
+  it('reuses the same engine instance when the preset scene blob changes', async () => {
+    const controller = createController()
+    vi.mocked(createMagePlayer).mockResolvedValue(controller)
+
+    const firstSceneBlob = {
+      visualizer: {
+        skyboxPreset: 6,
+      },
+    }
+    const secondSceneBlob = {
+      visualizer: {
+        skyboxPreset: 2,
+      },
+    }
+
+    const { rerender } = render(<MagePlayer sceneBlob={firstSceneBlob} />)
+
+    await waitFor(() => {
+      expect(controller.loadSceneBlob).toHaveBeenCalledWith(firstSceneBlob)
+    })
+
+    const initialCreateCount = vi.mocked(createMagePlayer).mock.calls.length
+
+    rerender(<MagePlayer sceneBlob={secondSceneBlob} />)
+
+    await waitFor(() => {
+      expect(vi.mocked(createMagePlayer).mock.calls.length).toBe(initialCreateCount)
+      expect(controller.loadSceneBlob).toHaveBeenCalledWith(secondSceneBlob)
+    })
+  })
+
   it('shows a recoverable error state when the preset is invalid', async () => {
-    const failingController = createController({
-      loadSceneBlob: vi.fn(() => {
-        throw new Error('Preset scene data is missing required MAGE fields.')
+    const controller = createController({
+      loadSceneBlob: vi.fn((sceneBlob: unknown) => {
+        if (
+          typeof sceneBlob === 'object' &&
+          sceneBlob !== null &&
+          'invalid' in sceneBlob
+        ) {
+          throw new Error('Preset scene data is missing required MAGE fields.')
+        }
       }),
     })
-    const workingController = createController()
 
-    vi.mocked(createMagePlayer)
-      .mockResolvedValueOnce(failingController)
-      .mockResolvedValueOnce(workingController)
+    vi.mocked(createMagePlayer).mockResolvedValue(controller)
 
     const { rerender } = render(
       <MagePlayer
@@ -65,7 +99,7 @@ describe('MagePlayer', () => {
     expect(await screen.findByRole('alert')).toHaveTextContent(
       'Preset scene data is missing required MAGE fields.',
     )
-    expect(failingController.dispose).toHaveBeenCalledTimes(1)
+    expect(controller.dispose).not.toHaveBeenCalled()
 
     const validSceneBlob = {
       visualizer: {
@@ -76,7 +110,7 @@ describe('MagePlayer', () => {
     rerender(<MagePlayer sceneBlob={validSceneBlob} />)
 
     await waitFor(() => {
-      expect(workingController.loadSceneBlob).toHaveBeenCalledWith(validSceneBlob)
+      expect(controller.loadSceneBlob).toHaveBeenCalledWith(validSceneBlob)
     })
 
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()

--- a/src/components/MagePlayer.tsx
+++ b/src/components/MagePlayer.tsx
@@ -29,20 +29,26 @@ export function MagePlayer({
   sceneBlob,
 }: MagePlayerProps) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const playerRef = useRef<MagePlayerController | null>(null)
+  const latestSceneBlobRef = useRef<MageSceneBlob | null | undefined>(sceneBlob)
 
   const [loadedSceneBlob, setLoadedSceneBlob] = useState<MageSceneBlob | null>(null)
+  const [playerVersion, setPlayerVersion] = useState(0)
   const [loadError, setLoadError] = useState<{ message: string; sceneBlob: MageSceneBlob } | null>(
     null,
   )
 
   useEffect(() => {
+    latestSceneBlobRef.current = sceneBlob
+  }, [sceneBlob])
+
+  useEffect(() => {
     const canvas = canvasRef.current
 
-    if (!canvas || !sceneBlob) {
+    if (!canvas) {
       return
     }
 
-    let currentPlayer: MagePlayerController | null = null
     let nextPlayer: MagePlayerController | null = null
     let isDisposed = false
     let animationFrameId = 0
@@ -57,24 +63,20 @@ export function MagePlayer({
             return
           }
 
-          nextPlayer.loadSceneBlob(sceneBlob)
-
-          if (isDisposed) {
-            nextPlayer.dispose()
-            return
-          }
-
-          currentPlayer = nextPlayer
-          setLoadError(null)
-          setLoadedSceneBlob(sceneBlob)
+          playerRef.current = nextPlayer
+          setPlayerVersion((currentVersion) => currentVersion + 1)
         } catch (error) {
           nextPlayer?.dispose()
 
           if (!isDisposed) {
-            setLoadError({
-              message: readErrorMessage(error),
-              sceneBlob,
-            })
+            const currentSceneBlob = latestSceneBlobRef.current
+
+            if (currentSceneBlob) {
+              setLoadError({
+                message: readErrorMessage(error),
+                sceneBlob: currentSceneBlob,
+              })
+            }
           }
         }
       })()
@@ -83,9 +85,52 @@ export function MagePlayer({
     return () => {
       isDisposed = true
       window.cancelAnimationFrame(animationFrameId)
-      currentPlayer?.dispose()
+      playerRef.current = null
+      nextPlayer?.dispose()
     }
-  }, [log, sceneBlob])
+  }, [log])
+
+  useEffect(() => {
+    if (!sceneBlob) {
+      return
+    }
+
+    const player = playerRef.current
+
+    if (!player) {
+      return
+    }
+
+    let isCancelled = false
+
+    try {
+      player.loadSceneBlob(sceneBlob)
+
+      queueMicrotask(() => {
+        if (isCancelled) {
+          return
+        }
+
+        setLoadError(null)
+        setLoadedSceneBlob(sceneBlob)
+      })
+    } catch (error) {
+      queueMicrotask(() => {
+        if (isCancelled) {
+          return
+        }
+
+        setLoadError({
+          message: readErrorMessage(error),
+          sceneBlob,
+        })
+      })
+    }
+
+    return () => {
+      isCancelled = true
+    }
+  }, [playerVersion, sceneBlob])
 
   const status: MagePlayerStatus =
     !sceneBlob

--- a/src/components/PresetEditorControls.tsx
+++ b/src/components/PresetEditorControls.tsx
@@ -1,0 +1,315 @@
+import type { ChangeEvent, PropsWithChildren, ReactNode } from 'react'
+import type { Vector3Value } from '../lib/presetEditor'
+
+type SectionProps = PropsWithChildren<{
+  className?: string
+  description: string
+  title: string
+}>
+
+type SelectFieldProps = {
+  description?: string
+  id: string
+  label: string
+  onChange: (value: string) => void
+  options: Array<{
+    label: string
+    value: string
+  }>
+  value: string
+}
+
+type NumberFieldProps = {
+  description?: string
+  id: string
+  label: string
+  max?: number
+  min?: number
+  onChange: (value: number) => void
+  placeholder?: string
+  step?: number
+  value: number
+}
+
+type SliderFieldProps = NumberFieldProps & {
+  formatValue?: (value: number) => string
+}
+
+type ToggleFieldProps = {
+  description?: string
+  id: string
+  label: string
+  onChange: (checked: boolean) => void
+  checked: boolean
+}
+
+type Vector3FieldProps = {
+  description?: string
+  id: string
+  label: string
+  onChange: (nextValue: Vector3Value) => void
+  step?: number
+  value: Vector3Value
+}
+
+type EffectCardProps = PropsWithChildren<{
+  description: string
+  enabled?: boolean
+  footer?: ReactNode
+  onToggle?: (enabled: boolean) => void
+  title: string
+}>
+
+function buildClassName(...classNames: Array<string | undefined | false>) {
+  return classNames.filter(Boolean).join(' ')
+}
+
+function FieldShell({
+  children,
+  description,
+  htmlFor,
+  label,
+}: PropsWithChildren<{
+  description?: string
+  htmlFor?: string
+  label: string
+}>) {
+  return (
+    <div className="preset-field">
+      <div className="preset-field__label-row">
+        <label className="preset-field__label" htmlFor={htmlFor}>
+          {label}
+        </label>
+      </div>
+      {description ? <p className="preset-field__description">{description}</p> : null}
+      {children}
+    </div>
+  )
+}
+
+function readNumericValue(event: ChangeEvent<HTMLInputElement>) {
+  return event.currentTarget.valueAsNumber
+}
+
+function forwardNumericValue(event: ChangeEvent<HTMLInputElement>, onChange: (value: number) => void) {
+  const nextValue = readNumericValue(event)
+
+  if (Number.isFinite(nextValue)) {
+    onChange(nextValue)
+  }
+}
+
+function formatSliderValue(value: number, formatValue?: (value: number) => string) {
+  if (formatValue) {
+    return formatValue(value)
+  }
+
+  return Number.isInteger(value) ? String(value) : value.toFixed(2).replace(/0+$/, '').replace(/\.$/, '')
+}
+
+export function PresetSection({ children, className, description, title }: SectionProps) {
+  return (
+    <section className={buildClassName('surface surface--soft preset-editor-section', className)}>
+      <div className="preset-editor-section__header">
+        <h2>{title}</h2>
+        <p>{description}</p>
+      </div>
+      <div className="preset-editor-section__content">{children}</div>
+    </section>
+  )
+}
+
+export function SelectField({
+  description,
+  id,
+  label,
+  onChange,
+  options,
+  value,
+}: SelectFieldProps) {
+  return (
+    <FieldShell description={description} htmlFor={id} label={label}>
+      <select
+        className="preset-select"
+        id={id}
+        value={value}
+        onChange={(event) => onChange(event.currentTarget.value)}
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </FieldShell>
+  )
+}
+
+export function NumberField({
+  description,
+  id,
+  label,
+  max,
+  min,
+  onChange,
+  placeholder,
+  step = 0.01,
+  value,
+}: NumberFieldProps) {
+  return (
+    <FieldShell description={description} htmlFor={id} label={label}>
+      <input
+        className="preset-number-input"
+        id={id}
+        max={max}
+        min={min}
+        onChange={(event) => forwardNumericValue(event, onChange)}
+        placeholder={placeholder}
+        step={step}
+        type="number"
+        value={Number.isFinite(value) ? value : ''}
+      />
+    </FieldShell>
+  )
+}
+
+export function SliderField({
+  description,
+  formatValue,
+  id,
+  label,
+  max,
+  min,
+  onChange,
+  step = 0.01,
+  value,
+}: SliderFieldProps) {
+  return (
+    <FieldShell description={description} htmlFor={id} label={label}>
+      <div className="preset-slider">
+        <div className="preset-slider__header">
+          <strong>{formatSliderValue(value, formatValue)}</strong>
+        </div>
+        <div className="preset-slider__controls">
+          <input
+            className="preset-slider__range"
+            id={id}
+            max={max}
+            min={min}
+            onChange={(event) => forwardNumericValue(event, onChange)}
+            step={step}
+            type="range"
+            value={value}
+          />
+          <input
+            className="preset-slider__number"
+            max={max}
+            min={min}
+            onChange={(event) => forwardNumericValue(event, onChange)}
+            step={step}
+            type="number"
+            value={Number.isFinite(value) ? value : ''}
+          />
+        </div>
+      </div>
+    </FieldShell>
+  )
+}
+
+export function ToggleField({
+  checked,
+  description,
+  id,
+  label,
+  onChange,
+}: ToggleFieldProps) {
+  return (
+    <label className="preset-toggle" htmlFor={id}>
+      <div className="preset-toggle__copy">
+        <span>{label}</span>
+        {description ? <small>{description}</small> : null}
+      </div>
+      <span className="preset-toggle__control">
+        <input
+          checked={checked}
+          className="preset-toggle__input"
+          id={id}
+          onChange={(event) => onChange(event.currentTarget.checked)}
+          type="checkbox"
+        />
+        <span className="preset-toggle__track" aria-hidden="true" />
+      </span>
+    </label>
+  )
+}
+
+export function Vector3Field({
+  description,
+  id,
+  label,
+  onChange,
+  step = 0.1,
+  value,
+}: Vector3FieldProps) {
+  function handleAxisChange(axis: keyof Vector3Value, nextValue: number) {
+    onChange({
+      ...value,
+      [axis]: nextValue,
+    })
+  }
+
+  return (
+    <FieldShell description={description} htmlFor={id} label={label}>
+      <div className="preset-vector-field" id={id}>
+        {(['x', 'y', 'z'] as Array<keyof Vector3Value>).map((axis) => (
+          <label className="preset-vector-field__axis" key={axis}>
+            <span>{axis.toUpperCase()}</span>
+            <input
+              className="preset-number-input"
+              onChange={(event) => forwardNumericValue(event, (nextValue) => handleAxisChange(axis, nextValue))}
+              step={step}
+              type="number"
+              value={Number.isFinite(value[axis]) ? value[axis] : ''}
+            />
+          </label>
+        ))}
+      </div>
+    </FieldShell>
+  )
+}
+
+export function EffectCard({
+  children,
+  description,
+  enabled,
+  footer,
+  onToggle,
+  title,
+}: EffectCardProps) {
+  const isEnabled = enabled ?? true
+  const hasContent = children !== undefined && children !== null
+  const toggleId = `${title.toLowerCase().replace(/\s+/g, '-')}-toggle`
+
+  return (
+    <section
+      className={buildClassName('surface surface--nested effect-card', !isEnabled && 'is-disabled')}
+    >
+      <div className="effect-card__header">
+        <div>
+          <h3>{title}</h3>
+          <p>{description}</p>
+        </div>
+        {onToggle ? (
+          <ToggleField
+            checked={isEnabled}
+            id={toggleId}
+            label={isEnabled ? 'On' : 'Off'}
+            onChange={onToggle}
+          />
+        ) : null}
+      </div>
+      {isEnabled && hasContent ? <div className="effect-card__content">{children}</div> : null}
+      {footer ? <div className="effect-card__footer">{footer}</div> : null}
+    </section>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,13 @@
   --muted: #9bb1ab;
   --accent: #63f0d6;
   --accent-soft: rgba(99, 240, 214, 0.14);
+  --surface-shadow: 0 24px 80px rgba(0, 0, 0, 0.35);
+  --surface-soft-border: rgba(255, 255, 255, 0.08);
+  --surface-soft-bg:
+    linear-gradient(160deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.02)),
+    rgba(4, 12, 14, 0.54);
+  --surface-soft-inset: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  --surface-nested-bg: rgba(3, 10, 12, 0.46);
   font-family:
     Inter,
     ui-sans-serif,

--- a/src/lib/presetEditor.ts
+++ b/src/lib/presetEditor.ts
@@ -1,0 +1,740 @@
+export type PresetSceneData = Record<string, unknown>
+
+export type Vector3Value = {
+  x: number
+  y: number
+  z: number
+}
+
+export type PresetPassId =
+  | 'glitchPass'
+  | 'bloom'
+  | 'RGBShift'
+  | 'dotShader'
+  | 'technicolorShader'
+  | 'luminosityShader'
+  | 'afterImagePass'
+  | 'sobelShader'
+  | 'colorifyShader'
+  | 'halftonePass'
+  | 'gammaCorrectionShader'
+  | 'kaleidoShader'
+  | 'copyShader'
+  | 'bleachBypassShader'
+  | 'toonShader'
+  | 'outputPass'
+
+export type PersistedPassFlag =
+  | 'rgbShift'
+  | 'dot'
+  | 'technicolor'
+  | 'luminosity'
+  | 'afterImage'
+  | 'sobel'
+  | 'glitch'
+  | 'colorify'
+  | 'halftone'
+  | 'gammaCorrection'
+  | 'kaleid'
+  | 'outputPass'
+
+export type ShaderPresetOption = {
+  description: string
+  id: string
+  label: string
+  shader: string
+}
+
+export type ToneMappingOption = {
+  description: string
+  label: string
+  value: number
+}
+
+export type SceneEditorModel = {
+  controls: {
+    position0: Vector3Value
+    target0: Vector3Value
+    zoom0: number
+  }
+  fx: {
+    bloom: {
+      enabled: boolean
+      radius: number
+      strength: number
+      threshold: number
+    }
+    params: {
+      afterImage: {
+        damp: number
+      }
+      colorify: {
+        color: string
+      }
+      kaleid: {
+        angle: number
+        sides: number
+      }
+      rgbShift: {
+        angle: number
+        amount: number
+      }
+    }
+    passOrder: PresetPassId[]
+    passes: Record<PersistedPassFlag, boolean>
+    toneMapping: {
+      exposure: number
+      method: number
+    }
+  }
+  intent: {
+    autoRotate: boolean
+    autoRotateSpeed: number
+    base_speed: number
+    camTilt: number
+    easing_speed: number
+    fov: number
+    minimizing_factor: number
+    pointerDownMultiplier: number
+    power_factor: number
+    time_multiplier: number
+  }
+  state: {
+    currAudio: number
+    currPointerDown: number
+    pointerDown: number
+    size: number
+    time: number
+    volume_multiplier: number
+  }
+  visualizer: {
+    scale: number
+    shader: string
+    skyboxPreset: number
+  }
+}
+
+const DEFAULT_PASS_ORDER: PresetPassId[] = [
+  'glitchPass',
+  'bloom',
+  'RGBShift',
+  'dotShader',
+  'technicolorShader',
+  'luminosityShader',
+  'afterImagePass',
+  'sobelShader',
+  'colorifyShader',
+  'halftonePass',
+  'gammaCorrectionShader',
+  'kaleidoShader',
+  'copyShader',
+  'bleachBypassShader',
+  'toonShader',
+  'outputPass',
+]
+
+export const PASS_LABELS: Record<PresetPassId, string> = {
+  RGBShift: 'RGB Shift',
+  afterImagePass: 'Afterimage',
+  bleachBypassShader: 'Bleach Bypass',
+  bloom: 'Bloom',
+  colorifyShader: 'Colorify',
+  copyShader: 'Copy Shader',
+  dotShader: 'Dot Screen',
+  gammaCorrectionShader: 'Gamma Correction',
+  glitchPass: 'Glitch',
+  halftonePass: 'Halftone',
+  kaleidoShader: 'Kaleidoscope',
+  luminosityShader: 'Luminosity',
+  outputPass: 'Output',
+  sobelShader: 'Sobel',
+  technicolorShader: 'Technicolor',
+  toonShader: 'Toon',
+}
+
+export const SHADER_PRESETS: ShaderPresetOption[] = [
+  {
+    id: 'aurora-drift',
+    label: 'Aurora Drift',
+    description: 'Layered rings and soft bloom-friendly motion.',
+    shader: `
+      let size = input()
+      let pointerDown = input()
+      time = 0.24 * time
+      size *= 1.1
+      rotateY(mouse.x * -PI * (1.0 + nsin(time)))
+      rotateX(mouse.y * PI * (1.0 + nsin(time)))
+      let rayDir = normalize(getRayDirection())
+      color(vec3(rayDir.x + 0.24, rayDir.y + 0.34, rayDir.z + 0.42))
+      metal(0.45 * size)
+      shine(0.72)
+      rotateY(sin(getRayDirection().y * 7.0 + time))
+      rotateX(cos(getRayDirection().x * 12.0 + time))
+      blend(0.12 + 0.08 * nsin(time * 2.0))
+      boxFrame(vec3(size), size * 0.08)
+      sphere(size * 0.44 - pointerDown * 0.18)
+    `,
+  },
+  {
+    id: 'signal-bloom',
+    label: 'Signal Bloom',
+    description: 'Dense geometric pulses that respond well to glow.',
+    shader: `
+      let size = input()
+      let pointerDown = input()
+      time *= 0.18
+      rotateY(time + mouse.x * PI * 0.7)
+      rotateX(mouse.y * PI * 0.6)
+      color(vec3(0.92, 0.47 + 0.16 * nsin(time), 0.36 + 0.14 * ncos(time)))
+      metal(0.36)
+      shine(0.86)
+      blend(0.08 + 0.04 * nsin(time * 3.0))
+      boxFrame(vec3(size * 0.82 + 0.36), 0.08 + pointerDown * 0.05)
+      rotateZ(time * 0.7)
+      boxFrame(vec3(size * 0.56 + 0.22), 0.03)
+      sphere(0.32 + 0.04 * nsin(time * 4.0))
+    `,
+  },
+  {
+    id: 'glacier-echo',
+    label: 'Glacier Echo',
+    description: 'Cool, reflective framing with slower rotation.',
+    shader: `
+      let size = input()
+      let pointerDown = input()
+      time *= 0.14
+      rotateY(time * 0.4 + mouse.x * PI * 0.5)
+      rotateX(mouse.y * PI * 0.35)
+      let rayDir = normalize(getRayDirection())
+      color(vec3(0.32 + rayDir.z * 0.2, 0.74, 0.96))
+      metal(0.62)
+      shine(0.94)
+      blend(0.06 + 0.03 * ncos(time * 2.0))
+      sphere(0.46 + 0.05 * nsin(time * 2.0) - pointerDown * 0.08)
+      boxFrame(vec3(size * 0.92 + 0.34), 0.04)
+      rotateZ(time * 0.35)
+      boxFrame(vec3(size * 0.64 + 0.18), 0.025)
+    `,
+  },
+  {
+    id: 'solar-thread',
+    label: 'Solar Thread',
+    description: 'Warm radial framing with quick directional motion.',
+    shader: `
+      let size = input()
+      let pointerDown = input()
+      time *= 0.28
+      rotateY(time * 0.9 + mouse.x * PI)
+      rotateX(mouse.y * PI * 0.45)
+      color(vec3(0.98, 0.68 + 0.14 * nsin(time), 0.24))
+      metal(0.4)
+      shine(0.8)
+      blend(0.1 + 0.05 * nsin(time * 5.0))
+      boxFrame(vec3(size * 0.7 + 0.5), 0.06)
+      rotateZ(time * 1.2)
+      boxFrame(vec3(size * 0.5 + 0.24), 0.02 + pointerDown * 0.01)
+      sphere(0.22 + 0.08 * ncos(time * 3.0))
+    `,
+  },
+]
+
+export const TONE_MAPPING_OPTIONS: ToneMappingOption[] = [
+  {
+    value: 0,
+    label: 'None',
+    description: 'No extra tone mapping on the final output.',
+  },
+  {
+    value: 1,
+    label: 'Linear',
+    description: 'Straight linear output with light compression.',
+  },
+  {
+    value: 2,
+    label: 'Reinhard',
+    description: 'Classic roll-off for bright highlights.',
+  },
+  {
+    value: 3,
+    label: 'Cineon',
+    description: 'Film-inspired contrast with a stronger curve.',
+  },
+  {
+    value: 4,
+    label: 'Filmic',
+    description: 'Cinematic highlight shaping with balanced contrast.',
+  },
+  {
+    value: 6,
+    label: 'AGX',
+    description: 'Modern color-rich tonality with smooth highlight handling.',
+  },
+  {
+    value: 7,
+    label: 'Neutral',
+    description: 'Clean neutral tonality with restrained clipping.',
+  },
+]
+
+export const SKYBOX_OPTIONS = Array.from({ length: 10 }, (_, index) => ({
+  value: index + 1,
+  label: `Skybox ${index + 1}`,
+}))
+
+const DEFAULT_SCENE_DATA: SceneEditorModel = {
+  visualizer: {
+    shader: SHADER_PRESETS[0].shader,
+    skyboxPreset: 6,
+    scale: 10,
+  },
+  controls: {
+    target0: { x: 0, y: 0, z: 0 },
+    position0: { x: 0, y: 0, z: 5.5 },
+    zoom0: 1,
+  },
+  intent: {
+    time_multiplier: 1,
+    minimizing_factor: 0.8,
+    power_factor: 8,
+    pointerDownMultiplier: 0,
+    base_speed: 0.2,
+    easing_speed: 0.6,
+    camTilt: 0,
+    autoRotate: true,
+    autoRotateSpeed: 0.2,
+    fov: 75,
+  },
+  fx: {
+    passOrder: DEFAULT_PASS_ORDER,
+    bloom: {
+      enabled: false,
+      strength: 1,
+      radius: 0.2,
+      threshold: 0.1,
+    },
+    toneMapping: {
+      method: 0,
+      exposure: 1.5,
+    },
+    passes: {
+      rgbShift: false,
+      dot: false,
+      technicolor: false,
+      luminosity: false,
+      afterImage: false,
+      sobel: false,
+      glitch: false,
+      colorify: false,
+      halftone: false,
+      gammaCorrection: false,
+      kaleid: false,
+      outputPass: true,
+    },
+    params: {
+      rgbShift: {
+        amount: 0.005,
+        angle: 0,
+      },
+      afterImage: {
+        damp: 0.96,
+      },
+      colorify: {
+        color: '#ffffff',
+      },
+      kaleid: {
+        sides: 6,
+        angle: 0,
+      },
+    },
+  },
+  state: {
+    size: 0,
+    pointerDown: 0,
+    currPointerDown: 0,
+    currAudio: 0,
+    time: 0,
+    volume_multiplier: 0,
+  },
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function readRecord(value: unknown) {
+  return isRecord(value) ? value : {}
+}
+
+function readNumber(value: unknown, fallback: number) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+function readBoolean(value: unknown, fallback: boolean) {
+  return typeof value === 'boolean' ? value : fallback
+}
+
+function readString(value: unknown, fallback: string) {
+  return typeof value === 'string' && value.trim() ? value : fallback
+}
+
+function readVector3(value: unknown, fallback: Vector3Value): Vector3Value {
+  const record = readRecord(value)
+
+  return {
+    x: readNumber(record.x, fallback.x),
+    y: readNumber(record.y, fallback.y),
+    z: readNumber(record.z, fallback.z),
+  }
+}
+
+function normalizePassOrder(value: unknown): PresetPassId[] {
+  if (!Array.isArray(value)) {
+    return [...DEFAULT_PASS_ORDER]
+  }
+
+  const nextOrder: PresetPassId[] = []
+
+  for (const item of value) {
+    if (typeof item !== 'string') {
+      continue
+    }
+
+    if (!DEFAULT_PASS_ORDER.includes(item as PresetPassId)) {
+      continue
+    }
+
+    if (nextOrder.includes(item as PresetPassId)) {
+      continue
+    }
+
+    nextOrder.push(item as PresetPassId)
+  }
+
+  for (const passId of DEFAULT_PASS_ORDER) {
+    if (!nextOrder.includes(passId)) {
+      nextOrder.push(passId)
+    }
+  }
+
+  return [...nextOrder.filter((passId) => passId !== 'outputPass'), 'outputPass']
+}
+
+function normalizeSkyboxPreset(value: unknown) {
+  if (typeof value === 'number' && Number.isInteger(value) && value >= 1 && value <= 10) {
+    return value
+  }
+
+  if (typeof value === 'string') {
+    const parsedValue = Number.parseInt(value, 10)
+
+    if (Number.isInteger(parsedValue) && parsedValue >= 1 && parsedValue <= 10) {
+      return parsedValue
+    }
+
+    const matchedPreset = value.match(/preset(\d+)/i)
+
+    if (matchedPreset) {
+      const matchedValue = Number.parseInt(matchedPreset[1], 10)
+
+      if (Number.isInteger(matchedValue) && matchedValue >= 1 && matchedValue <= 10) {
+        return matchedValue
+      }
+    }
+  }
+
+  if (isRecord(value) && value.type === 'preset') {
+    return normalizeSkyboxPreset(value.presetId)
+  }
+
+  return DEFAULT_SCENE_DATA.visualizer.skyboxPreset
+}
+
+function normalizeColorValue(value: unknown) {
+  if (typeof value === 'string' && /^#?[0-9a-f]{6}$/i.test(value.trim())) {
+    return value.trim().startsWith('#') ? value.trim() : `#${value.trim()}`
+  }
+
+  if (typeof value === 'number' && Number.isInteger(value) && value >= 0 && value <= 0xffffff) {
+    return `#${value.toString(16).padStart(6, '0')}`
+  }
+
+  return DEFAULT_SCENE_DATA.fx.params.colorify.color
+}
+
+function createDefaultModel(): SceneEditorModel {
+  return {
+    visualizer: { ...DEFAULT_SCENE_DATA.visualizer },
+    controls: {
+      position0: { ...DEFAULT_SCENE_DATA.controls.position0 },
+      target0: { ...DEFAULT_SCENE_DATA.controls.target0 },
+      zoom0: DEFAULT_SCENE_DATA.controls.zoom0,
+    },
+    intent: { ...DEFAULT_SCENE_DATA.intent },
+    fx: {
+      passOrder: [...DEFAULT_SCENE_DATA.fx.passOrder],
+      bloom: { ...DEFAULT_SCENE_DATA.fx.bloom },
+      toneMapping: { ...DEFAULT_SCENE_DATA.fx.toneMapping },
+      passes: { ...DEFAULT_SCENE_DATA.fx.passes },
+      params: {
+        rgbShift: { ...DEFAULT_SCENE_DATA.fx.params.rgbShift },
+        afterImage: { ...DEFAULT_SCENE_DATA.fx.params.afterImage },
+        colorify: { ...DEFAULT_SCENE_DATA.fx.params.colorify },
+        kaleid: { ...DEFAULT_SCENE_DATA.fx.params.kaleid },
+      },
+    },
+    state: { ...DEFAULT_SCENE_DATA.state },
+  }
+}
+
+export function createDefaultSceneData(): PresetSceneData {
+  const defaults = createDefaultModel()
+
+  return {
+    visualizer: defaults.visualizer,
+    controls: defaults.controls,
+    intent: defaults.intent,
+    fx: defaults.fx,
+    state: defaults.state,
+  }
+}
+
+export function getSceneEditorModel(sceneData: PresetSceneData): SceneEditorModel {
+  const defaults = createDefaultModel()
+  const visualizer = readRecord(sceneData.visualizer)
+  const controls = readRecord(sceneData.controls)
+  const intent = readRecord(sceneData.intent)
+  const fx = readRecord(sceneData.fx)
+  const fxParams = readRecord(fx.params)
+  const fxPasses = readRecord(fx.passes)
+  const state = readRecord(sceneData.state)
+
+  return {
+    visualizer: {
+      shader: readString(visualizer.shader, defaults.visualizer.shader),
+      skyboxPreset: normalizeSkyboxPreset(visualizer.skyboxPreset),
+      scale: readNumber(visualizer.scale, defaults.visualizer.scale),
+    },
+    controls: {
+      position0: readVector3(controls.position0, defaults.controls.position0),
+      target0: readVector3(controls.target0, defaults.controls.target0),
+      zoom0: readNumber(controls.zoom0, defaults.controls.zoom0),
+    },
+    intent: {
+      time_multiplier: readNumber(intent.time_multiplier, defaults.intent.time_multiplier),
+      minimizing_factor: readNumber(intent.minimizing_factor, defaults.intent.minimizing_factor),
+      power_factor: readNumber(intent.power_factor, defaults.intent.power_factor),
+      pointerDownMultiplier: readNumber(
+        intent.pointerDownMultiplier,
+        defaults.intent.pointerDownMultiplier,
+      ),
+      base_speed: readNumber(intent.base_speed, defaults.intent.base_speed),
+      easing_speed: readNumber(intent.easing_speed, defaults.intent.easing_speed),
+      camTilt: readNumber(intent.camTilt, defaults.intent.camTilt),
+      autoRotate: readBoolean(intent.autoRotate, defaults.intent.autoRotate),
+      autoRotateSpeed: readNumber(intent.autoRotateSpeed, defaults.intent.autoRotateSpeed),
+      fov: readNumber(intent.fov, defaults.intent.fov),
+    },
+    fx: {
+      passOrder: normalizePassOrder(fx.passOrder),
+      bloom: {
+        enabled: readBoolean(readRecord(fx.bloom).enabled, defaults.fx.bloom.enabled),
+        strength: readNumber(readRecord(fx.bloom).strength, defaults.fx.bloom.strength),
+        radius: readNumber(readRecord(fx.bloom).radius, defaults.fx.bloom.radius),
+        threshold: readNumber(readRecord(fx.bloom).threshold, defaults.fx.bloom.threshold),
+      },
+      toneMapping: {
+        method: readNumber(readRecord(fx.toneMapping).method, defaults.fx.toneMapping.method),
+        exposure: readNumber(
+          readRecord(fx.toneMapping).exposure,
+          defaults.fx.toneMapping.exposure,
+        ),
+      },
+      passes: {
+        rgbShift: readBoolean(fxPasses.rgbShift, defaults.fx.passes.rgbShift),
+        dot: readBoolean(fxPasses.dot, defaults.fx.passes.dot),
+        technicolor: readBoolean(fxPasses.technicolor, defaults.fx.passes.technicolor),
+        luminosity: readBoolean(fxPasses.luminosity, defaults.fx.passes.luminosity),
+        afterImage: readBoolean(fxPasses.afterImage, defaults.fx.passes.afterImage),
+        sobel: readBoolean(fxPasses.sobel, defaults.fx.passes.sobel),
+        glitch: readBoolean(fxPasses.glitch, defaults.fx.passes.glitch),
+        colorify: readBoolean(fxPasses.colorify, defaults.fx.passes.colorify),
+        halftone: readBoolean(fxPasses.halftone, defaults.fx.passes.halftone),
+        gammaCorrection: readBoolean(
+          fxPasses.gammaCorrection,
+          defaults.fx.passes.gammaCorrection,
+        ),
+        kaleid: readBoolean(fxPasses.kaleid, defaults.fx.passes.kaleid),
+        outputPass: readBoolean(fxPasses.outputPass, defaults.fx.passes.outputPass),
+      },
+      params: {
+        rgbShift: {
+          amount: readNumber(readRecord(fxParams.rgbShift).amount, defaults.fx.params.rgbShift.amount),
+          angle: readNumber(readRecord(fxParams.rgbShift).angle, defaults.fx.params.rgbShift.angle),
+        },
+        afterImage: {
+          damp: readNumber(readRecord(fxParams.afterImage).damp, defaults.fx.params.afterImage.damp),
+        },
+        colorify: {
+          color: normalizeColorValue(readRecord(fxParams.colorify).color),
+        },
+        kaleid: {
+          sides: readNumber(readRecord(fxParams.kaleid).sides, defaults.fx.params.kaleid.sides),
+          angle: readNumber(readRecord(fxParams.kaleid).angle, defaults.fx.params.kaleid.angle),
+        },
+      },
+    },
+    state: {
+      size: readNumber(state.size, defaults.state.size),
+      pointerDown: readNumber(state.pointerDown, defaults.state.pointerDown),
+      currPointerDown: readNumber(state.currPointerDown, defaults.state.currPointerDown),
+      currAudio: readNumber(state.currAudio, defaults.state.currAudio),
+      time: readNumber(state.time, defaults.state.time),
+      volume_multiplier: readNumber(state.volume_multiplier, defaults.state.volume_multiplier),
+    },
+  }
+}
+
+export function mergeSceneEditorBranch<K extends keyof SceneEditorModel>(
+  sceneData: PresetSceneData,
+  branch: K,
+  value: SceneEditorModel[K],
+): PresetSceneData {
+  switch (branch) {
+    case 'visualizer': {
+      const nextVisualizer = value as SceneEditorModel['visualizer']
+
+      return {
+        ...sceneData,
+        visualizer: {
+          ...readRecord(sceneData.visualizer),
+          ...nextVisualizer,
+        },
+      }
+    }
+
+    case 'controls': {
+      const nextControls = value as SceneEditorModel['controls']
+
+      return {
+        ...sceneData,
+        controls: {
+          ...readRecord(sceneData.controls),
+          ...nextControls,
+          target0: {
+            ...readRecord(readRecord(sceneData.controls).target0),
+            ...nextControls.target0,
+          },
+          position0: {
+            ...readRecord(readRecord(sceneData.controls).position0),
+            ...nextControls.position0,
+          },
+        },
+      }
+    }
+
+    case 'intent': {
+      const nextIntent = value as SceneEditorModel['intent']
+
+      return {
+        ...sceneData,
+        intent: {
+          ...readRecord(sceneData.intent),
+          ...nextIntent,
+        },
+      }
+    }
+
+    case 'fx': {
+      const nextFx = value as SceneEditorModel['fx']
+      const currentFx = readRecord(sceneData.fx)
+      const currentParams = readRecord(currentFx.params)
+
+      return {
+        ...sceneData,
+        fx: {
+          ...currentFx,
+          ...nextFx,
+          bloom: {
+            ...readRecord(currentFx.bloom),
+            ...nextFx.bloom,
+          },
+          toneMapping: {
+            ...readRecord(currentFx.toneMapping),
+            ...nextFx.toneMapping,
+          },
+          passes: {
+            ...readRecord(currentFx.passes),
+            ...nextFx.passes,
+          },
+          params: {
+            ...currentParams,
+            ...nextFx.params,
+            rgbShift: {
+              ...readRecord(currentParams.rgbShift),
+              ...nextFx.params.rgbShift,
+            },
+            afterImage: {
+              ...readRecord(currentParams.afterImage),
+              ...nextFx.params.afterImage,
+            },
+            colorify: {
+              ...readRecord(currentParams.colorify),
+              ...nextFx.params.colorify,
+            },
+            kaleid: {
+              ...readRecord(currentParams.kaleid),
+              ...nextFx.params.kaleid,
+            },
+          },
+        },
+      }
+    }
+
+    case 'state': {
+      const nextState = value as SceneEditorModel['state']
+
+      return {
+        ...sceneData,
+        state: {
+          ...readRecord(sceneData.state),
+          ...nextState,
+        },
+      }
+    }
+  }
+}
+
+export function sanitizeSceneData(sceneData: PresetSceneData): PresetSceneData {
+  const normalizedModel = getSceneEditorModel(sceneData)
+  let nextSceneData = { ...sceneData }
+
+  nextSceneData = mergeSceneEditorBranch(nextSceneData, 'visualizer', normalizedModel.visualizer)
+  nextSceneData = mergeSceneEditorBranch(nextSceneData, 'controls', normalizedModel.controls)
+  nextSceneData = mergeSceneEditorBranch(nextSceneData, 'intent', normalizedModel.intent)
+  nextSceneData = mergeSceneEditorBranch(nextSceneData, 'fx', normalizedModel.fx)
+  nextSceneData = mergeSceneEditorBranch(nextSceneData, 'state', normalizedModel.state)
+
+  return nextSceneData
+}
+
+export function parseSceneDataJson(value: string) {
+  const parsedValue = JSON.parse(value) as unknown
+
+  if (!isRecord(parsedValue)) {
+    throw new Error('Scene data must be a JSON object.')
+  }
+
+  return parsedValue
+}
+
+export function prettyPrintSceneData(sceneData: PresetSceneData) {
+  return JSON.stringify(sanitizeSceneData(sceneData), null, 2)
+}
+
+export function toDegrees(radians: number) {
+  return radians * (180 / Math.PI)
+}
+
+export function toRadians(degrees: number) {
+  return degrees * (Math.PI / 180)
+}

--- a/src/pages/CreatePresetPage.test.tsx
+++ b/src/pages/CreatePresetPage.test.tsx
@@ -1,0 +1,224 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  AUTH_SESSION_STORAGE_KEY,
+  AuthProvider,
+  type AuthenticatedUser,
+} from '../auth/AuthContext'
+import { buildApiUrl } from '../lib/api'
+import { CreatePresetPage } from './CreatePresetPage'
+
+vi.mock('../components/MagePlayer', () => ({
+  MagePlayer: ({ sceneBlob }: { sceneBlob: unknown }) => (
+    <div data-testid="mage-player">{sceneBlob ? 'preview-ready' : 'no-preview'}</div>
+  ),
+}))
+
+const storedUser: AuthenticatedUser = {
+  userId: 8,
+  email: 'artist@example.com',
+  displayName: 'Preset Artist',
+  authProvider: 'LOCAL',
+}
+
+function jsonResponse(payload: unknown, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+}
+
+function storeSession() {
+  window.localStorage.setItem(
+    AUTH_SESSION_STORAGE_KEY,
+    JSON.stringify({
+      accessToken: 'stored-auth-token',
+      user: storedUser,
+    }),
+  )
+}
+
+function renderCreatePresetPage() {
+  return render(
+    <MemoryRouter initialEntries={['/create-preset']}>
+      <AuthProvider>
+        <Routes>
+          <Route path="/create-preset" element={<CreatePresetPage />} />
+          <Route path="/my-presets" element={<div>My Presets</div>} />
+        </Routes>
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('CreatePresetPage', () => {
+  it('renders the curated editor with the full section menu available', async () => {
+    storeSession()
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      if (input === buildApiUrl('/users/me')) {
+        return Promise.resolve(jsonResponse(storedUser))
+      }
+
+      throw new Error(`Unexpected request: ${String(input)}`)
+    })
+
+    renderCreatePresetPage()
+
+    expect(screen.getByRole('heading', { name: /create preset/i })).toBeInTheDocument()
+    expect(screen.queryByRole('tab', { name: /basic/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /^scene$/i })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: /^camera$/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: /^motion$/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: /^effects$/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('option', { name: /pass order/i })).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: /advanced/i })).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/scene data json/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/custom shader/i)).not.toBeInTheDocument()
+    expect(screen.getByTestId('mage-player')).toHaveTextContent('preview-ready')
+  })
+
+  it('renders interactive metadata controls beneath the preset name field', async () => {
+    storeSession()
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      if (input === buildApiUrl('/users/me')) {
+        return Promise.resolve(jsonResponse(storedUser))
+      }
+
+      throw new Error(`Unexpected request: ${String(input)}`)
+    })
+
+    renderCreatePresetPage()
+
+    fireEvent.change(screen.getByLabelText(/description/i), {
+      target: { value: 'A soft drifting preset for night scenes.' },
+    })
+    fireEvent.change(screen.getByLabelText(/playlists/i), {
+      target: { value: 'ambient-atlas' },
+    })
+    fireEvent.change(screen.getByLabelText(/upload thumbnail file/i), {
+      target: {
+        files: [new File(['cover'], 'cover.png', { type: 'image/png' })],
+      },
+    })
+
+    expect(screen.getByLabelText(/description/i)).toHaveValue(
+      'A soft drifting preset for night scenes.',
+    )
+    expect(screen.getByLabelText(/playlists/i)).toHaveValue('ambient-atlas')
+    expect(screen.getByText(/selected file:/i)).toBeInTheDocument()
+    expect(screen.getByText(/cover\.png/i)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /a\/b testing/i })).not.toBeInTheDocument()
+  })
+
+  it('keeps the Motion section focused on the controls that affect the preset most directly', async () => {
+    storeSession()
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      if (input === buildApiUrl('/users/me')) {
+        return Promise.resolve(jsonResponse(storedUser))
+      }
+
+      throw new Error(`Unexpected request: ${String(input)}`)
+    })
+
+    renderCreatePresetPage()
+
+    fireEvent.change(screen.getByLabelText(/jump to section/i), { target: { value: 'motion' } })
+
+    expect(screen.getByRole('heading', { name: /^motion$/i })).toBeInTheDocument()
+    expect(screen.getByLabelText(/auto rotate/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/distortion/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/rotation speed/i)).toBeInTheDocument()
+    expect(screen.queryByLabelText(/time speed/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/smoothness/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/compression/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/intensity/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/interaction boost/i)).not.toBeInTheDocument()
+  })
+
+  it('splits pass ordering into its own section and groups effects into categorized cards', async () => {
+    storeSession()
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      if (input === buildApiUrl('/users/me')) {
+        return Promise.resolve(jsonResponse(storedUser))
+      }
+
+      throw new Error(`Unexpected request: ${String(input)}`)
+    })
+
+    renderCreatePresetPage()
+
+    fireEvent.change(screen.getByLabelText(/jump to section/i), { target: { value: 'effects' } })
+
+    expect(screen.getByRole('heading', { name: /^effects$/i })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: /^pass order$/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /^finish & output$/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /^channel & motion$/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /^color & tone$/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /^pattern & structure$/i })).toBeInTheDocument()
+    expect(screen.getByText(/^gamma correction$/i)).toBeInTheDocument()
+    expect(screen.getByText(/sharp digital breakups and instability/i)).toBeInTheDocument()
+    expect(screen.queryByText(/^additional passes$/i)).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText(/jump to section/i), { target: { value: 'pass-order' } })
+
+    expect(screen.getByRole('heading', { name: /^pass order$/i })).toBeInTheDocument()
+    expect(screen.getByText(/^output$/i)).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: /^finish & output$/i })).not.toBeInTheDocument()
+  })
+
+  it('submits the structured scene data and converts degree controls back to radians', async () => {
+    storeSession()
+
+    let submittedBody: Record<string, unknown> | null = null
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      if (input === buildApiUrl('/users/me')) {
+        return Promise.resolve(jsonResponse(storedUser))
+      }
+
+      if (input === buildApiUrl('/presets')) {
+        submittedBody = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
+        return Promise.resolve(jsonResponse({ presetId: 18 }, 201))
+      }
+
+      throw new Error(`Unexpected request: ${String(input)}`)
+    })
+
+    const user = userEvent.setup()
+
+    renderCreatePresetPage()
+
+    await user.type(screen.getByLabelText(/preset name/i), 'Aurora Drift')
+    fireEvent.change(screen.getByLabelText(/jump to section/i), { target: { value: 'camera' } })
+    expect(screen.getByRole('heading', { name: /^camera$/i })).toBeInTheDocument()
+    fireEvent.change(screen.getByLabelText(/camera tilt/i), { target: { value: '90' } })
+    await user.click(screen.getByRole('button', { name: /create preset/i }))
+
+    await waitFor(() => expect(submittedBody).not.toBeNull())
+
+    if (!submittedBody) {
+      throw new Error('Expected preset submission payload to be captured.')
+    }
+
+    const responseBody: { name: string; sceneData: Record<string, unknown> } = submittedBody
+    const sceneData = responseBody.sceneData
+    const intent = sceneData.intent as Record<string, number>
+    const fx = sceneData.fx as Record<string, unknown>
+    const passOrder = fx.passOrder as string[]
+
+    expect(responseBody).toMatchObject({
+      name: 'Aurora Drift',
+    })
+    expect(intent.camTilt).toBeCloseTo(Math.PI / 2, 5)
+    expect(passOrder.at(-1)).toBe('outputPass')
+    expect(await screen.findByText('My Presets')).toBeInTheDocument()
+  })
+})

--- a/src/pages/CreatePresetPage.tsx
+++ b/src/pages/CreatePresetPage.tsx
@@ -1,0 +1,164 @@
+import { useId, useState } from 'react'
+import type { FormEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { AuthPage, AuthPageHeader } from '../components/AuthPage'
+import { parseApiError } from '../lib/authForm'
+import { useAuth } from '../auth/AuthContext'
+
+type CreatePresetFormValues = {
+  name: string
+  sceneData: string
+}
+
+type CreatePresetFormErrors = Partial<Record<keyof CreatePresetFormValues | 'form', string>>
+
+const initialValues: CreatePresetFormValues = {
+  name: '',
+  sceneData: '',
+}
+
+function validateForm(values: CreatePresetFormValues): CreatePresetFormErrors {
+  const errors: CreatePresetFormErrors = {}
+
+  if (!values.name.trim()) {
+    errors.name = 'Preset name is required.'
+  } else if (values.name.trim().length < 2) {
+    errors.name = 'Preset name must be at least 2 characters.'
+  }
+
+  if (!values.sceneData.trim()) {
+    errors.sceneData = 'Scene data is required.'
+  } else {
+    try {
+      JSON.parse(values.sceneData.trim())
+    } catch {
+      errors.sceneData = 'Scene data must be valid JSON.'
+    }
+  }
+
+  return errors
+}
+
+export function CreatePresetPage() {
+  const { authenticatedFetch } = useAuth()
+  const navigate = useNavigate()
+  const [values, setValues] = useState(initialValues)
+  const [errors, setErrors] = useState<CreatePresetFormErrors>({})
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const formErrorId = useId()
+  const titleId = 'create-preset-title'
+
+  function handleChange(field: keyof CreatePresetFormValues, nextValue: string) {
+    setValues((currentValues) => ({ ...currentValues, [field]: nextValue }))
+    setErrors((currentErrors) => {
+      if (!currentErrors[field] && !currentErrors.form) return currentErrors
+      return { ...currentErrors, [field]: undefined, form: undefined }
+    })
+  }
+
+   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    const trimmedValues = {
+      name: values.name.trim(),
+      sceneData: values.sceneData.trim(),
+    }
+
+    const nextErrors = validateForm(trimmedValues)
+    if (Object.keys(nextErrors).length > 0) {
+      setErrors(nextErrors)
+      return
+    }
+
+    setIsSubmitting(true)
+    setErrors({})
+
+    try {
+      const response = await authenticatedFetch('/presets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: trimmedValues.name,
+          sceneData: JSON.parse(trimmedValues.sceneData),
+        }),
+      })
+
+      if (!response.ok) {
+        const apiError = await parseApiError(response)
+        const backendDetails = apiError?.details ?? {}
+        setErrors({
+          name: backendDetails.name,
+          sceneData: backendDetails.sceneData,
+          form: apiError?.message ?? 'Failed to create preset. Please try again.',
+        })
+        return
+      }
+
+      navigate('/my-presets')
+    } catch {
+      setErrors({
+        form: 'Preset creation is unavailable right now. Please try again in a moment.',
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <AuthPage titleId={titleId}>
+      <AuthPageHeader
+        description="Fill in the details below to create a new preset."
+        eyebrow="New Preset"
+        title="Create Preset"
+        titleId={titleId}
+      />
+    <form className="auth-form" noValidate onSubmit={handleSubmit}>
+        <div className="field-group">
+          <label htmlFor="name">Preset name</label>
+          <input
+            id="name"
+            name="name"
+            type="text"
+            required
+            minLength={2}
+            value={values.name}
+            onChange={(event) => handleChange('name', event.target.value)}
+            aria-invalid={Boolean(errors.name)}
+            aria-describedby={errors.name ? 'name-error' : undefined}
+            placeholder="My Preset"
+          />
+          {errors.name ? (
+            <p className="field-error" id="name-error" role="alert">{errors.name}</p>
+          ) : null}
+          </div>
+
+           <div className="field-group">
+          <label htmlFor="sceneData">Scene data (JSON)</label>
+          <textarea
+            id="sceneData"
+            name="sceneData"
+            required
+            rows={6}
+            value={values.sceneData}
+            onChange={(event) => handleChange('sceneData', event.target.value)}
+            aria-invalid={Boolean(errors.sceneData)}
+            aria-describedby={errors.sceneData ? 'sceneData-error' : undefined}
+            placeholder='{"key": "value"}'
+          />
+          {errors.sceneData ? (
+            <p className="field-error" id="sceneData-error" role="alert">{errors.sceneData}</p>
+          ) : null}
+        </div>
+        
+        {errors.form ? (
+          <div className="form-alert" id={formErrorId} role="alert">{errors.form}</div>
+        ) : null}
+        
+        <button className="demo-link auth-submit" type="submit" disabled={isSubmitting}>
+          {isSubmitting ? 'Creating preset...' : 'Create preset'}
+        </button>
+    </form>
+    </AuthPage>
+  )
+}

--- a/src/pages/CreatePresetPage.tsx
+++ b/src/pages/CreatePresetPage.tsx
@@ -1,164 +1,1644 @@
-import { useId, useState } from 'react'
-import type { FormEvent } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { AuthPage, AuthPageHeader } from '../components/AuthPage'
-import { parseApiError } from '../lib/authForm'
-import { useAuth } from '../auth/AuthContext'
+import type { FormEvent } from "react";
+import { useId, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../auth/AuthContext";
+import { AuthPage, AuthPageHeader } from "../components/AuthPage";
+import { MagePlayer } from "../components/MagePlayer";
+import {
+  EffectCard,
+  NumberField,
+  PresetSection,
+  SelectField,
+  SliderField,
+  ToggleField,
+  Vector3Field,
+} from "../components/PresetEditorControls";
+import { parseApiError } from "../lib/authForm";
+import {
+  createDefaultSceneData,
+  getSceneEditorModel,
+  mergeSceneEditorBranch,
+  parseSceneDataJson,
+  PASS_LABELS,
+  prettyPrintSceneData,
+  sanitizeSceneData,
+  SHADER_PRESETS,
+  SKYBOX_OPTIONS,
+  TONE_MAPPING_OPTIONS,
+  toDegrees,
+  toRadians,
+  type PersistedPassFlag,
+  type PresetPassId,
+  type PresetSceneData,
+  type SceneEditorModel,
+} from "../lib/presetEditor";
 
-type CreatePresetFormValues = {
-  name: string
-  sceneData: string
-}
+type CreatePresetFormErrors = Partial<
+  Record<"form" | "name" | "sceneData", string>
+>;
+type EditorSectionId =
+  | "advanced"
+  | "camera"
+  | "effects"
+  | "motion"
+  | "pass-order"
+  | "scene";
+type EffectCategoryId = "color" | "finish" | "pattern" | "trail";
+type ThumbnailMode = "auto" | "upload";
 
-type CreatePresetFormErrors = Partial<Record<keyof CreatePresetFormValues | 'form', string>>
+type AdditionalPassConfig = {
+  category: EffectCategoryId;
+  description: string;
+  flag: PersistedPassFlag;
+  passId: PresetPassId;
+};
 
-const initialValues: CreatePresetFormValues = {
-  name: '',
-  sceneData: '',
-}
+type EditorSectionConfig = {
+  id: EditorSectionId;
+  title: string;
+};
 
-function validateForm(values: CreatePresetFormValues): CreatePresetFormErrors {
-  const errors: CreatePresetFormErrors = {}
+const EDITOR_SECTIONS: EditorSectionConfig[] = [
+  {
+    id: "scene",
+    title: "Scene",
+  },
+  {
+    id: "camera",
+    title: "Camera",
+  },
+  {
+    id: "motion",
+    title: "Motion",
+  },
+  {
+    id: "effects",
+    title: "Effects",
+  },
+  {
+    id: "pass-order",
+    title: "Pass Order",
+  },
+];
 
-  if (!values.name.trim()) {
-    errors.name = 'Preset name is required.'
-  } else if (values.name.trim().length < 2) {
-    errors.name = 'Preset name must be at least 2 characters.'
+const initialSceneData = sanitizeSceneData(createDefaultSceneData());
+const PLAYLIST_OPTIONS = [
+  {
+    label: "Featured Collection",
+    value: "featured-collection",
+  },
+  {
+    label: "Ambient Atlas",
+    value: "ambient-atlas",
+  },
+  {
+    label: "Night Drive",
+    value: "night-drive",
+  },
+  {
+    label: "Discovery Lab",
+    value: "discovery-lab",
+  },
+];
+
+const additionalPasses: AdditionalPassConfig[] = [
+  {
+    category: "trail",
+    flag: "glitch",
+    passId: "glitchPass",
+    description: "Inject sharp digital breakups and instability.",
+  },
+  {
+    category: "pattern",
+    flag: "dot",
+    passId: "dotShader",
+    description: "Halftone-style dots for a print-like screen texture.",
+  },
+  {
+    category: "color",
+    flag: "technicolor",
+    passId: "technicolorShader",
+    description: "Shift the image toward a high-contrast retro palette.",
+  },
+  {
+    category: "color",
+    flag: "luminosity",
+    passId: "luminosityShader",
+    description: "Flatten the palette toward a luminance-driven look.",
+  },
+  {
+    category: "pattern",
+    flag: "sobel",
+    passId: "sobelShader",
+    description: "Emphasize outlines and edge contrast.",
+  },
+  {
+    category: "pattern",
+    flag: "halftone",
+    passId: "halftonePass",
+    description: "Break the image into clustered print cells.",
+  },
+  {
+    category: "finish",
+    flag: "gammaCorrection",
+    passId: "gammaCorrectionShader",
+    description: "Apply a gamma correction pass at the end of the stack.",
+  },
+];
+
+const additionalPassesByCategory: Record<
+  EffectCategoryId,
+  AdditionalPassConfig[]
+> = {
+  color: additionalPasses.filter(
+    (passConfig) => passConfig.category === "color",
+  ),
+  finish: additionalPasses.filter(
+    (passConfig) => passConfig.category === "finish",
+  ),
+  pattern: additionalPasses.filter(
+    (passConfig) => passConfig.category === "pattern",
+  ),
+  trail: additionalPasses.filter(
+    (passConfig) => passConfig.category === "trail",
+  ),
+};
+
+const passFlagsById: Partial<Record<PresetPassId, PersistedPassFlag>> = {
+  RGBShift: "rgbShift",
+  afterImagePass: "afterImage",
+  colorifyShader: "colorify",
+  dotShader: "dot",
+  gammaCorrectionShader: "gammaCorrection",
+  glitchPass: "glitch",
+  halftonePass: "halftone",
+  kaleidoShader: "kaleid",
+  luminosityShader: "luminosity",
+  outputPass: "outputPass",
+  sobelShader: "sobel",
+  technicolorShader: "technicolor",
+};
+
+function buildShaderOptions(currentShader: string) {
+  const matchedPreset = SHADER_PRESETS.find(
+    (preset) => preset.shader.trim() === currentShader.trim(),
+  );
+  const options = SHADER_PRESETS.map((preset) => ({
+    label: preset.label,
+    value: preset.id,
+  }));
+
+  if (!matchedPreset) {
+    options.unshift({
+      label: "Custom Shader",
+      value: "custom",
+    });
   }
 
-  if (!values.sceneData.trim()) {
-    errors.sceneData = 'Scene data is required.'
+  return {
+    matchedPreset,
+    options,
+    value: matchedPreset?.id ?? "custom",
+  };
+}
+
+function formatFixed(value: number, fractionDigits = 2) {
+  return value.toFixed(fractionDigits).replace(/0+$/, "").replace(/\.$/, "");
+}
+
+function formatDegrees(value: number) {
+  return `${Math.round(value)}\u00B0`;
+}
+
+function NavigationIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24">
+      <path
+        d="M12 3.8a8.2 8.2 0 1 0 8.2 8.2A8.2 8.2 0 0 0 12 3.8Zm0 14.9a6.7 6.7 0 1 1 6.7-6.7 6.7 6.7 0 0 1-6.7 6.7Z"
+        fill="currentColor"
+      />
+      <path
+        d="M14.9 8.3 9.8 10.6a.8.8 0 0 0-.4.4l-2.3 5.1a.4.4 0 0 0 .5.5l5.1-2.3a.8.8 0 0 0 .4-.4l2.3-5.1a.4.4 0 0 0-.5-.5Zm-2.8 4.8-2.4 1.1 1.1-2.4 2.4-1.1Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function buildToneMappingOptions(currentMethod: number) {
+  const matchedOption = TONE_MAPPING_OPTIONS.find(
+    (option) => option.value === currentMethod,
+  );
+  const options = TONE_MAPPING_OPTIONS.map((option) => ({
+    label: option.label,
+    value: String(option.value),
+  }));
+
+  if (!matchedOption) {
+    options.unshift({
+      label: `Custom (${currentMethod})`,
+      value: String(currentMethod),
+    });
+  }
+
+  return {
+    matchedOption,
+    options,
+    value: String(currentMethod),
+  };
+}
+
+function describePassState(passId: PresetPassId, sceneModel: SceneEditorModel) {
+  if (passId === "outputPass") {
+    return "Fixed last";
+  }
+
+  if (passId === "bloom") {
+    return sceneModel.fx.bloom.enabled ? "Enabled" : "Disabled";
+  }
+
+  const flag = passFlagsById[passId];
+
+  if (!flag) {
+    return "Order only";
+  }
+
+  return sceneModel.fx.passes[flag] ? "Enabled" : "Disabled";
+}
+
+function validateForm(name: string, sceneDataText: string) {
+  const errors: CreatePresetFormErrors = {};
+  let parsedSceneData: PresetSceneData | null = null;
+
+  if (!name.trim()) {
+    errors.name = "Preset name is required.";
+  } else if (name.trim().length < 2) {
+    errors.name = "Preset name must be at least 2 characters.";
+  }
+
+  if (!sceneDataText.trim()) {
+    errors.sceneData = "Scene data is required.";
   } else {
     try {
-      JSON.parse(values.sceneData.trim())
-    } catch {
-      errors.sceneData = 'Scene data must be valid JSON.'
+      parsedSceneData = parseSceneDataJson(sceneDataText.trim());
+    } catch (error) {
+      errors.sceneData =
+        error instanceof Error && error.message.trim()
+          ? error.message
+          : "Scene data must be valid JSON.";
     }
   }
 
-  return errors
+  return {
+    errors,
+    parsedSceneData,
+  };
 }
 
 export function CreatePresetPage() {
-  const { authenticatedFetch } = useAuth()
-  const navigate = useNavigate()
-  const [values, setValues] = useState(initialValues)
-  const [errors, setErrors] = useState<CreatePresetFormErrors>({})
-  const [isSubmitting, setIsSubmitting] = useState(false)
+  const { authenticatedFetch } = useAuth();
+  const navigate = useNavigate();
 
-  const formErrorId = useId()
-  const titleId = 'create-preset-title'
+  const [sectionMenuValue, setSectionMenuValue] =
+    useState<EditorSectionId>("scene");
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [thumbnailMode, setThumbnailMode] = useState<ThumbnailMode>("auto");
+  const [thumbnailFileName, setThumbnailFileName] = useState("");
+  const [playlistValue, setPlaylistValue] = useState("");
+  const [sceneData, setSceneData] = useState<PresetSceneData>(initialSceneData);
+  const [sceneDataText, setSceneDataText] = useState(() =>
+    prettyPrintSceneData(initialSceneData),
+  );
+  const [errors, setErrors] = useState<CreatePresetFormErrors>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const thumbnailFileInputRef = useRef<HTMLInputElement | null>(null);
 
-  function handleChange(field: keyof CreatePresetFormValues, nextValue: string) {
-    setValues((currentValues) => ({ ...currentValues, [field]: nextValue }))
-    setErrors((currentErrors) => {
-      if (!currentErrors[field] && !currentErrors.form) return currentErrors
-      return { ...currentErrors, [field]: undefined, form: undefined }
-    })
+  const formErrorId = useId();
+  const thumbnailInputId = useId();
+  const titleId = "create-preset-title";
+  const sceneModel = useMemo(() => getSceneEditorModel(sceneData), [sceneData]);
+  const previewSceneData = useMemo(
+    () => sanitizeSceneData(sceneData),
+    [sceneData],
+  );
+  const shaderSelection = useMemo(
+    () => buildShaderOptions(sceneModel.visualizer.shader),
+    [sceneModel.visualizer.shader],
+  );
+  const toneMappingSelection = useMemo(
+    () => buildToneMappingOptions(sceneModel.fx.toneMapping.method),
+    [sceneModel.fx.toneMapping.method],
+  );
+  const selectedShaderPreset = shaderSelection.matchedPreset;
+  const selectedToneMapping =
+    toneMappingSelection.matchedOption ?? TONE_MAPPING_OPTIONS[0];
+
+  function renderAdditionalPassCard(passConfig: AdditionalPassConfig) {
+    return (
+      <EffectCard
+        description={passConfig.description}
+        enabled={sceneModel.fx.passes[passConfig.flag]}
+        key={passConfig.flag}
+        onToggle={(nextValue) =>
+          updateBranch("fx", (currentFx) => ({
+            ...currentFx,
+            passes: {
+              ...currentFx.passes,
+              [passConfig.flag]: nextValue,
+            },
+          }))
+        }
+        title={PASS_LABELS[passConfig.passId]}
+      />
+    );
   }
 
-   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-
-    const trimmedValues = {
-      name: values.name.trim(),
-      sceneData: values.sceneData.trim(),
+  function clearErrors(...fields: Array<"form" | "name" | "sceneData">) {
+    if (fields.length === 0) {
+      setErrors({});
+      return;
     }
 
-    const nextErrors = validateForm(trimmedValues)
-    if (Object.keys(nextErrors).length > 0) {
-      setErrors(nextErrors)
-      return
+    setErrors((currentErrors) => {
+      const nextErrors = { ...currentErrors };
+
+      for (const field of fields) {
+        nextErrors[field] = undefined;
+      }
+
+      return nextErrors;
+    });
+  }
+
+  function applySceneData(nextSceneData: PresetSceneData) {
+    const sanitizedSceneData = sanitizeSceneData(nextSceneData);
+    setSceneData(sanitizedSceneData);
+    setSceneDataText(prettyPrintSceneData(sanitizedSceneData));
+    clearErrors("sceneData", "form");
+  }
+
+  function updateBranch<K extends keyof SceneEditorModel>(
+    branch: K,
+    recipe: (currentBranch: SceneEditorModel[K]) => SceneEditorModel[K],
+  ) {
+    const currentModel = getSceneEditorModel(sceneData);
+    const nextBranch = recipe(currentModel[branch]);
+    applySceneData(mergeSceneEditorBranch(sceneData, branch, nextBranch));
+  }
+
+  function handleNameChange(nextValue: string) {
+    setName(nextValue);
+    clearErrors("name", "form");
+  }
+
+  function handleThumbnailModeChange(nextValue: ThumbnailMode) {
+    setThumbnailMode(nextValue);
+  }
+
+  function handleThumbnailUploadClick() {
+    setThumbnailMode("upload");
+    thumbnailFileInputRef.current?.click();
+  }
+
+  function handleThumbnailFileChange(fileList: FileList | File[] | null) {
+    let nextFile: File | null = null;
+
+    if (Array.isArray(fileList)) {
+      nextFile = fileList[0] ?? null;
+    } else {
+      nextFile = fileList?.item(0) ?? null;
     }
 
-    setIsSubmitting(true)
-    setErrors({})
+    if (!nextFile) {
+      return;
+    }
+
+    setThumbnailMode("upload");
+    setThumbnailFileName(nextFile.name);
+  }
+
+  function handleSectionJump(nextSectionId: EditorSectionId) {
+    setSectionMenuValue(nextSectionId);
+  }
+
+  function handleRawSceneDataChange(nextValue: string) {
+    setSceneDataText(nextValue);
+    clearErrors("sceneData", "form");
 
     try {
-      const response = await authenticatedFetch('/presets', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+      setSceneData(sanitizeSceneData(parseSceneDataJson(nextValue)));
+    } catch {
+      return;
+    }
+  }
+
+  function handleFormatJson() {
+    try {
+      const parsedSceneData = parseSceneDataJson(sceneDataText);
+      applySceneData(parsedSceneData);
+    } catch (error) {
+      setErrors((currentErrors) => ({
+        ...currentErrors,
+        sceneData:
+          error instanceof Error && error.message.trim()
+            ? error.message
+            : "Scene data must be valid JSON before formatting.",
+      }));
+    }
+  }
+
+  function movePass(passId: PresetPassId, direction: -1 | 1) {
+    if (passId === "outputPass") {
+      return;
+    }
+
+    updateBranch("fx", (currentFx) => {
+      const movablePasses = currentFx.passOrder.filter(
+        (currentPassId): currentPassId is Exclude<PresetPassId, "outputPass"> =>
+          currentPassId !== "outputPass",
+      );
+      const currentIndex = movablePasses.indexOf(passId);
+      const nextIndex = currentIndex + direction;
+
+      if (
+        currentIndex < 0 ||
+        nextIndex < 0 ||
+        nextIndex >= movablePasses.length
+      ) {
+        return currentFx;
+      }
+
+      const nextPassOrder = [...movablePasses];
+      const [movedPass] = nextPassOrder.splice(currentIndex, 1);
+      nextPassOrder.splice(nextIndex, 0, movedPass);
+
+      return {
+        ...currentFx,
+        passOrder: [...nextPassOrder, "outputPass"],
+      };
+    });
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const trimmedName = name.trim();
+    const { errors: nextErrors, parsedSceneData } = validateForm(
+      trimmedName,
+      sceneDataText,
+    );
+
+    if (Object.keys(nextErrors).length > 0) {
+      setErrors(nextErrors);
+      return;
+    }
+
+    const sanitizedSceneData = sanitizeSceneData(parsedSceneData ?? sceneData);
+
+    setIsSubmitting(true);
+    setErrors({});
+
+    try {
+      const response = await authenticatedFetch("/presets", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          name: trimmedValues.name,
-          sceneData: JSON.parse(trimmedValues.sceneData),
+          name: trimmedName,
+          sceneData: sanitizedSceneData,
         }),
-      })
+      });
 
       if (!response.ok) {
-        const apiError = await parseApiError(response)
-        const backendDetails = apiError?.details ?? {}
+        const apiError = await parseApiError(response);
+        const backendDetails = apiError?.details ?? {};
         setErrors({
           name: backendDetails.name,
           sceneData: backendDetails.sceneData,
-          form: apiError?.message ?? 'Failed to create preset. Please try again.',
-        })
-        return
+          form:
+            apiError?.message ?? "Failed to create preset. Please try again.",
+        });
+        return;
       }
 
-      navigate('/my-presets')
+      navigate("/my-presets");
     } catch {
       setErrors({
-        form: 'Preset creation is unavailable right now. Please try again in a moment.',
-      })
+        form: "Preset creation is unavailable right now. Please try again in a moment.",
+      });
     } finally {
-      setIsSubmitting(false)
+      setIsSubmitting(false);
     }
   }
 
   return (
-    <AuthPage titleId={titleId}>
+    <AuthPage
+      className="auth-page--wide"
+      cardClassName="surface--editor"
+      titleId={titleId}
+    >
       <AuthPageHeader
-        description="Fill in the details below to create a new preset."
-        eyebrow="New Preset"
+        description="Build a preset with curated scene controls and effect shaping."
+        eyebrow="Preset Studio"
         title="Create Preset"
         titleId={titleId}
       />
-    <form className="auth-form" noValidate onSubmit={handleSubmit}>
-        <div className="field-group">
-          <label htmlFor="name">Preset name</label>
-          <input
-            id="name"
-            name="name"
-            type="text"
-            required
-            minLength={2}
-            value={values.name}
-            onChange={(event) => handleChange('name', event.target.value)}
-            aria-invalid={Boolean(errors.name)}
-            aria-describedby={errors.name ? 'name-error' : undefined}
-            placeholder="My Preset"
-          />
-          {errors.name ? (
-            <p className="field-error" id="name-error" role="alert">{errors.name}</p>
-          ) : null}
+
+      <form
+        aria-describedby={errors.form ? formErrorId : undefined}
+        className="preset-editor-form"
+        noValidate
+        onSubmit={handleSubmit}
+      >
+        <div className="preset-editor-layout">
+          <div className="preset-editor-main">
+            <div className="preset-editor-toolbar">
+              <div className="field-group preset-editor-toolbar__name">
+                <label htmlFor="name">Preset Name</label>
+                <input
+                  id="name"
+                  minLength={2}
+                  name="name"
+                  onChange={(event) =>
+                    handleNameChange(event.currentTarget.value)
+                  }
+                  placeholder="Aurora Drift"
+                  required
+                  type="text"
+                  value={name}
+                  aria-describedby={errors.name ? "name-error" : "name-hint"}
+                  aria-invalid={Boolean(errors.name)}
+                />
+                {errors.name ? (
+                  <p className="field-error" id="name-error" role="alert">
+                    {errors.name}
+                  </p>
+                ) : (
+                  <p className="field-hint" id="name-hint">
+                    Start with a memorable name.
+                  </p>
+                )}
+              </div>
+
+              <div className="preset-editor-toolbar__metadata">
+                <div className="field-group">
+                  <label htmlFor="description">Description</label>
+                  <textarea
+                    id="description"
+                    onChange={(event) =>
+                      setDescription(event.currentTarget.value)
+                    }
+                    placeholder="Describe the mood, motion, or moment this preset is built for."
+                    rows={5}
+                    value={description}
+                  />
+                </div>
+
+                <div className="field-group">
+                  <label htmlFor={thumbnailInputId}>Thumbnail</label>
+                  <div className="preset-thumbnail-picker">
+                    <input
+                      accept="image/*"
+                      aria-label="Upload thumbnail file"
+                      className="preset-thumbnail-input"
+                      id={thumbnailInputId}
+                      onChange={(event) =>
+                        handleThumbnailFileChange(event.currentTarget.files)
+                      }
+                      ref={thumbnailFileInputRef}
+                      type="file"
+                    />
+
+                    <div className="preset-thumbnail-picker__grid">
+                      <button
+                        className={`preset-thumbnail-choice${
+                          thumbnailMode === "upload" ? " is-selected" : ""
+                        }`}
+                        onClick={handleThumbnailUploadClick}
+                        type="button"
+                      >
+                        <span className="preset-thumbnail-choice__eyebrow">
+                          Upload
+                        </span>
+                        <strong className="preset-thumbnail-choice__title">
+                          Upload File
+                        </strong>
+                        <span className="preset-thumbnail-choice__description">
+                          Bring in a custom still from your device.
+                        </span>
+                      </button>
+
+                      <button
+                        className={`preset-thumbnail-choice${
+                          thumbnailMode === "auto" ? " is-selected" : ""
+                        }`}
+                        onClick={() => handleThumbnailModeChange("auto")}
+                        type="button"
+                      >
+                        <span className="preset-thumbnail-choice__eyebrow">
+                          Quick Pick
+                        </span>
+                        <strong className="preset-thumbnail-choice__title">
+                          Auto-generated
+                        </strong>
+                        <span className="preset-thumbnail-choice__description">
+                          Start from a generated cover treatment.
+                        </span>
+                      </button>
+                    </div>
+
+                    {thumbnailFileName ? (
+                      <p className="field-hint">
+                        Selected file: <strong>{thumbnailFileName}</strong>
+                      </p>
+                    ) : null}
+                  </div>
+                </div>
+
+                <div className="field-group">
+                  <label htmlFor="playlists">Playlists</label>
+                  <select
+                    className="preset-select"
+                    id="playlists"
+                    onChange={(event) =>
+                      setPlaylistValue(event.currentTarget.value)
+                    }
+                    value={playlistValue}
+                  >
+                    <option value="">Select playlist</option>
+                    {PLAYLIST_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+
+              <div className="preset-editor-toolbar__controls">
+                <div className="preset-editor-toolbar__control-group preset-editor-toolbar__control-group--navigation">
+                  <div className="preset-editor-toolbar__control-copy">
+                    <span className="preset-editor-toolbar__eyebrow">
+                      Navigation
+                    </span>
+                    <label
+                      className="preset-field__label"
+                      htmlFor="section-jump"
+                    >
+                      Jump To Section
+                    </label>
+                  </div>
+
+                  <div className="preset-editor-toolbar__navigation-shell">
+                    <span
+                      aria-hidden="true"
+                      className="preset-editor-toolbar__navigation-icon"
+                    >
+                      <NavigationIcon />
+                    </span>
+                    <select
+                      className="preset-select preset-select--navigation"
+                      id="section-jump"
+                      onChange={(event) =>
+                        handleSectionJump(
+                          event.currentTarget.value as EditorSectionId,
+                        )
+                      }
+                      value={sectionMenuValue}
+                    >
+                      {EDITOR_SECTIONS.map((section) => (
+                        <option key={section.id} value={section.id}>
+                          {section.title}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {errors.form ? (
+              <div className="form-alert" id={formErrorId} role="alert">
+                {errors.form}
+              </div>
+            ) : null}
+
+            {sectionMenuValue === "scene" ? (
+              <PresetSection
+                description="Visual identity, environment, and scale."
+                title="Scene"
+              >
+                <div className="preset-editor-grid preset-editor-grid--3">
+                  <SelectField
+                    description={
+                      selectedShaderPreset?.description ??
+                      "Custom shader text is currently active."
+                    }
+                    id="shader"
+                    label="Shader"
+                    onChange={(nextValue) => {
+                      const nextShaderPreset = SHADER_PRESETS.find(
+                        (preset) => preset.id === nextValue,
+                      );
+
+                      if (!nextShaderPreset) {
+                        return;
+                      }
+
+                      updateBranch("visualizer", (currentVisualizer) => ({
+                        ...currentVisualizer,
+                        shader: nextShaderPreset.shader,
+                      }));
+                    }}
+                    options={shaderSelection.options}
+                    value={shaderSelection.value}
+                  />
+
+                  <SelectField
+                    description="Pick from the bundled skybox presets instead of entering loader-specific values."
+                    id="skybox"
+                    label="Skybox"
+                    onChange={(nextValue) =>
+                      updateBranch("visualizer", (currentVisualizer) => ({
+                        ...currentVisualizer,
+                        skyboxPreset: Number(nextValue),
+                      }))
+                    }
+                    options={SKYBOX_OPTIONS.map((option) => ({
+                      label: option.label,
+                      value: String(option.value),
+                    }))}
+                    value={String(sceneModel.visualizer.skyboxPreset)}
+                  />
+
+                  <SliderField
+                    description="Scale the main geometry authored by the shader."
+                    formatValue={(value) => formatFixed(value, 0)}
+                    id="scene-scale"
+                    label="Scene Scale"
+                    max={200}
+                    min={1}
+                    onChange={(nextValue) =>
+                      updateBranch("visualizer", (currentVisualizer) => ({
+                        ...currentVisualizer,
+                        scale: nextValue,
+                      }))
+                    }
+                    step={1}
+                    value={sceneModel.visualizer.scale}
+                  />
+                </div>
+              </PresetSection>
+            ) : null}
+
+            {sectionMenuValue === "camera" ? (
+              <PresetSection
+                description="Position, framing, and lens."
+                title="Camera"
+              >
+                <div className="preset-editor-grid preset-editor-grid--2">
+                  <Vector3Field
+                    description="The camera position in the scene."
+                    id="camera-position"
+                    label="Camera Position"
+                    onChange={(nextValue) =>
+                      updateBranch("controls", (currentControls) => ({
+                        ...currentControls,
+                        position0: nextValue,
+                      }))
+                    }
+                    value={sceneModel.controls.position0}
+                  />
+
+                  <Vector3Field
+                    description="Where the camera points while the preset loads."
+                    id="camera-target"
+                    label="Camera Target"
+                    onChange={(nextValue) =>
+                      updateBranch("controls", (currentControls) => ({
+                        ...currentControls,
+                        target0: nextValue,
+                      }))
+                    }
+                    value={sceneModel.controls.target0}
+                  />
+
+                  <SliderField
+                    description="How wide the camera lens feels."
+                    formatValue={(value) => formatFixed(value, 0)}
+                    id="field-of-view"
+                    label="Field of View"
+                    max={359}
+                    min={1}
+                    onChange={(nextValue) =>
+                      updateBranch("intent", (currentIntent) => ({
+                        ...currentIntent,
+                        fov: nextValue,
+                      }))
+                    }
+                    step={1}
+                    value={sceneModel.intent.fov}
+                  />
+
+                  <SliderField
+                    description="Displayed in degrees while the engine still stores radians."
+                    formatValue={formatDegrees}
+                    id="camera-tilt"
+                    label="Camera Tilt"
+                    max={360}
+                    min={0}
+                    onChange={(nextValue) =>
+                      updateBranch("intent", (currentIntent) => ({
+                        ...currentIntent,
+                        camTilt: toRadians(nextValue),
+                      }))
+                    }
+                    step={1}
+                    value={toDegrees(sceneModel.intent.camTilt)}
+                  />
+
+                  <NumberField
+                    description="Free-form camera zoom for precise framing."
+                    id="zoom"
+                    label="Zoom"
+                    onChange={(nextValue) =>
+                      updateBranch("controls", (currentControls) => ({
+                        ...currentControls,
+                        zoom0: nextValue,
+                      }))
+                    }
+                    step={0.1}
+                    value={sceneModel.controls.zoom0}
+                  />
+                </div>
+              </PresetSection>
+            ) : null}
+
+            {sectionMenuValue === "motion" ? (
+              <PresetSection
+                description="Rotation and visual shaping."
+                title="Motion"
+              >
+                <div className="preset-editor-grid preset-editor-grid--2">
+                  <SliderField
+                    description="How quickly the auto rotation travels when enabled."
+                    id="rotation-speed"
+                    label="Rotation Speed"
+                    max={50}
+                    min={0.1}
+                    onChange={(nextValue) =>
+                      updateBranch("intent", (currentIntent) => ({
+                        ...currentIntent,
+                        autoRotateSpeed: nextValue,
+                      }))
+                    }
+                    step={0.1}
+                    value={sceneModel.intent.autoRotateSpeed}
+                  />
+
+                  <SliderField
+                    description="This shapes and distorts the visual more than it changes speed."
+                    id="base-speed"
+                    label="Distortion"
+                    max={0.9}
+                    min={0.01}
+                    onChange={(nextValue) =>
+                      updateBranch("intent", (currentIntent) => ({
+                        ...currentIntent,
+                        base_speed: nextValue,
+                      }))
+                    }
+                    step={0.01}
+                    value={sceneModel.intent.base_speed}
+                  />
+
+                  <div className="preset-editor-grid__item--full">
+                    <ToggleField
+                      checked={sceneModel.intent.autoRotate}
+                      description="Keep the scene gently rotating on its own."
+                      id="auto-rotate"
+                      label="Auto Rotate"
+                      onChange={(nextValue) =>
+                        updateBranch("intent", (currentIntent) => ({
+                          ...currentIntent,
+                          autoRotate: nextValue,
+                        }))
+                      }
+                    />
+                  </div>
+                </div>
+              </PresetSection>
+            ) : null}
+
+            {sectionMenuValue === "effects" ? (
+              <PresetSection
+                description="Post-processing and final image shaping."
+                title="Effects"
+              >
+                <div className="preset-effects-grid">
+                  <div className="preset-effects-category">
+                    <h3 className="preset-effects-category__title">
+                      Finish &amp; Output
+                    </h3>
+                    <div className="preset-effects-category__grid">
+                      <EffectCard
+                        description="Soft glow for bright edges and highlights."
+                        enabled={sceneModel.fx.bloom.enabled}
+                        onToggle={(nextValue) =>
+                          updateBranch("fx", (currentFx) => ({
+                            ...currentFx,
+                            bloom: {
+                              ...currentFx.bloom,
+                              enabled: nextValue,
+                            },
+                          }))
+                        }
+                        title="Bloom"
+                      >
+                        <div className="preset-editor-grid preset-editor-grid--2">
+                          <SliderField
+                            description="Glow intensity."
+                            id="bloom-strength"
+                            label="Strength"
+                            max={10}
+                            min={0}
+                            onChange={(nextValue) =>
+                              updateBranch("fx", (currentFx) => ({
+                                ...currentFx,
+                                bloom: {
+                                  ...currentFx.bloom,
+                                  strength: nextValue,
+                                },
+                              }))
+                            }
+                            step={0.1}
+                            value={sceneModel.fx.bloom.strength}
+                          />
+                          <SliderField
+                            description="Glow radius spread."
+                            id="bloom-radius"
+                            label="Radius"
+                            max={10}
+                            min={-10}
+                            onChange={(nextValue) =>
+                              updateBranch("fx", (currentFx) => ({
+                                ...currentFx,
+                                bloom: {
+                                  ...currentFx.bloom,
+                                  radius: nextValue,
+                                },
+                              }))
+                            }
+                            step={0.1}
+                            value={sceneModel.fx.bloom.radius}
+                          />
+                          <SliderField
+                            description="Threshold for highlights entering the bloom pass."
+                            id="bloom-threshold"
+                            label="Threshold"
+                            max={10}
+                            min={0}
+                            onChange={(nextValue) =>
+                              updateBranch("fx", (currentFx) => ({
+                                ...currentFx,
+                                bloom: {
+                                  ...currentFx.bloom,
+                                  threshold: nextValue,
+                                },
+                              }))
+                            }
+                            step={0.1}
+                            value={sceneModel.fx.bloom.threshold}
+                          />
+                        </div>
+                      </EffectCard>
+
+                      <EffectCard
+                        description="Choose the final output roll-off using named tone-mapping options."
+                        footer={
+                          <p className="preset-effect-footnote">
+                            {selectedToneMapping.description}
+                          </p>
+                        }
+                        title="Tone Mapping"
+                      >
+                        <div className="preset-editor-grid preset-editor-grid--2">
+                          <SelectField
+                            description="Switch between filmic output curves without using numeric ids."
+                            id="tone-mapping-method"
+                            label="Method"
+                            onChange={(nextValue) =>
+                              updateBranch("fx", (currentFx) => ({
+                                ...currentFx,
+                                toneMapping: {
+                                  ...currentFx.toneMapping,
+                                  method: Number(nextValue),
+                                },
+                              }))
+                            }
+                            options={toneMappingSelection.options}
+                            value={toneMappingSelection.value}
+                          />
+                          <SliderField
+                            description="Brighten or darken the post-tonemapped output."
+                            id="tone-mapping-exposure"
+                            label="Exposure"
+                            max={500}
+                            min={-500}
+                            onChange={(nextValue) =>
+                              updateBranch("fx", (currentFx) => ({
+                                ...currentFx,
+                                toneMapping: {
+                                  ...currentFx.toneMapping,
+                                  exposure: nextValue,
+                                },
+                              }))
+                            }
+                            step={1}
+                            value={sceneModel.fx.toneMapping.exposure}
+                          />
+                        </div>
+                      </EffectCard>
+
+                      {additionalPassesByCategory.finish.map(
+                        renderAdditionalPassCard,
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="preset-effects-category">
+                    <h3 className="preset-effects-category__title">
+                      Channel &amp; Motion
+                    </h3>
+                    <div className="preset-effects-category__grid">
+                      <EffectCard
+                        description="Shift the red, green, and blue channels apart for chromatic distortion."
+                        enabled={sceneModel.fx.passes.rgbShift}
+                        onToggle={(nextValue) =>
+                          updateBranch("fx", (currentFx) => ({
+                            ...currentFx,
+                            passes: {
+                              ...currentFx.passes,
+                              rgbShift: nextValue,
+                            },
+                          }))
+                        }
+                        title="RGB Shift"
+                      >
+                        <div className="preset-editor-grid preset-editor-grid--2">
+                          <SliderField
+                            description="Offset amount between color channels."
+                            formatValue={(value) => formatFixed(value, 3)}
+                            id="rgb-shift-amount"
+                            label="Shift Amount"
+                            max={0.1}
+                            min={0}
+                            onChange={(nextValue) =>
+                              updateBranch("fx", (currentFx) => ({
+                                ...currentFx,
+                                params: {
+                                  ...currentFx.params,
+                                  rgbShift: {
+                                    ...currentFx.params.rgbShift,
+                                    amount: nextValue,
+                                  },
+                                },
+                              }))
+                            }
+                            step={0.001}
+                            value={sceneModel.fx.params.rgbShift.amount}
+                          />
+                          <SliderField
+                            description="Displayed in degrees while the engine stores radians."
+                            formatValue={formatDegrees}
+                            id="rgb-shift-angle"
+                            label="Shift Angle"
+                            max={360}
+                            min={0}
+                            onChange={(nextValue) =>
+                              updateBranch("fx", (currentFx) => ({
+                                ...currentFx,
+                                params: {
+                                  ...currentFx.params,
+                                  rgbShift: {
+                                    ...currentFx.params.rgbShift,
+                                    angle: toRadians(nextValue),
+                                  },
+                                },
+                              }))
+                            }
+                            step={1}
+                            value={toDegrees(
+                              sceneModel.fx.params.rgbShift.angle,
+                            )}
+                          />
+                        </div>
+                      </EffectCard>
+
+                      <EffectCard
+                        description="Leave fading trails behind moving geometry."
+                        enabled={sceneModel.fx.passes.afterImage}
+                        onToggle={(nextValue) =>
+                          updateBranch("fx", (currentFx) => ({
+                            ...currentFx,
+                            passes: {
+                              ...currentFx.passes,
+                              afterImage: nextValue,
+                            },
+                          }))
+                        }
+                        title="Afterimage"
+                      >
+                        <SliderField
+                          description="Higher values keep trails visible for longer."
+                          id="trail-fade"
+                          label="Trail Fade"
+                          max={1}
+                          min={0}
+                          onChange={(nextValue) =>
+                            updateBranch("fx", (currentFx) => ({
+                              ...currentFx,
+                              params: {
+                                ...currentFx.params,
+                                afterImage: {
+                                  ...currentFx.params.afterImage,
+                                  damp: nextValue,
+                                },
+                              },
+                            }))
+                          }
+                          step={0.01}
+                          value={sceneModel.fx.params.afterImage.damp}
+                        />
+                      </EffectCard>
+
+                      {additionalPassesByCategory.trail.map(
+                        renderAdditionalPassCard,
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="preset-effects-category">
+                    <h3 className="preset-effects-category__title">
+                      Color &amp; Tone
+                    </h3>
+                    <div className="preset-effects-category__grid">
+                      <EffectCard
+                        description="Wash the output toward a chosen tint."
+                        enabled={sceneModel.fx.passes.colorify}
+                        onToggle={(nextValue) =>
+                          updateBranch("fx", (currentFx) => ({
+                            ...currentFx,
+                            passes: {
+                              ...currentFx.passes,
+                              colorify: nextValue,
+                            },
+                          }))
+                        }
+                        title="Colorify"
+                      >
+                        <div className="preset-field">
+                          <div className="preset-field__label-row">
+                            <label
+                              className="preset-field__label"
+                              htmlFor="colorify-color"
+                            >
+                              Color
+                            </label>
+                          </div>
+                          <p className="preset-field__description">
+                            Choose the tint used by the colorify pass.
+                          </p>
+                          <div className="preset-color-field">
+                            <input
+                              className="preset-color-field__picker"
+                              id="colorify-color"
+                              onChange={(event) =>
+                                updateBranch("fx", (currentFx) => ({
+                                  ...currentFx,
+                                  params: {
+                                    ...currentFx.params,
+                                    colorify: {
+                                      ...currentFx.params.colorify,
+                                      color: event.currentTarget.value,
+                                    },
+                                  },
+                                }))
+                              }
+                              type="color"
+                              value={sceneModel.fx.params.colorify.color}
+                            />
+                            <span>
+                              {sceneModel.fx.params.colorify.color.toUpperCase()}
+                            </span>
+                          </div>
+                        </div>
+                      </EffectCard>
+
+                      {additionalPassesByCategory.color.map(
+                        renderAdditionalPassCard,
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="preset-effects-category">
+                    <h3 className="preset-effects-category__title">
+                      Pattern &amp; Structure
+                    </h3>
+                    <div className="preset-effects-category__grid">
+                      <EffectCard
+                        description="Mirror the frame into repeating radial segments."
+                        enabled={sceneModel.fx.passes.kaleid}
+                        onToggle={(nextValue) =>
+                          updateBranch("fx", (currentFx) => ({
+                            ...currentFx,
+                            passes: {
+                              ...currentFx.passes,
+                              kaleid: nextValue,
+                            },
+                          }))
+                        }
+                        title="Kaleidoscope"
+                      >
+                        <div className="preset-editor-grid preset-editor-grid--2">
+                          <SliderField
+                            description="The number of mirrored slices in the frame."
+                            formatValue={(value) => formatFixed(value, 0)}
+                            id="kaleid-sides"
+                            label="Segments"
+                            max={24}
+                            min={1}
+                            onChange={(nextValue) =>
+                              updateBranch("fx", (currentFx) => ({
+                                ...currentFx,
+                                params: {
+                                  ...currentFx.params,
+                                  kaleid: {
+                                    ...currentFx.params.kaleid,
+                                    sides: Math.round(nextValue),
+                                  },
+                                },
+                              }))
+                            }
+                            step={1}
+                            value={Math.round(
+                              sceneModel.fx.params.kaleid.sides,
+                            )}
+                          />
+                          <SliderField
+                            description="Rotate the mirrored segment pattern in degrees."
+                            formatValue={formatDegrees}
+                            id="kaleid-angle"
+                            label="Rotation"
+                            max={360}
+                            min={0}
+                            onChange={(nextValue) =>
+                              updateBranch("fx", (currentFx) => ({
+                                ...currentFx,
+                                params: {
+                                  ...currentFx.params,
+                                  kaleid: {
+                                    ...currentFx.params.kaleid,
+                                    angle: toRadians(nextValue),
+                                  },
+                                },
+                              }))
+                            }
+                            step={1}
+                            value={toDegrees(sceneModel.fx.params.kaleid.angle)}
+                          />
+                        </div>
+                      </EffectCard>
+
+                      {additionalPassesByCategory.pattern.map(
+                        renderAdditionalPassCard,
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </PresetSection>
+            ) : null}
+
+            {sectionMenuValue === "pass-order" ? (
+              <PresetSection
+                description="Reorder the effect stack to control how the image is built. Output stays pinned last."
+                title="Pass Order"
+              >
+                <ol className="preset-pass-order">
+                  {sceneModel.fx.passOrder.map((passId, index) => {
+                    const isOutputPass = passId === "outputPass";
+
+                    return (
+                      <li className="preset-pass-order__item" key={passId}>
+                        <div className="preset-pass-order__copy">
+                          <strong>{PASS_LABELS[passId]}</strong>
+                          <span>{describePassState(passId, sceneModel)}</span>
+                        </div>
+                        <div className="preset-pass-order__actions">
+                          <button
+                            aria-label={`Move ${PASS_LABELS[passId]} up`}
+                            className="preset-order-button"
+                            disabled={isOutputPass || index === 0}
+                            onClick={() => movePass(passId, -1)}
+                            type="button"
+                          >
+                            Up
+                          </button>
+                          <button
+                            aria-label={`Move ${PASS_LABELS[passId]} down`}
+                            className="preset-order-button"
+                            disabled={
+                              isOutputPass ||
+                              index >= sceneModel.fx.passOrder.length - 2
+                            }
+                            onClick={() => movePass(passId, 1)}
+                            type="button"
+                          >
+                            Down
+                          </button>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ol>
+              </PresetSection>
+            ) : null}
+
+            {sectionMenuValue === "advanced" ? (
+              <PresetSection
+                description="Raw engine controls and scene data."
+                title="Advanced"
+              >
+                <div className="preset-advanced-stack">
+                  <div className="field-group">
+                    <label>Motion Tuning</label>
+                    <p className="field-hint">
+                      Lower-level motion controls that stay out of the main
+                      authoring flow.
+                    </p>
+                  </div>
+
+                  <div className="preset-editor-grid preset-editor-grid--2">
+                    <NumberField
+                      description="Overall engine time multiplier."
+                      id="time-speed"
+                      label="Time Speed"
+                      onChange={(nextValue) =>
+                        updateBranch("intent", (currentIntent) => ({
+                          ...currentIntent,
+                          time_multiplier: nextValue,
+                        }))
+                      }
+                      step={0.05}
+                      value={sceneModel.intent.time_multiplier}
+                    />
+
+                    <SliderField
+                      description="How quickly movement eases toward its target."
+                      id="smoothness"
+                      label="Smoothness"
+                      max={0.9}
+                      min={0.01}
+                      onChange={(nextValue) =>
+                        updateBranch("intent", (currentIntent) => ({
+                          ...currentIntent,
+                          easing_speed: nextValue,
+                        }))
+                      }
+                      step={0.01}
+                      value={sceneModel.intent.easing_speed}
+                    />
+
+                    <SliderField
+                      description="Compresses the movement range for tighter motion."
+                      id="compression"
+                      label="Compression"
+                      max={2}
+                      min={0.01}
+                      onChange={(nextValue) =>
+                        updateBranch("intent", (currentIntent) => ({
+                          ...currentIntent,
+                          minimizing_factor: nextValue,
+                        }))
+                      }
+                      step={0.01}
+                      value={sceneModel.intent.minimizing_factor}
+                    />
+
+                    <SliderField
+                      description="Boosts the overall energy of the response."
+                      id="intensity"
+                      label="Intensity"
+                      max={10}
+                      min={1}
+                      onChange={(nextValue) =>
+                        updateBranch("intent", (currentIntent) => ({
+                          ...currentIntent,
+                          power_factor: nextValue,
+                        }))
+                      }
+                      step={0.1}
+                      value={sceneModel.intent.power_factor}
+                    />
+
+                    <SliderField
+                      description="Extra motion added during interaction or pointer pressure."
+                      id="interaction-boost"
+                      label="Interaction Boost"
+                      max={1}
+                      min={0}
+                      onChange={(nextValue) =>
+                        updateBranch("intent", (currentIntent) => ({
+                          ...currentIntent,
+                          pointerDownMultiplier: nextValue,
+                        }))
+                      }
+                      step={0.01}
+                      value={sceneModel.intent.pointerDownMultiplier}
+                    />
+                  </div>
+
+                  <div className="field-group">
+                    <label htmlFor="shader-source">Custom Shader</label>
+                    <textarea
+                      className="preset-textarea"
+                      id="shader-source"
+                      onChange={(event) =>
+                        updateBranch("visualizer", (currentVisualizer) => ({
+                          ...currentVisualizer,
+                          shader: event.currentTarget.value,
+                        }))
+                      }
+                      rows={10}
+                      value={sceneModel.visualizer.shader}
+                    />
+                    <p className="field-hint">
+                      Use this only when the preset needs shader code beyond the
+                      curated presets.
+                    </p>
+                  </div>
+
+                  <div className="preset-editor-grid preset-editor-grid--3">
+                    <NumberField
+                      description="Low-level runtime state."
+                      id="state-size"
+                      label="State Size"
+                      onChange={(nextValue) =>
+                        updateBranch("state", (currentState) => ({
+                          ...currentState,
+                          size: nextValue,
+                        }))
+                      }
+                      step={0.01}
+                      value={sceneModel.state.size}
+                    />
+                    <NumberField
+                      description="Initial runtime pointer state."
+                      id="state-pointer-down"
+                      label="Pointer Down"
+                      onChange={(nextValue) =>
+                        updateBranch("state", (currentState) => ({
+                          ...currentState,
+                          pointerDown: nextValue,
+                        }))
+                      }
+                      step={0.01}
+                      value={sceneModel.state.pointerDown}
+                    />
+                    <NumberField
+                      description="Initial smoothed pointer state."
+                      id="state-current-pointer-down"
+                      label="Current Pointer"
+                      onChange={(nextValue) =>
+                        updateBranch("state", (currentState) => ({
+                          ...currentState,
+                          currPointerDown: nextValue,
+                        }))
+                      }
+                      step={0.01}
+                      value={sceneModel.state.currPointerDown}
+                    />
+                    <NumberField
+                      description="Initial runtime audio input."
+                      id="state-current-audio"
+                      label="Current Audio"
+                      onChange={(nextValue) =>
+                        updateBranch("state", (currentState) => ({
+                          ...currentState,
+                          currAudio: nextValue,
+                        }))
+                      }
+                      step={0.01}
+                      value={sceneModel.state.currAudio}
+                    />
+                    <NumberField
+                      description="Initial runtime time value."
+                      id="state-time"
+                      label="State Time"
+                      onChange={(nextValue) =>
+                        updateBranch("state", (currentState) => ({
+                          ...currentState,
+                          time: nextValue,
+                        }))
+                      }
+                      step={0.01}
+                      value={sceneModel.state.time}
+                    />
+                    <NumberField
+                      description="Initial runtime volume multiplier."
+                      id="state-volume"
+                      label="Volume Multiplier"
+                      onChange={(nextValue) =>
+                        updateBranch("state", (currentState) => ({
+                          ...currentState,
+                          volume_multiplier: nextValue,
+                        }))
+                      }
+                      step={0.01}
+                      value={sceneModel.state.volume_multiplier}
+                    />
+                  </div>
+
+                  <div className="field-group">
+                    <div className="preset-advanced-header">
+                      <div>
+                        <label htmlFor="sceneData">Scene Data JSON</label>
+                        <p className="field-hint">
+                          Raw scene data stays available here. While the JSON is
+                          invalid, the preview keeps the last valid preset
+                          state.
+                        </p>
+                      </div>
+                      <button
+                        className="preset-secondary-button"
+                        onClick={handleFormatJson}
+                        type="button"
+                      >
+                        Format JSON
+                      </button>
+                    </div>
+                    <textarea
+                      aria-describedby={
+                        errors.sceneData ? "sceneData-error" : "sceneData-hint"
+                      }
+                      aria-invalid={Boolean(errors.sceneData)}
+                      className="preset-textarea preset-textarea--code"
+                      id="sceneData"
+                      name="sceneData"
+                      onChange={(event) =>
+                        handleRawSceneDataChange(event.currentTarget.value)
+                      }
+                      required
+                      rows={16}
+                      value={sceneDataText}
+                    />
+                    {errors.sceneData ? (
+                      <p
+                        className="field-error"
+                        id="sceneData-error"
+                        role="alert"
+                      >
+                        {errors.sceneData}
+                      </p>
+                    ) : (
+                      <p className="field-hint" id="sceneData-hint">
+                        Structured controls above keep this JSON in sync with
+                        the current preset.
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </PresetSection>
+            ) : null}
+
+            <button
+              className="demo-link auth-submit preset-editor-submit"
+              disabled={isSubmitting}
+              type="submit"
+            >
+              {isSubmitting ? "Creating preset..." : "Create preset"}
+            </button>
           </div>
 
-           <div className="field-group">
-          <label htmlFor="sceneData">Scene data (JSON)</label>
-          <textarea
-            id="sceneData"
-            name="sceneData"
-            required
-            rows={6}
-            value={values.sceneData}
-            onChange={(event) => handleChange('sceneData', event.target.value)}
-            aria-invalid={Boolean(errors.sceneData)}
-            aria-describedby={errors.sceneData ? 'sceneData-error' : undefined}
-            placeholder='{"key": "value"}'
-          />
-          {errors.sceneData ? (
-            <p className="field-error" id="sceneData-error" role="alert">{errors.sceneData}</p>
-          ) : null}
+          <aside className="preset-editor-preview">
+            <section className="surface surface--soft preset-editor-preview__card">
+              <div className="preset-editor-preview__header">
+                <div>
+                  <span className="preset-editor-toolbar__eyebrow">
+                    Preview
+                  </span>
+                  <h2>Live Preview</h2>
+                </div>
+              </div>
+
+              <MagePlayer
+                className="preset-editor-preview__player"
+                sceneBlob={previewSceneData}
+              />
+            </section>
+          </aside>
         </div>
-        
-        {errors.form ? (
-          <div className="form-alert" id={formErrorId} role="alert">{errors.form}</div>
-        ) : null}
-        
-        <button className="demo-link auth-submit" type="submit" disabled={isSubmitting}>
-          {isSubmitting ? 'Creating preset...' : 'Create preset'}
-        </button>
-    </form>
+      </form>
     </AuthPage>
-  )
+  );
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -43,18 +43,18 @@ const HOME_PAGE_PRESET_SCENE = {
 
 export function HomePage() {
   return (
-    <main className="card home-card">
+    <main className="surface surface--hero home-hero">
       <div className="eyebrow">Preview</div>
       <h1>MAGE</h1>
-      <p className="sub">Musical Autonomous Generated Environments</p>
+      <p className="page-lead">Musical Autonomous Generated Environments</p>
       <section className="home-preview-section" aria-label="Live preset preview">
         <MagePlayer
           ariaLabel="MAGE live preset preview"
           sceneBlob={HOME_PAGE_PRESET_SCENE}
         />
       </section>
-      <p className="foot">The full platform experience is currently in development.</p>
-      <div className="brand">MAGE</div>
+      <p className="page-footnote">The full platform experience is currently in development.</p>
+      <div className="page-mark">MAGE</div>
     </main>
   )
 }

--- a/src/pages/MyPresetsPage.tsx
+++ b/src/pages/MyPresetsPage.tsx
@@ -240,10 +240,10 @@ export function MyPresetsPage() {
 
   if (isRestoringSession) {
     return (
-      <main className="card">
+      <main className="surface surface--hero">
         <div className="eyebrow">My Presets</div>
         <h1>Loading presets...</h1>
-        <p className="sub">MAGE is restoring your session and loading your saved presets.</p>
+        <p className="page-lead">MAGE is restoring your session and loading your saved presets.</p>
       </main>
     )
   }
@@ -254,25 +254,25 @@ export function MyPresetsPage() {
 
   if (typeof user?.userId !== 'number') {
     return (
-      <main className="card">
+      <main className="surface surface--hero">
         <div className="eyebrow">My Presets</div>
         <h1>Unable to load presets</h1>
-        <p className="sub">Your session is missing the user information needed to load presets.</p>
+        <p className="page-lead">Your session is missing the user information needed to load presets.</p>
       </main>
     )
   }
 
   return (
-    <main className="preset-page">
-      <section className="preset-page-header">
+    <main className="page-stack">
+      <section className="surface surface--page-header">
         <div className="eyebrow">My Presets</div>
         <h1>Saved presets</h1>
-        <p className="sub">
+        <p className="page-lead">
           Browse the presets created by your account and open any preset detail page directly.
         </p>
       </section>
 
-      <section className="preset-page-panel" aria-live="polite">
+      <section className="surface surface--page-panel" aria-live="polite">
         {isLoading ? (
           <p className="preset-status">Loading presets...</p>
         ) : errorMessage ? (

--- a/src/pages/PlaceholderPage.tsx
+++ b/src/pages/PlaceholderPage.tsx
@@ -16,18 +16,18 @@ export function PlaceholderPage({
   footnote = 'More platform features are coming soon.',
 }: PlaceholderPageProps) {
   return (
-    <main className="card">
+    <main className="surface surface--hero">
       <div className="eyebrow">{eyebrow}</div>
       <h1>{title}</h1>
-      <p className="sub">{description}</p>
+      <p className="page-lead">{description}</p>
       {action ? (
         <>
           <div className="divider" />
           {action}
         </>
       ) : null}
-      <p className="foot">{footnote}</p>
-      <div className="brand">MAGE</div>
+      <p className="page-footnote">{footnote}</p>
+      <div className="page-mark">MAGE</div>
     </main>
   )
 }

--- a/src/pages/PresetDetailPage.tsx
+++ b/src/pages/PresetDetailPage.tsx
@@ -14,7 +14,7 @@ export function PresetDetailPage() {
       title={`Preset ${id}`}
       description="This preset detail route is ready for the next preset experience."
       action={
-        <div className="home-actions">
+        <div className="auth-actions">
           <Link className="demo-link" to="/my-presets">
             Back to My Presets
           </Link>


### PR DESCRIPTION
## Summary

This PR refreshes the frontend shell and rebuilds preset creation into a guided editor flow.

### What changed

- unified shared page/surface styling across the frontend
- replaced the old header nav with an account dropdown and authenticated `Create` action
- stabilized `MagePlayer` so preview scene changes reuse the same engine instance instead of recreating it
- rebuilt the create preset page into a structured editor with:
  - section-based navigation
  - live sticky preview
  - grouped scene, camera, motion, effects, and pass order controls
  - reusable preset editor form components
  - scene-data normalization and editor helpers
  - local-only metadata UI for description, thumbnail choice, and playlists

### Notes

- no backend changes are included in this PR
- the new metadata controls on the preset editor are UI-only for now and are not sent in the create preset request
- `outputPass` remains pinned at the end of pass ordering to match engine behavior

## Testing

- `npm.cmd test`
- `npm.cmd run lint`
- `npm.cmd run build`
