### PR TITLE
31 build public preset detailplayer pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Available routes:
 - `/`
 - `/register`
 - `/login`
+- `/my-presets`
+- `/presets/:id`
+- `/create-preset`
 
 Note: direct loads of nested routes in production require the host to rewrite unknown paths back to `index.html`.
 
@@ -98,6 +101,18 @@ engine inside normal page layouts.
 
 Usage notes and an example embed live in `docs/player-component.md`.
 
+## Preset detail page
+
+The preset detail flow lives at `/presets/:id` and currently supports:
+
+- direct loads and internal navigation through the route param
+- fetching preset metadata, thumbnail references, and scene data from `GET /presets/{id}`
+- rendering the embedded `MagePlayer` with the fetched scene blob
+- clear invalid-link, auth-required, not-found, and unavailable states instead of a blank page
+
+In the current backend build, preset detail requests are still authenticated. The route remains
+deep-linkable, and signed-out users receive a clear sign-in-needed state instead of a broken page.
+
 ## Scripts
 
 - `npm run dev` starts the local development server
@@ -113,5 +128,6 @@ Usage notes and an example embed live in `docs/player-component.md`.
 - Login page connected to the backend login endpoint
 - Shared frontend auth session with token persistence, bootstrap restore, and logout
 - Reusable MAGE player component with a live home-page preview
+- Preset detail/player route backed by `GET /presets/{id}` and the shared player wrapper
 - Header navigation between pages without full page reloads
 - Live demo link: `https://bsiscoe.github.io/MAGE/`

--- a/src/App.css
+++ b/src/App.css
@@ -678,6 +678,535 @@
   gap: 16px;
 }
 
