### PR TITLE
Fix auth session restore in StrictMode

### DIFF
--- a/src/auth/AuthContext.test.tsx
+++ b/src/auth/AuthContext.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
@@ -59,28 +60,36 @@ function storeSession(accessToken = 'stored-auth-token') {
   )
 }
 
-function renderAuthHarness() {
-  return render(
+function jsonResponse(payload: unknown, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+}
+
+function renderAuthHarness(options?: { strictMode?: boolean }) {
+  const tree = (
     <MemoryRouter>
       <AuthProvider>
         <AuthHarness />
       </AuthProvider>
-    </MemoryRouter>,
+    </MemoryRouter>
   )
+
+  if (options?.strictMode) {
+    return render(<StrictMode>{tree}</StrictMode>)
+  }
+
+  return render(tree)
 }
 
 describe('AuthProvider', () => {
   it('calls GET /users/me during app bootstrap and restores the authenticated user', async () => {
     storeSession()
 
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify(restoredUser), {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      }),
-    )
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(restoredUser))
 
     renderAuthHarness()
 
@@ -105,16 +114,11 @@ describe('AuthProvider', () => {
     storeSession('expired-auth-token')
 
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          message: 'Authentication is required.',
-        }),
+      jsonResponse(
         {
-          status: 401,
-          headers: {
-            'Content-Type': 'application/json',
-          },
+          message: 'Authentication is required.',
         },
+        401,
       ),
     )
 
@@ -131,14 +135,7 @@ describe('AuthProvider', () => {
   it('logout clears the stored token and shared auth state', async () => {
     storeSession()
 
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify(restoredUser), {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      }),
-    )
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(restoredUser))
 
     const user = userEvent.setup()
 
@@ -158,25 +155,13 @@ describe('AuthProvider', () => {
 
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(jsonResponse(restoredUser))
       .mockResolvedValueOnce(
-        new Response(JSON.stringify(restoredUser), {
-          status: 200,
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        }),
-      )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            message: 'Authentication is required.',
-          }),
+        jsonResponse(
           {
-            status: 401,
-            headers: {
-              'Content-Type': 'application/json',
-            },
+            message: 'Authentication is required.',
           },
+          401,
         ),
       )
 
@@ -207,5 +192,31 @@ describe('AuthProvider', () => {
     })
 
     expect(screen.getByTestId('auth-status')).toHaveTextContent('signed-out')
+  })
+
+  it('finishes restoring a stored session when mounted in StrictMode', async () => {
+    storeSession()
+
+    const pendingResponses: Array<(value: Response) => void> = []
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          pendingResponses.push(resolve)
+        }),
+    )
+
+    renderAuthHarness({ strictMode: true })
+
+    await waitFor(() => {
+      expect(pendingResponses.length).toBeGreaterThan(0)
+    })
+
+    pendingResponses.forEach((resolveResponse) => {
+      resolveResponse(jsonResponse(restoredUser))
+    })
+
+    expect(await screen.findByText('restored-user@example.com')).toBeInTheDocument()
+    expect(screen.getByTestId('auth-status')).toHaveTextContent('authenticated')
   })
 })

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -3,7 +3,6 @@ import {
   createContext,
   useContext,
   useEffect,
-  useRef,
   useState,
   type PropsWithChildren,
 } from 'react'
@@ -111,8 +110,6 @@ export function AuthProvider({ children }: PropsWithChildren) {
   const [session, setSession] = useState<StoredAuthSession | null>(null)
   const [isRestoringSession, setIsRestoringSession] = useState(true)
 
-  const hasBootstrappedSession = useRef(false)
-
   function clearSession() {
     window.localStorage.removeItem(AUTH_SESSION_STORAGE_KEY)
     setSession(null)
@@ -144,12 +141,6 @@ export function AuthProvider({ children }: PropsWithChildren) {
   }
 
   useEffect(() => {
-    if (hasBootstrappedSession.current) {
-      return
-    }
-
-    hasBootstrappedSession.current = true
-
     const storedSession = readStoredSession()
 
     if (!storedSession) {
@@ -190,6 +181,8 @@ export function AuthProvider({ children }: PropsWithChildren) {
 
         persistSession(restoredSession)
         setSession(restoredSession)
+      } catch {
+        // Preserve the stored session snapshot when bootstrap verification fails.
       } finally {
         if (isCurrent) {
           setIsRestoringSession(false)


### PR DESCRIPTION
Description:
## Summary
- remove the one-time auth bootstrap guard that broke session restoration under React StrictMode
- ensure stored-session restore always settles instead of leaving the app stuck in a restoring state
- add a regression test that covers restoring a stored session in StrictMode

## Problem
Signed-in users who refreshed `/my-presets` could get stuck on "Loading presets..." even though the backend auth endpoints were healthy. The frontend auth bootstrap effect was ignoring the completed `/users/me` response after StrictMode cleanup, so `isRestoringSession` never flipped back to `false`.

## Testing
- npm.cmd test -- src/auth/AuthContext.test.tsx
- npm.cmd test -- src/pages/MyPresetsPage.test.tsx

## User Impact
- signed-in users can refresh `/my-presets` without getting stuck on the loading state
- valid stored sessions restore normally
- invalid or expired sessions still clear and redirect to `/login`