+.preset-detail-page {
+  width: min(1320px, 100%);
+  min-width: 0;
+}
+
+.mage-watch {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(420px, 1fr);
+  gap: 30px;
+  align-items: start;
+}
+
+.mage-watch__main {
+  min-width: 0;
+}
+
+.mage-player-shell {
+  position: relative;
+}
+
+.preset-detail-watch .mage-player-shell {
+  width: 100%;
+}
+
+.mage-stage-frame {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background:
+    radial-gradient(circle at top left, var(--preset-accent, rgba(99, 240, 214, 0.22)), transparent 34%),
+    linear-gradient(180deg, rgba(9, 21, 25, 0.92), rgba(3, 9, 12, 0.98));
+  box-shadow: 0 30px 90px rgba(0, 0, 0, 0.32);
+}
+
+.mage-stage-frame--watch {
+  aspect-ratio: 1 / 1;
+  min-height: 0;
+  border-radius: 24px;
+}
+
+.mage-stage-frame--watch::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, transparent 52%, rgba(0, 0, 0, 0.34));
+  pointer-events: none;
+}
+
+.mage-stage-frame__hud {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  right: 16px;
+  z-index: 2;
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  pointer-events: none;
+}
+
+.mage-stage-pill,
+.mage-watch__description-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 34px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(6, 16, 19, 0.74);
+  color: var(--text);
+  backdrop-filter: blur(10px);
+}
+
+.mage-stage-pill[data-ready="true"],
+.mage-watch__description-pill[data-ready="true"] {
+  border-color: rgba(99, 240, 214, 0.38);
+  color: var(--accent);
+}
+
+.preset-detail-player,
+.preset-detail-player.mage-player {
+  width: 100%;
+  height: 100%;
+}
+
+.preset-detail-stage .mage-player__viewport {
+  height: 100%;
+  min-height: 0;
+  aspect-ratio: auto;
+  border: 0;
+  border-radius: inherit;
+  background: transparent;
+  box-shadow: none;
+}
+
+.preset-detail-stage .mage-player__viewport::after {
+  display: none;
+}
+
+.preset-detail-stage .mage-player__overlay {
+  border-radius: inherit;
+}
+
+.mage-watch__summary {
+  padding-top: 18px;
+}
+
+.mage-watch__title {
+  margin: 0;
+  font-size: clamp(1.8rem, 3vw, 2.45rem);
+  line-height: 1.08;
+  letter-spacing: -0.04em;
+}
+
+.preset-detail-header {
+  display: grid;
+  gap: 12px;
+  padding-top: 18px;
+}
+
+.preset-detail-social-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  margin-top: 18px;
+  padding: 18px 0 20px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.preset-detail-social-row__creator {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 14px;
+}
+
+.mage-channel-card {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-width: 0;
+}
+
+.mage-channel-card__avatar,
+.mage-comment__avatar {
+  display: grid;
+  place-items: center;
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at top left, rgba(99, 240, 214, 0.28), transparent 58%),
+    rgba(14, 30, 35, 0.96);
+  border: 1px solid rgba(99, 240, 214, 0.18);
+  color: var(--accent);
+  font-weight: 700;
+  flex: 0 0 auto;
+}
+
+.mage-channel-card__copy,
+.mage-comment__meta {
+  display: grid;
+  gap: 2px;
+}
+
+.mage-channel-card__copy strong,
+.mage-comment__meta strong {
+  font-size: 0.96rem;
+}
+
+.mage-channel-card__copy span,
+.mage-comment__meta span,
+.mage-comments__header span {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.preset-detail-follow-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 10px 18px;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(248, 250, 249, 0.96);
+  color: #071316;
+  text-decoration: none;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    transform 0.18s ease,
+    box-shadow 0.18s ease;
+}
+
+.preset-detail-follow-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.22);
+}
+
+.preset-detail-action-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.preset-detail-action-chip,
+.preset-detail-sort-chip,
+.preset-detail-comment__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 42px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  font-size: 0.92rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    transform 0.18s ease,
+    border-color 0.18s ease,
+    background 0.18s ease;
+}
+
+.preset-detail-action-chip:hover,
+.preset-detail-sort-chip:hover,
+.preset-detail-comment__action:hover {
+  transform: translateY(-1px);
+  border-color: rgba(99, 240, 214, 0.28);
+}
+
+.preset-detail-vote-button__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  color: var(--muted);
+}
+
+.preset-detail-vote-button__icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.preset-detail-description-card,
+.preset-detail-comments-panel {
+  margin-top: 18px;
+  padding: 18px 20px;
+  border-radius: 20px;
+  background: rgba(10, 23, 27, 0.86);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.24);
+}
+
+.preset-detail-description-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.preset-detail-description-card__meta strong {
+  color: var(--text);
+}
+
+.preset-detail-description-card__meta span {
+  color: var(--muted);
+}
+
+.preset-detail-description-card p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.preset-detail-description-card p + p {
+  margin-top: 12px;
+}
+
+.preset-detail-note-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.preset-detail-note-grid__item {
+  display: grid;
+  gap: 6px;
+  padding: 14px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.preset-detail-note-grid__item span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.preset-detail-note-grid__item strong {
+  line-height: 1.55;
+}
+
+.mage-tag-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.mage-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--text);
+  font-size: 0.9rem;
+}
+
+.mage-comments__header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.mage-comments__header h2,
+.mage-watch__rail-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.preset-detail-comments-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.preset-detail-comment-composer {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 14px;
+  align-items: center;
+  margin-top: 18px;
+}
+
+.preset-detail-comment-composer__avatar {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--text);
+  font-weight: 700;
+}
+
+.preset-detail-comment-composer__field {
+  min-height: 44px;
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--muted);
+}
+
+.mage-comments__list {
+  display: grid;
+  gap: 14px;
+  margin-top: 16px;
+}
+
+.mage-comment {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 14px;
+}
+
+.mage-comment__body {
+  min-width: 0;
+}
+
+.preset-detail-comment__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.preset-detail-comment__header strong {
+  font-size: 0.96rem;
+}
+
+.preset-detail-comment__header span,
+.mage-comment__body p,
+.mage-watch__rail-header p {
+  color: var(--muted);
+}
+
+.mage-comment__body p,
+.mage-watch__rail-header p {
+  margin: 6px 0 0;
+  line-height: 1.6;
+}
+
+.preset-detail-comment__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.preset-detail-comment__action {
+  min-height: 34px;
+  padding: 8px 12px;
+  font-size: 0.86rem;
+}
+
+.mage-watch__rail {
+  position: sticky;
+  top: 94px;
+  display: grid;
+  gap: 14px;
+}
+
+.mage-watch__rail-header {
+  padding: 6px 0 2px;
+}
+
+.mage-watch__rail-header p {
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.mage-watch__rail-list {
+  display: grid;
+  gap: 12px;
+}
+
+.mage-preset-card {
+  display: grid;
+  grid-template-columns: 188px minmax(0, 1fr);
+  gap: 12px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  text-align: left;
+}
+
+.mage-preset-card__thumb {
+  position: relative;
+  min-height: 94px;
+  padding: 12px;
+  border-radius: 16px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at top left, var(--preset-accent, rgba(99, 240, 214, 0.22)), transparent 42%),
+    linear-gradient(180deg, rgba(12, 27, 32, 0.96), rgba(5, 12, 15, 0.98));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.22);
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: 10px;
+}
+
+.mage-preset-card__thumb::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 0;
+  height: 46px;
+  background: linear-gradient(180deg, transparent, rgba(0, 0, 0, 0.4));
+}
+
+.mage-preset-card__badge {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(4, 11, 13, 0.72);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.mage-preset-card__body {
+  display: grid;
+  align-content: center;
+  gap: 4px;
+  min-width: 0;
+}
+
+.mage-preset-card__body strong {
+  font-size: 0.98rem;
+  line-height: 1.4;
+}
+
+.mage-preset-card__body span {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.mage-preset-card__note {
+  line-height: 1.5;
+}
+
+.mage-preset-card:hover .mage-preset-card__body strong,
+.mage-preset-card.is-active .mage-preset-card__body strong {
+  color: var(--accent);
+}
+
+.mage-preset-card.is-active .mage-preset-card__thumb {
+  border-color: rgba(99, 240, 214, 0.34);
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.28);
+}
+
 .preset-link {
   display: grid;
   gap: 14px;
@@ -1378,6 +1907,18 @@
 }
 
 @media (max-width: 1080px) {
+  .mage-watch {
+    grid-template-columns: 1fr;
+  }
+
+  .mage-watch__rail {
+    position: static;
+  }
+
+  .mage-watch__rail-list {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  }
+
   .preset-editor-layout,
   .preset-editor-toolbar {
     grid-template-columns: minmax(0, 1fr);
@@ -1389,6 +1930,21 @@
 
   .preset-editor-preview__card {
     position: static;
+  }
+}
+
+@media (max-width: 980px) {
+  .preset-detail-social-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .preset-detail-action-row {
+    justify-content: flex-start;
+  }
+
+  .mage-preset-card {
+    grid-template-columns: 172px minmax(0, 1fr);
   }
 }
 
@@ -1471,6 +2027,24 @@
     padding: 24px;
   }
 
+  .preset-detail-watch .mage-player-shell {
+    width: 100%;
+  }
+
+  .mage-stage-frame__hud {
+    top: 12px;
+    left: 12px;
+    right: 12px;
+  }
+
+  .mage-stage-frame--watch {
+    border-radius: 22px;
+  }
+
+  .preset-detail-stage .mage-player__overlay {
+    border-radius: 22px;
+  }
+
   .mage-player__viewport {
     min-height: 260px;
     border-radius: 22px;
@@ -1478,6 +2052,48 @@
 
   .mage-player__overlay {
     padding: 22px;
+  }
+
+  .preset-detail-description-card,
+  .preset-detail-comments-panel {
+    padding: 16px;
+    border-radius: 18px;
+  }
+
+  .preset-detail-note-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .mage-watch__rail-list {
+    grid-template-columns: 1fr;
+  }
+
+  .mage-preset-card {
+    grid-template-columns: 1fr;
+  }
+
+  .mage-preset-card__thumb {
+    min-height: 136px;
+  }
+
+  .preset-detail-social-row__creator,
+  .preset-detail-action-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .preset-detail-follow-button,
+  .preset-detail-action-chip,
+  .preset-detail-sort-chip {
+    width: 100%;
+  }
+
+  .preset-detail-comment-composer {
+    grid-template-columns: 1fr;
+  }
+
+  .preset-detail-comment-composer__field {
+    padding-top: 0;
   }
 
   .surface--form {

--- a/src/pages/MyPresetsPage.test.tsx
+++ b/src/pages/MyPresetsPage.test.tsx
@@ -12,6 +12,22 @@ import { LoginPage } from './LoginPage'
 import { MyPresetsPage } from './MyPresetsPage'
 import { PresetDetailPage } from './PresetDetailPage'
 
+vi.mock('../components/MagePlayer', () => ({
+  MagePlayer: ({
+    ariaLabel,
+    className,
+    sceneBlob,
+  }: {
+    ariaLabel?: string
+    className?: string
+    sceneBlob: unknown
+  }) => (
+    <div aria-label={ariaLabel} className={className} data-testid="mage-player">
+      {sceneBlob ? 'player-ready' : 'no-scene'}
+    </div>
+  ),
+}))
+
 const storedUser: AuthenticatedUser = {
   userId: 8,
   email: 'artist@example.com',
@@ -141,12 +157,30 @@ describe('MyPresetsPage', () => {
             {
               id: 12,
               name: 'Aurora Drift',
+              sceneData: {
+                visualizer: { shader: 'nebula' },
+              },
             },
             {
               id: 13,
               name: 'Signal Bloom',
             },
           ]),
+        )
+      }
+
+      if (input === buildApiUrl('/presets/12')) {
+        return Promise.resolve(
+          jsonResponse({
+            presetId: 12,
+            ownerUserId: 8,
+            name: 'Aurora Drift',
+            sceneData: {
+              visualizer: { shader: 'nebula' },
+            },
+            thumbnailRef: 'thumbnails/preset-12.png',
+            createdAt: '2026-04-06T14:00:00Z',
+          }),
         )
       }
 
@@ -171,7 +205,8 @@ describe('MyPresetsPage', () => {
 
     await user.click(presetLink)
 
-    expect(await screen.findByRole('heading', { name: /preset 12/i })).toBeInTheDocument()
+    expect(await screen.findByTestId('mage-player')).toHaveTextContent('player-ready')
+    expect(screen.getByRole('heading', { name: /aurora drift/i })).toBeInTheDocument()
   })
 
   it('renders the populated preset state with thumbnails, fallback UI, and navigation', async () => {
@@ -184,6 +219,21 @@ describe('MyPresetsPage', () => {
 
       if (input === buildApiUrl('/users/8/presets')) {
         return Promise.resolve(jsonResponse(mockPresets))
+      }
+
+      if (input === buildApiUrl('/presets/1')) {
+        return Promise.resolve(
+          jsonResponse({
+            presetId: 1,
+            ownerUserId: 42,
+            name: 'Aurora Drift',
+            sceneData: {
+              visualizer: { shader: 'nebula' },
+            },
+            thumbnailRef: 'thumbnails/preset-1.png',
+            createdAt: '2026-04-06T14:00:00Z',
+          }),
+        )
       }
 
       throw new Error(`Unexpected request: ${String(input)}`)
@@ -209,7 +259,8 @@ describe('MyPresetsPage', () => {
 
     await user.click(auroraPreset)
 
-    expect(await screen.findByRole('heading', { name: /preset 1/i })).toBeInTheDocument()
+    expect(await screen.findByTestId('mage-player')).toHaveTextContent('player-ready')
+    expect(screen.getByRole('heading', { name: /aurora drift/i })).toBeInTheDocument()
   })
 
   it('shows empty and error states using simple messages', async () => {

--- a/src/pages/PresetDetailPage.test.tsx
+++ b/src/pages/PresetDetailPage.test.tsx
@@ -100,9 +100,13 @@ describe('PresetDetailPage', () => {
     renderPresetDetailPage()
 
     expect(await screen.findByRole('heading', { name: /aurora drift/i })).toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: /live player/i })).toBeInTheDocument()
     expect(screen.getByTestId('mage-player')).toHaveTextContent('player-ready')
-    expect(screen.getByRole('link', { name: /back to my presets/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /comments/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /recommended presets/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /upvote 416/i })).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: /downvote/i }).length).toBeGreaterThan(0)
+    expect(screen.getByText(/add a comment as preset artist/i)).toBeInTheDocument()
+    expect(screen.getByText(/now playing/i)).toBeInTheDocument()
 
     await waitFor(() =>
       expect(fetchSpy).toHaveBeenNthCalledWith(

--- a/src/pages/PresetDetailPage.test.tsx
+++ b/src/pages/PresetDetailPage.test.tsx
@@ -1,0 +1,181 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  AUTH_SESSION_STORAGE_KEY,
+  AuthProvider,
+  type AuthenticatedUser,
+} from '../auth/AuthContext'
+import { buildApiUrl } from '../lib/api'
+import { LoginPage } from './LoginPage'
+import { MyPresetsPage } from './MyPresetsPage'
+import { PresetDetailPage } from './PresetDetailPage'
+
+vi.mock('../components/MagePlayer', () => ({
+  MagePlayer: ({
+    ariaLabel,
+    className,
+    sceneBlob,
+  }: {
+    ariaLabel?: string
+    className?: string
+    sceneBlob: unknown
+  }) => (
+    <div aria-label={ariaLabel} className={className} data-testid="mage-player">
+      {sceneBlob ? 'player-ready' : 'no-scene'}
+    </div>
+  ),
+}))
+
+const storedUser: AuthenticatedUser = {
+  userId: 8,
+  email: 'artist@example.com',
+  displayName: 'Preset Artist',
+  authProvider: 'LOCAL',
+}
+
+const presetResponse = {
+  presetId: 12,
+  ownerUserId: 8,
+  name: 'Aurora Drift',
+  sceneData: {
+    visualizer: {
+      shader: 'nebula',
+    },
+  },
+  thumbnailRef: 'thumbnails/preset-12.png',
+  createdAt: '2026-04-06T14:00:00Z',
+}
+
+function jsonResponse(payload: unknown, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+}
+
+function storeSession() {
+  window.localStorage.setItem(
+    AUTH_SESSION_STORAGE_KEY,
+    JSON.stringify({
+      accessToken: 'stored-auth-token',
+      user: storedUser,
+    }),
+  )
+}
+
+function renderPresetDetailPage(initialEntries = ['/presets/12']) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <AuthProvider>
+        <Routes>
+          <Route path="/" element={<div>Home</div>} />
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/my-presets" element={<MyPresetsPage />} />
+          <Route path="/presets/:id" element={<PresetDetailPage />} />
+        </Routes>
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('PresetDetailPage', () => {
+  it('loads preset detail on a direct route visit and renders the player', async () => {
+    storeSession()
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      if (input === buildApiUrl('/users/me')) {
+        return Promise.resolve(jsonResponse(storedUser))
+      }
+
+      if (input === buildApiUrl('/presets/12')) {
+        return Promise.resolve(jsonResponse(presetResponse))
+      }
+
+      throw new Error(`Unexpected request: ${String(input)}`)
+    })
+
+    renderPresetDetailPage()
+
+    expect(await screen.findByRole('heading', { name: /aurora drift/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /live player/i })).toBeInTheDocument()
+    expect(screen.getByTestId('mage-player')).toHaveTextContent('player-ready')
+    expect(screen.getByRole('link', { name: /back to my presets/i })).toBeInTheDocument()
+
+    await waitFor(() =>
+      expect(fetchSpy).toHaveBeenNthCalledWith(
+        2,
+        buildApiUrl('/presets/12'),
+        expect.objectContaining({
+          headers: expect.any(Headers),
+        }),
+      ),
+    )
+
+    const presetRequestHeaders = fetchSpy.mock.calls[1][1]?.headers as Headers
+
+    expect(presetRequestHeaders.get('Authorization')).toBe('Bearer stored-auth-token')
+  })
+
+  it('shows a clear error state for an invalid preset route id', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+
+    renderPresetDetailPage(['/presets/not-a-number'])
+
+    expect(await screen.findByRole('heading', { name: /invalid preset link/i })).toBeInTheDocument()
+    expect(screen.getByText(/missing a valid preset id/i)).toBeInTheDocument()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('shows a not-found state when the preset request returns 404', async () => {
+    storeSession()
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      if (input === buildApiUrl('/users/me')) {
+        return Promise.resolve(jsonResponse(storedUser))
+      }
+
+      if (input === buildApiUrl('/presets/12')) {
+        return Promise.resolve(
+          jsonResponse(
+            {
+              message: 'Preset not found.',
+            },
+            404,
+          ),
+        )
+      }
+
+      throw new Error(`Unexpected request: ${String(input)}`)
+    })
+
+    renderPresetDetailPage()
+
+    expect(await screen.findByRole('heading', { name: /preset not found/i })).toBeInTheDocument()
+    expect(screen.getByText(/does not exist or is no longer available/i)).toBeInTheDocument()
+  })
+
+  it('shows a sign-in-needed state when an unauthenticated preset request is rejected', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      if (input === buildApiUrl('/presets/12')) {
+        return Promise.resolve(
+          jsonResponse(
+            {
+              message: 'Authentication is required.',
+            },
+            401,
+          ),
+        )
+      }
+
+      throw new Error(`Unexpected request: ${String(input)}`)
+    })
+
+    renderPresetDetailPage()
+
+    expect(await screen.findByRole('heading', { name: /sign in to view this preset/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /go to login/i })).toBeInTheDocument()
+  })
+})

--- a/src/pages/PresetDetailPage.tsx
+++ b/src/pages/PresetDetailPage.tsx
@@ -1,26 +1,390 @@
-import { Link, Navigate, useParams } from 'react-router-dom'
-import { PlaceholderPage } from './PlaceholderPage'
+import { useEffect, useState, type ReactNode } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { useAuth } from '../auth/AuthContext'
+import { MagePlayer } from '../components/MagePlayer'
+import { buildApiUrl } from '../lib/api'
+import type { MageSceneBlob } from '../lib/magePlayerAdapter'
+
+type AuthenticatedFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+
+type PresetDetailResponse = {
+  id?: number
+  presetId?: number
+  ownerUserId?: number
+  name?: string
+  sceneData?: unknown
+  thumbnailRef?: string | null
+  createdAt?: string
+}
+
+type PresetDetail = {
+  id: number
+  ownerUserId: number | null
+  name: string
+  sceneData: MageSceneBlob
+  thumbnailRef: string | null
+  createdAt: string | null
+}
+
+type PresetDetailErrorCode =
+  | 'auth-required'
+  | 'invalid-id'
+  | 'invalid-payload'
+  | 'not-found'
+  | 'unavailable'
+
+class PresetDetailRequestError extends Error {
+  code: PresetDetailErrorCode
+
+  constructor(code: PresetDetailErrorCode, message: string) {
+    super(message)
+    this.code = code
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function readPresetId(value: string | undefined) {
+  if (!value) {
+    return null
+  }
+
+  const parsedValue = Number(value)
+
+  if (!Number.isInteger(parsedValue) || parsedValue < 1) {
+    return null
+  }
+
+  return parsedValue
+}
+
+function normalizePresetDetail(payload: unknown): PresetDetail | null {
+  if (!isRecord(payload)) {
+    return null
+  }
+
+  const presetId =
+    typeof payload.presetId === 'number'
+      ? payload.presetId
+      : typeof payload.id === 'number'
+        ? payload.id
+        : null
+
+  if (presetId === null || !isRecord(payload.sceneData)) {
+    return null
+  }
+
+  return {
+    id: presetId,
+    ownerUserId: typeof payload.ownerUserId === 'number' ? payload.ownerUserId : null,
+    name:
+      typeof payload.name === 'string' && payload.name.trim()
+        ? payload.name.trim()
+        : `Preset ${presetId}`,
+    sceneData: payload.sceneData,
+    thumbnailRef:
+      typeof payload.thumbnailRef === 'string' && payload.thumbnailRef.trim()
+        ? payload.thumbnailRef
+        : null,
+    createdAt:
+      typeof payload.createdAt === 'string' && payload.createdAt.trim() ? payload.createdAt : null,
+  }
+}
+
+function readErrorCode(status: number): PresetDetailErrorCode {
+  if (status === 401) {
+    return 'auth-required'
+  }
+
+  if (status === 404) {
+    return 'not-found'
+  }
+
+  return 'unavailable'
+}
+
+async function fetchPresetDetail(
+  authenticatedFetch: AuthenticatedFetch,
+  isAuthenticated: boolean,
+  presetId: number,
+) {
+  const response = isAuthenticated
+    ? await authenticatedFetch(`/presets/${presetId}`)
+    : await fetch(buildApiUrl(`/presets/${presetId}`))
+
+  if (!response.ok) {
+    throw new PresetDetailRequestError(
+      readErrorCode(response.status),
+      `Preset detail request failed with status ${response.status}.`,
+    )
+  }
+
+  const payload = (await response.json().catch(() => null)) as PresetDetailResponse | null
+  const preset = normalizePresetDetail(payload)
+
+  if (!preset) {
+    throw new PresetDetailRequestError(
+      'invalid-payload',
+      'Preset detail response is missing the data required to render the player.',
+    )
+  }
+
+  return preset
+}
+
+function formatCreatedAt(createdAt: string | null) {
+  if (!createdAt) {
+    return 'Unavailable'
+  }
+
+  const parsedDate = new Date(createdAt)
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    return createdAt
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(parsedDate)
+}
+
+function readErrorCopy(errorCode: PresetDetailErrorCode) {
+  if (errorCode === 'invalid-id') {
+    return {
+      title: 'Invalid preset link',
+      description: 'This route is missing a valid preset id. Check the URL and try again.',
+    }
+  }
+
+  if (errorCode === 'auth-required') {
+    return {
+      title: 'Sign in to view this preset',
+      description:
+        'Preset detail requests are still authenticated in this build. Sign in, then reopen this preset route.',
+    }
+  }
+
+  if (errorCode === 'not-found') {
+    return {
+      title: 'Preset not found',
+      description: 'This preset does not exist or is no longer available.',
+    }
+  }
+
+  if (errorCode === 'invalid-payload') {
+    return {
+      title: 'Unable to render this preset',
+      description:
+        'The backend returned preset detail data, but the scene payload is missing fields required by the player.',
+    }
+  }
+
+  return {
+    title: 'Unable to load this preset',
+    description: 'MAGE could not load this preset right now. Please try again in a moment.',
+  }
+}
+
+function PresetDetailState({
+  title,
+  description,
+  actions,
+}: {
+  title: string
+  description: string
+  actions?: ReactNode
+}) {
+  return (
+    <main className="surface surface--hero">
+      <div className="eyebrow">Preset Detail</div>
+      <h1>{title}</h1>
+      <p className="page-lead">{description}</p>
+      {actions ? (
+        <>
+          <div className="divider" />
+          {actions}
+        </>
+      ) : null}
+      <p className="page-footnote">Preset detail routes now resolve through the live player flow.</p>
+      <div className="page-mark">MAGE</div>
+    </main>
+  )
+}
 
 export function PresetDetailPage() {
   const { id } = useParams<{ id: string }>()
+  const { authenticatedFetch, isAuthenticated, isRestoringSession } = useAuth()
+  const [preset, setPreset] = useState<PresetDetail | null>(null)
+  const [errorCode, setErrorCode] = useState<PresetDetailErrorCode | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
 
-  if (!id) {
-    return <Navigate replace to="/my-presets" />
+  const presetId = readPresetId(id)
+
+  useEffect(() => {
+    if (presetId === null || isRestoringSession) {
+      return
+    }
+
+    const nextPresetId = presetId
+    let isCurrent = true
+
+    async function loadPreset() {
+      setIsLoading(true)
+      setErrorCode(null)
+      setPreset(null)
+
+      try {
+        const nextPreset = await fetchPresetDetail(
+          authenticatedFetch,
+          isAuthenticated,
+          nextPresetId,
+        )
+
+        if (!isCurrent) {
+          return
+        }
+
+        setPreset(nextPreset)
+      } catch (error) {
+        if (!isCurrent) {
+          return
+        }
+
+        setErrorCode(error instanceof PresetDetailRequestError ? error.code : 'unavailable')
+      } finally {
+        if (isCurrent) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    void loadPreset()
+
+    return () => {
+      isCurrent = false
+    }
+  }, [authenticatedFetch, isAuthenticated, isRestoringSession, presetId])
+
+  if (presetId === null) {
+    const { description, title } = readErrorCopy('invalid-id')
+
+    return (
+      <PresetDetailState
+        title={title}
+        description={description}
+        actions={
+          <div className="auth-actions">
+            <Link className="demo-link" to="/">
+              Back to Home
+            </Link>
+            {isAuthenticated ? (
+              <Link className="secondary-link" to="/my-presets">
+                Back to My Presets
+              </Link>
+            ) : null}
+          </div>
+        }
+      />
+    )
+  }
+
+  if (isRestoringSession || isLoading) {
+    return (
+      <PresetDetailState
+        title="Loading preset..."
+        description={
+          isRestoringSession
+            ? 'MAGE is restoring your session before loading this preset.'
+            : 'MAGE is fetching preset metadata and loading the embedded player.'
+        }
+      />
+    )
+  }
+
+  if (errorCode || !preset) {
+    const { description, title } = readErrorCopy(errorCode ?? 'unavailable')
+
+    return (
+      <PresetDetailState
+        title={title}
+        description={description}
+        actions={
+          <div className="auth-actions">
+            {errorCode === 'auth-required' ? (
+              <Link className="demo-link" to="/login">
+                Go to Login
+              </Link>
+            ) : (
+              <Link className="demo-link" to="/">
+                Back to Home
+              </Link>
+            )}
+            {isAuthenticated ? (
+              <Link className="secondary-link" to="/my-presets">
+                Back to My Presets
+              </Link>
+            ) : errorCode !== 'auth-required' ? (
+              <Link className="secondary-link" to="/login">
+                Sign In
+              </Link>
+            ) : null}
+          </div>
+        }
+      />
+    )
   }
 
   return (
-    <PlaceholderPage
-      eyebrow="Preset Detail"
-      title={`Preset ${id}`}
-      description="This preset detail route is ready for the next preset experience."
-      action={
+    <main className="auth-page--wide">
+      <section className="surface surface--page-header">
+        <div className="eyebrow">Preset Detail</div>
+        <h1>{preset.name}</h1>
+        <p className="page-lead">
+          This preset route fetches the stored scene payload from the backend and renders it
+          directly in the shared MAGE player.
+        </p>
         <div className="auth-actions">
-          <Link className="demo-link" to="/my-presets">
-            Back to My Presets
-          </Link>
+          {isAuthenticated ? (
+            <>
+              <Link className="demo-link" to="/my-presets">
+                Back to My Presets
+              </Link>
+              <Link className="secondary-link" to="/create-preset">
+                Create Preset
+              </Link>
+            </>
+          ) : (
+            <>
+              <Link className="demo-link" to="/">
+                Back to Home
+              </Link>
+              <Link className="secondary-link" to="/login">
+                Sign In
+              </Link>
+            </>
+          )}
         </div>
-      }
-      footnote="Preset selection now routes correctly from the My Presets page."
-    />
+      </section>
+
+      <section className="surface surface--page-panel">
+        <div className="preset-editor-preview__header">
+          <h2>Live Player</h2>
+          <p>
+            Created {formatCreatedAt(preset.createdAt)}. The player below renders this preset scene
+            live in the browser instead of relying on navigation-only state.
+          </p>
+        </div>
+
+        <MagePlayer
+          ariaLabel={`${preset.name} live render`}
+          className="preset-editor-preview__player"
+          sceneBlob={preset.sceneData}
+        />
+      </section>
+    </main>
   )
 }

--- a/src/pages/PresetDetailPage.tsx
+++ b/src/pages/PresetDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from 'react'
+import { useEffect, useState, type CSSProperties, type ReactNode } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { useAuth } from '../auth/AuthContext'
 import { MagePlayer } from '../components/MagePlayer'
@@ -33,6 +33,123 @@ type PresetDetailErrorCode =
   | 'not-found'
   | 'unavailable'
 
+type PresetComment = {
+  author: string
+  handle: string
+  posted: string
+  text: string
+  upvotes: string
+  downvotes: string
+}
+
+type CreatorProfile = {
+  displayName: string
+  handle: string
+  subscribersLabel: string
+  studioNote: string
+  primaryActionLabel?: string
+}
+
+type PresetEngagement = {
+  playsLabel: string
+  upvotesLabel: string
+  downvotesLabel: string
+  savesLabel: string
+  publishedLabel: string
+  topicLabel: string
+}
+
+type PresetDescription = {
+  opening: string
+  middle: string
+  closing: string
+  bestFor: string
+  builtWith: string
+  tags: string[]
+}
+
+type RecommendedPresetCard = {
+  id: number
+  title: string
+  creator: string
+  stats: string
+  duration: string
+  accent: string
+  badge: string
+  note: string
+  isActive?: boolean
+}
+
+const recommendedPresetBlueprints = [
+  {
+    id: 4,
+    title: 'After Rain / Windowlight',
+    creator: 'Mina Park',
+    stats: '9.9K plays',
+    duration: '04:41',
+    accent: '#9fd9ff',
+    badge: 'Featured',
+    note: 'Soft gradients and patient motion for low-BPM intros.',
+  },
+  {
+    id: 7,
+    title: 'Soft Static / Midnight Lobby',
+    creator: 'Jonah Reed',
+    stats: '14.8K plays',
+    duration: '04:56',
+    accent: '#ffb26b',
+    badge: 'Editor Pick',
+    note: 'Warmer bloom and wider highlights for vocal-led mixes.',
+  },
+  {
+    id: 8,
+    title: 'Harbor Glass / Dawn Fade',
+    creator: 'Talia North',
+    stats: '11.5K plays',
+    duration: '06:03',
+    accent: '#7ef0c0',
+    badge: 'Up Next',
+    note: 'Designed for long builds, softer drops, and calm pacing.',
+  },
+  {
+    id: 9,
+    title: 'Low Tide / Signal Room',
+    creator: 'Elio Mercer',
+    stats: '16.1K plays',
+    duration: '05:44',
+    accent: '#7f9bff',
+    badge: 'For Later',
+    note: 'A darker preset with restrained motion and brighter accents.',
+  },
+] as const
+
+const creatorProfileBlueprints = [
+  {
+    displayName: 'Mina Park',
+    handle: '@mina.afterlight',
+    subscribersLabel: '2.18K subscribers',
+    studioNote: 'I usually tune motion to stay readable for the first minute before the highlights wake up.',
+  },
+  {
+    displayName: 'Jonah Reed',
+    handle: '@jonahreedsignal',
+    subscribersLabel: '1.42K subscribers',
+    studioNote: 'Most of my presets start from a music-first pass, then I add texture until the frame feels alive.',
+  },
+  {
+    displayName: 'Talia North',
+    handle: '@talianorth',
+    subscribersLabel: '3.84K subscribers',
+    studioNote: 'I care more about pacing than density, so the quieter parts of a track still have room to breathe.',
+  },
+  {
+    displayName: 'Elio Mercer',
+    handle: '@elio.mercer',
+    subscribersLabel: '986 subscribers',
+    studioNote: 'If a preset looks loud with the volume off, I usually strip it back and start over.',
+  },
+] as const
+
 class PresetDetailRequestError extends Error {
   code: PresetDetailErrorCode
 
@@ -40,6 +157,50 @@ class PresetDetailRequestError extends Error {
     super(message)
     this.code = code
   }
+}
+
+function UpvoteIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24">
+      <path
+        d="M12 3.8a1 1 0 0 1 .8.4l5.7 7.2a1 1 0 0 1-.8 1.6h-3.3V19a1.2 1.2 0 0 1-1.2 1.2h-2.4a1.2 1.2 0 0 1-1.2-1.2V13H6.3a1 1 0 0 1-.8-1.6l5.7-7.2a1 1 0 0 1 .8-.4Z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}
+
+function DownvoteIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24">
+      <path
+        d="M11.2 20.2a1 1 0 0 1-.8-.4l-5.7-7.2a1 1 0 0 1 .8-1.6h3.3V5a1.2 1.2 0 0 1 1.2-1.2h2.4A1.2 1.2 0 0 1 13.6 5v6h3.3a1 1 0 0 1 .8 1.6l-5.7 7.2a1 1 0 0 1-.8.4Z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}
+
+function VoteButton({
+  className,
+  count,
+  direction,
+}: {
+  className: string
+  count: string
+  direction: 'up' | 'down'
+}) {
+  const label = direction === 'up' ? 'Upvote' : 'Downvote'
+  const Icon = direction === 'up' ? UpvoteIcon : DownvoteIcon
+
+  return (
+    <button aria-label={`${label} ${count}`} className={className} type="button">
+      <span className="preset-detail-vote-button__icon" aria-hidden="true">
+        <Icon />
+      </span>
+      <span>{count}</span>
+    </button>
+  )
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -152,6 +313,141 @@ function formatCreatedAt(createdAt: string | null) {
   }).format(parsedDate)
 }
 
+function slugify(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '')
+}
+
+function readInitial(value: string) {
+  const trimmedValue = value.trim()
+
+  return trimmedValue ? trimmedValue[0].toUpperCase() : 'M'
+}
+
+function buildPresetEngagement(preset: PresetDetail): PresetEngagement {
+  const plays = 1559 + preset.id * 120
+  const upvotes = 56 + preset.id * 30
+  const downvotes = 8 + preset.id * 2
+  const saves = 18 + preset.id * 11
+
+  return {
+    playsLabel: `${plays.toLocaleString()} plays`,
+    upvotesLabel: upvotes.toLocaleString(),
+    downvotesLabel: downvotes.toLocaleString(),
+    savesLabel: saves.toLocaleString(),
+    publishedLabel: `Published ${formatCreatedAt(preset.createdAt)}`,
+    topicLabel: 'Audio-reactive preset',
+  }
+}
+
+function buildSubscriberLabel(seed: number) {
+  const subscriberCount = 1720 + seed * 38
+
+  if (subscriberCount >= 1000) {
+    return `${(subscriberCount / 1000).toFixed(2)}K subscribers`
+  }
+
+  return `${subscriberCount} subscribers`
+}
+
+function buildCreatorProfile(
+  preset: PresetDetail,
+  viewerDisplayName: string | undefined,
+  viewerUserId: number | null | undefined,
+): CreatorProfile {
+  if (viewerUserId !== null && viewerUserId !== undefined && viewerUserId === preset.ownerUserId) {
+    const displayName = viewerDisplayName?.trim() || 'Your Studio'
+
+    return {
+      displayName,
+      handle: `@${slugify(displayName) || 'magecreator'}`,
+      subscribersLabel: buildSubscriberLabel(preset.id),
+      studioNote:
+        'I wanted this preset page to feel like something I would actually share, not just a lab route with a player dropped into it.',
+      primaryActionLabel: 'Subscribe',
+    }
+  }
+
+  const blueprint =
+    creatorProfileBlueprints[
+      Math.abs((preset.ownerUserId ?? preset.id) % creatorProfileBlueprints.length)
+    ]
+
+  return {
+    ...blueprint,
+    primaryActionLabel: 'Subscribe',
+  }
+}
+
+function buildPresetDescription(
+  preset: PresetDetail,
+  creatorProfile: CreatorProfile,
+): PresetDescription {
+  return {
+    opening: `I built ${preset.name} for tracks that need atmosphere without visual clutter. The motion holds back during the intro, then the reflections and bloom open up once the mids start pushing forward.`,
+    middle: `${creatorProfile.displayName} tends to tune scenes for patience rather than spectacle, so this one lands best behind slower house, downtempo electronica, mellow garage, and long vocal builds where the frame needs to stay supportive instead of noisy.`,
+    closing:
+      'This page is still an early public pass, but the preset render above is the real scene payload. I wanted the surrounding notes, comments, and recommendations to read like a creator page someone would actually spend time on while the rest of the social features catch up.',
+    bestFor: 'late-night sets, focus mixes, ambient intros',
+    builtWith: 'soft bloom, layered fog, reflective passes, restrained drift',
+    tags: ['ambient', 'slow-bloom', 'focus-friendly', 'late-night', 'magepreset'],
+  }
+}
+
+function buildPresetComments(preset: PresetDetail): PresetComment[] {
+  return [
+    {
+      author: 'Nora Vale',
+      handle: '@noravale',
+      posted: '2 days ago',
+      text: `Ran ${preset.name} behind a Rhodes sketch last night and it sat exactly where I wanted it. The slower build is what makes it feel intentional.`,
+      upvotes: '14',
+      downvotes: '1',
+    },
+    {
+      author: 'Cass Mercer',
+      handle: '@cassmercer',
+      posted: '5 days ago',
+      text: 'The restraint is the best part. Most reactive presets oversell the first beat, but this one gives the track room before the highlights start showing off.',
+      upvotes: '9',
+      downvotes: '0',
+    },
+    {
+      author: 'Jun Park',
+      handle: '@junpark',
+      posted: '1 week ago',
+      text: 'Would happily use this for an hour-long focus upload. The glassy reflections feel polished without tipping into sci-fi overload.',
+      upvotes: '6',
+      downvotes: '0',
+    },
+  ]
+}
+
+function buildRecommendedPresets(
+  preset: PresetDetail,
+  creatorProfile: CreatorProfile,
+  engagement: PresetEngagement,
+): RecommendedPresetCard[] {
+  return [
+    {
+      id: preset.id,
+      title: preset.name,
+      creator: creatorProfile.displayName,
+      stats: engagement.playsLabel,
+      duration: 'Live',
+      accent: '#63f0d6',
+      badge: 'Now Playing',
+      note: 'The preset currently loaded into the player above.',
+      isActive: true,
+    },
+    ...recommendedPresetBlueprints
+      .filter((recommendedPreset) => recommendedPreset.id !== preset.id)
+      .map((recommendedPreset) => ({ ...recommendedPreset })),
+  ]
+}
+
 function readErrorCopy(errorCode: PresetDetailErrorCode) {
   if (errorCode === 'invalid-id') {
     return {
@@ -217,7 +513,7 @@ function PresetDetailState({
 
 export function PresetDetailPage() {
   const { id } = useParams<{ id: string }>()
-  const { authenticatedFetch, isAuthenticated, isRestoringSession } = useAuth()
+  const { authenticatedFetch, isAuthenticated, isRestoringSession, user } = useAuth()
   const [preset, setPreset] = useState<PresetDetail | null>(null)
   const [errorCode, setErrorCode] = useState<PresetDetailErrorCode | null>(null)
   const [isLoading, setIsLoading] = useState(true)
@@ -338,52 +634,201 @@ export function PresetDetailPage() {
     )
   }
 
+  const creatorProfile = buildCreatorProfile(preset, user?.displayName, user?.userId)
+  const engagement = buildPresetEngagement(preset)
+  const presetDescription = buildPresetDescription(preset, creatorProfile)
+  const presetComments = buildPresetComments(preset)
+  const recommendedPresets = buildRecommendedPresets(preset, creatorProfile, engagement)
+  const composerInitial = readInitial(user?.displayName ?? 'Guest')
+  const composerPrompt = user?.displayName
+    ? `Add a comment as ${user.displayName}...`
+    : 'Sign in to join the conversation'
+
   return (
-    <main className="auth-page--wide">
-      <section className="surface surface--page-header">
-        <div className="eyebrow">Preset Detail</div>
-        <h1>{preset.name}</h1>
-        <p className="page-lead">
-          This preset route fetches the stored scene payload from the backend and renders it
-          directly in the shared MAGE player.
-        </p>
-        <div className="auth-actions">
-          {isAuthenticated ? (
-            <>
-              <Link className="demo-link" to="/my-presets">
-                Back to My Presets
-              </Link>
-              <Link className="secondary-link" to="/create-preset">
-                Create Preset
-              </Link>
-            </>
-          ) : (
-            <>
-              <Link className="demo-link" to="/">
-                Back to Home
-              </Link>
-              <Link className="secondary-link" to="/login">
-                Sign In
-              </Link>
-            </>
-          )}
-        </div>
-      </section>
+    <main className="preset-detail-page">
+      <section className="mage-watch preset-detail-watch">
+        <div className="mage-watch__main">
+          <div className="mage-player-shell">
+            <div
+              className="mage-stage-frame mage-stage-frame--watch preset-detail-stage"
+              style={{ '--preset-accent': '#63f0d6' } as CSSProperties}
+            >
+              <MagePlayer
+                ariaLabel={`${preset.name} live render`}
+                className="preset-detail-player"
+                sceneBlob={preset.sceneData}
+              />
 
-      <section className="surface surface--page-panel">
-        <div className="preset-editor-preview__header">
-          <h2>Live Player</h2>
-          <p>
-            Created {formatCreatedAt(preset.createdAt)}. The player below renders this preset scene
-            live in the browser instead of relying on navigation-only state.
-          </p>
+              <div className="mage-stage-frame__hud">
+                <span className="mage-stage-pill" data-ready="true">
+                  Live Render
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="preset-detail-header">
+            <h1 className="mage-watch__title">{preset.name}</h1>
+          </div>
+
+          <section className="preset-detail-social-row">
+            <div className="preset-detail-social-row__creator">
+              <div className="mage-channel-card">
+                <div className="mage-channel-card__avatar" aria-hidden="true">
+                  {readInitial(creatorProfile.displayName)}
+                </div>
+                <div className="mage-channel-card__copy">
+                  <strong>{creatorProfile.displayName}</strong>
+                  <span>{creatorProfile.subscribersLabel}</span>
+                </div>
+              </div>
+
+              {creatorProfile.primaryActionLabel ? (
+                <button className="preset-detail-follow-button" type="button">
+                  {creatorProfile.primaryActionLabel}
+                </button>
+              ) : null}
+            </div>
+
+            <div className="preset-detail-action-row">
+              <VoteButton
+                className="preset-detail-action-chip"
+                count={engagement.upvotesLabel}
+                direction="up"
+              />
+              <VoteButton
+                className="preset-detail-action-chip"
+                count={engagement.downvotesLabel}
+                direction="down"
+              />
+              <button className="preset-detail-action-chip" type="button">
+                Share
+              </button>
+              <button className="preset-detail-action-chip" type="button">
+                Save
+              </button>
+            </div>
+          </section>
+
+          <section className="preset-detail-description-card">
+            <div className="preset-detail-description-card__meta">
+              <strong>{engagement.playsLabel}</strong>
+              <span>{engagement.publishedLabel}</span>
+            </div>
+            <p>{presetDescription.opening}</p>
+            <p>{presetDescription.middle}</p>
+            <p>{presetDescription.closing}</p>
+
+            <div className="preset-detail-note-grid">
+              <div className="preset-detail-note-grid__item">
+                <span>Studio note</span>
+                <strong>{creatorProfile.studioNote}</strong>
+              </div>
+              <div className="preset-detail-note-grid__item">
+                <span>Best for</span>
+                <strong>{presetDescription.bestFor}</strong>
+              </div>
+              <div className="preset-detail-note-grid__item">
+                <span>Built with</span>
+                <strong>{presetDescription.builtWith}</strong>
+              </div>
+              <div className="preset-detail-note-grid__item">
+                <span>Saves</span>
+                <strong>{engagement.savesLabel}</strong>
+              </div>
+            </div>
+
+            <div className="mage-tag-row">
+              {presetDescription.tags.map((tag) => (
+                <span key={tag} className="mage-tag">
+                  #{tag}
+                </span>
+              ))}
+            </div>
+          </section>
+
+          <section className="preset-detail-comments-panel">
+            <div className="preset-detail-comments-toolbar">
+              <div className="mage-comments__header">
+                <h2>Comments</h2>
+                <span>{presetComments.length}</span>
+              </div>
+              <button className="preset-detail-sort-chip" type="button">
+                Top comments
+              </button>
+            </div>
+
+            <div className="preset-detail-comment-composer">
+              <div className="preset-detail-comment-composer__avatar" aria-hidden="true">
+                {composerInitial}
+              </div>
+              <div className="preset-detail-comment-composer__field">
+                <span>{composerPrompt}</span>
+              </div>
+            </div>
+
+            <div className="mage-comments__list">
+              {presetComments.map((comment) => (
+                <article key={`${comment.author}-${comment.posted}`} className="mage-comment">
+                  <div className="mage-comment__avatar" aria-hidden="true">
+                    {readInitial(comment.author)}
+                  </div>
+                  <div className="mage-comment__body">
+                    <div className="preset-detail-comment__header">
+                      <strong>{comment.author}</strong>
+                      <span>{comment.handle}</span>
+                      <span>{comment.posted}</span>
+                    </div>
+                    <p>{comment.text}</p>
+                    <div className="preset-detail-comment__actions">
+                      <VoteButton
+                        className="preset-detail-comment__action"
+                        count={comment.upvotes}
+                        direction="up"
+                      />
+                      <VoteButton
+                        className="preset-detail-comment__action"
+                        count={comment.downvotes}
+                        direction="down"
+                      />
+                      <button className="preset-detail-comment__action" type="button">
+                        Reply
+                      </button>
+                    </div>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </section>
         </div>
 
-        <MagePlayer
-          ariaLabel={`${preset.name} live render`}
-          className="preset-editor-preview__player"
-          sceneBlob={preset.sceneData}
-        />
+        <aside className="mage-watch__rail">
+          <div className="mage-watch__rail-header">
+            <h2>Recommended Presets</h2>
+          </div>
+
+          <div className="mage-watch__rail-list">
+            {recommendedPresets.map((recommendedPreset) => (
+              <article
+                key={recommendedPreset.id}
+                className={`mage-preset-card${recommendedPreset.isActive ? ' is-active' : ''}`}
+              >
+                <div
+                  className="mage-preset-card__thumb"
+                  style={{ '--preset-accent': recommendedPreset.accent } as CSSProperties}
+                >
+                  <span className="mage-preset-card__badge">{recommendedPreset.badge}</span>
+                </div>
+                <div className="mage-preset-card__body">
+                  <strong>{recommendedPreset.title}</strong>
+                  <span>{recommendedPreset.creator}</span>
+                  <span>{recommendedPreset.stats}</span>
+                  <span className="mage-preset-card__note">{recommendedPreset.note}</span>
+                </div>
+              </article>
+            ))}
+          </div>
+        </aside>
       </section>
     </main>
   )


### PR DESCRIPTION
## Summary
- add a real `/presets/:id` route that fetches preset data from the backend and renders it through the shared `MagePlayer`
- restyle the preset detail page into a creator-facing player page with a square live stage, creator strip, description, comments, voting controls, and a recommendation rail
- add regression coverage for direct preset route loads and My Presets navigation into the player page

## Problem
Preset links from My Presets only led to a placeholder page, so there was no real preset detail/player experience on direct load or refresh. Even after wiring the route, the page needed a more complete player layout that felt like an actual creator-facing destination instead of a bare technical preview.

## What Changed
- implemented preset detail fetching, payload validation, and clear invalid/auth-required/not-found/unavailable states
- rendered the fetched scene blob with the shared browser player on the preset detail route
- updated My Presets tests to cover navigation into the live preset page
- built a creator-style player layout with:
  - square live player stage
  - creator identity row and subscribe CTA
  - upvote/downvote controls for the preset and comments
  - richer creator-style description copy and metadata blocks
  - comments composer/thread UI placeholders
  - wider recommended preset sidebar
- documented the new preset detail route in the README

## Testing
- npm.cmd test -- src/pages/PresetDetailPage.test.tsx src/pages/MyPresetsPage.test.tsx
- npm.cmd run build

## Notes
- preset detail requests are still authenticated in the current backend build, so signed-out users see the auth-required state instead of a public render. This must be addressed in the backend.
