### PR TITLE
Frontend update

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -63,6 +63,7 @@
   display: flex;
   align-items: center;
   gap: 14px;
+  position: relative;
 }
 
 .nav-session-copy {
@@ -82,6 +83,7 @@
   color: var(--muted);
 }
 
+.nav-account-toggle,
 .nav-logout {
   min-height: 40px;
   padding: 0 16px;
@@ -97,10 +99,105 @@
     transform 0.18s ease;
 }
 
+.nav-account-toggle:hover,
 .nav-logout:hover {
   color: var(--accent);
   border-color: rgba(99, 240, 214, 0.28);
   transform: translateY(-1px);
+}
+
+.account-panel {
+  position: absolute;
+  top: calc(100% + 12px);
+  right: 0;
+  width: min(360px, 92vw);
+  display: grid;
+  gap: 18px;
+  padding: 20px;
+  border-radius: 24px;
+  border: 1px solid rgba(99, 240, 214, 0.14);
+  background: rgba(6, 16, 19, 0.96);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.38);
+  backdrop-filter: blur(18px);
+}
+
+.account-panel-header {
+  display: grid;
+  gap: 4px;
+}
+
+.account-panel-header strong {
+  font-size: 1rem;
+  color: #f5fbf9;
+}
+
+.account-panel-header span {
+  color: var(--muted);
+  font-size: 0.88rem;
+  word-break: break-word;
+}
+
+.account-panel-fields {
+  display: grid;
+  gap: 14px;
+}
+
+.account-field {
+  display: grid;
+  gap: 8px;
+}
+
+.account-field label {
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: #f5fbf9;
+}
+
+.account-field input {
+  width: 100%;
+  min-height: 46px;
+  padding: 0 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(4, 12, 14, 0.72);
+  color: var(--text);
+}
+
+.account-field input[type='file'] {
+  padding: 10px 12px;
+}
+
+.account-field input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px rgba(99, 240, 214, 0.12);
+}
+
+.account-panel-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.account-action {
+  min-height: 40px;
+  padding: 0 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(99, 240, 214, 0.2);
+  background: rgba(99, 240, 214, 0.12);
+  color: #f5fbf9;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    border-color 0.18s ease,
+    background-color 0.18s ease,
+    transform 0.18s ease;
+}
+
+.account-action:hover {
+  transform: translateY(-1px);
+  border-color: rgba(99, 240, 214, 0.34);
+  background: rgba(99, 240, 214, 0.18);
 }
 
 .app-shell {
@@ -345,10 +442,19 @@
   gap: 18px;
 }
 
+.auth-state-welcome {
+  justify-items: center;
+  text-align: center;
+}
+
 .auth-header .eyebrow,
 .auth-state .eyebrow {
   justify-self: start;
   margin-bottom: 0;
+}
+
+.auth-state-welcome .eyebrow {
+  justify-self: center;
 }
 
 .auth-title {
@@ -362,6 +468,14 @@
   font-size: 1rem;
   line-height: 1.7;
   color: var(--muted);
+}
+
+.auth-welcome-name {
+  margin: 0;
+  font-size: clamp(1.4rem, 4vw, 2rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  color: #f5fbf9;
 }
 
 .auth-form {
@@ -454,6 +568,20 @@
 .auth-footnote {
   margin: 20px 0 0;
   color: var(--muted);
+}
+
+.auth-link-button {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.auth-link-button:hover {
+  color: var(--accent);
 }
 
 .auth-actions {
@@ -636,6 +764,10 @@
     flex-direction: column;
     align-items: flex-end;
     gap: 14px;
+  }
+
+  .account-panel {
+    right: 0;
   }
 
   .app-shell {

--- a/src/App.css
+++ b/src/App.css
@@ -717,19 +717,29 @@
 }
 
 .settings-page {
-  width: min(1200px, 100%);
+  width: min(760px, 100%);
 }
 
-.settings-layout {
-  display: grid;
-  grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
-  gap: 24px;
+.settings-title {
+  margin: 0;
+  font-size: clamp(2.2rem, 5vw, 3.1rem);
+  line-height: 0.98;
+  letter-spacing: -0.05em;
+}
+
+.settings-lead {
+  max-width: 560px;
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.7;
 }
 
 .settings-section {
   display: grid;
   gap: 18px;
-  padding: 24px;
+  padding: 22px;
+  margin-top: 28px;
 }
 
 .settings-section__header {
@@ -744,46 +754,15 @@
 }
 
 .settings-section__header p,
-.settings-account-list dt,
-.settings-account-list dd,
-.settings-panel-note {
+.settings-section__header p {
   margin: 0;
   color: var(--muted);
   line-height: 1.6;
 }
 
-.settings-form-grid {
+.settings-fields {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 16px;
-}
-
-.settings-account-list {
-  display: grid;
-  gap: 12px;
-  margin: 0;
-}
-
-.settings-account-list div {
-  display: grid;
-  gap: 4px;
-  padding: 14px;
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.04);
-}
-
-.settings-account-list dt {
-  font-size: 0.76rem;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.settings-account-list dd {
-  color: var(--text);
-  font-size: 0.96rem;
-  font-weight: 600;
 }
 
 .settings-reset-button {
@@ -2042,10 +2021,6 @@
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   }
 
-  .settings-layout {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
   .preset-editor-layout,
   .preset-editor-toolbar {
     grid-template-columns: minmax(0, 1fr);
@@ -2156,10 +2131,6 @@
 
   .settings-section {
     padding: 20px;
-  }
-
-  .settings-form-grid {
-    grid-template-columns: minmax(0, 1fr);
   }
 
   .preset-detail-watch .mage-player-shell {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,37 @@
 import './App.css'
+import type { ReactElement } from 'react'
 import { Navigate, Route, Routes } from 'react-router-dom'
-import { AuthProvider } from './auth/AuthContext'
+import { AuthProvider, useAuth } from './auth/AuthContext'
 import { Layout } from './components/Layout'
 import { HomePage } from './pages/HomePage'
 import { LoginPage } from './pages/LoginPage'
 import { MyPresetsPage } from './pages/MyPresetsPage'
 import { PresetDetailPage } from './pages/PresetDetailPage'
 import { RegisterPage } from './pages/RegisterPage'
+
+type ProtectedRouteProps = {
+  children: ReactElement
+}
+
+function ProtectedRoute({ children }: ProtectedRouteProps) {
+  const { isAuthenticated, isRestoringSession } = useAuth()
+
+  if (isRestoringSession) {
+    return (
+      <main className="card">
+        <div className="eyebrow">Session</div>
+        <h1>Checking your login...</h1>
+        <p className="sub">MAGE is restoring your account before opening this page.</p>
+      </main>
+    )
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate replace to="/login" />
+  }
+
+  return children
+}
 
 function App() {
   return (
@@ -15,8 +40,22 @@ function App() {
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/login" element={<LoginPage />} />
-          <Route path="/my-presets" element={<MyPresetsPage />} />
-          <Route path="/presets/:id" element={<PresetDetailPage />} />
+          <Route
+            path="/my-presets"
+            element={
+              <ProtectedRoute>
+                <MyPresetsPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/presets/:id"
+            element={
+              <ProtectedRoute>
+                <PresetDetailPage />
+              </ProtectedRoute>
+            }
+          />
           <Route path="/register" element={<RegisterPage />} />
           <Route path="*" element={<Navigate replace to="/" />} />
         </Routes>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import type { PropsWithChildren } from 'react'
+import { useMemo, useState, type PropsWithChildren } from 'react'
 import { Link, NavLink } from 'react-router-dom'
 import { useAuth } from '../auth/AuthContext'
 
@@ -12,8 +12,32 @@ const authenticatedNavItems = [
   { label: 'My Presets', to: '/my-presets' },
 ]
 
+function splitDisplayName(displayName: string) {
+  const trimmedDisplayName = displayName.trim()
+
+  if (!trimmedDisplayName) {
+    return { firstName: '', lastName: '' }
+  }
+
+  const [firstName = '', ...remainingParts] = trimmedDisplayName.split(/\s+/)
+
+  return {
+    firstName,
+    lastName: remainingParts.join(' '),
+  }
+}
+
 export function Layout({ children }: PropsWithChildren) {
   const { accessToken, isAuthenticated, isRestoringSession, logout, user } = useAuth()
+  const [isAccountPanelOpen, setIsAccountPanelOpen] = useState(false)
+
+  const accountFields = useMemo(() => {
+    if (!user) {
+      return { firstName: '', lastName: '' }
+    }
+
+    return splitDisplayName(user.displayName)
+  }, [user])
 
   return (
     <>
@@ -32,13 +56,53 @@ export function Layout({ children }: PropsWithChildren) {
                 ))}
               </nav>
               <div className="nav-session">
-                <div className="nav-session-copy">
-                  <strong>{user.displayName}</strong>
-                  <span>{user.email}</span>
-                </div>
-                <button className="nav-logout" type="button" onClick={logout}>
-                  Log out
+                <button
+                  className="nav-account-toggle"
+                  type="button"
+                  aria-expanded={isAccountPanelOpen}
+                  aria-controls="account-panel"
+                  onClick={() => setIsAccountPanelOpen((currentValue) => !currentValue)}
+                >
+                  Account
                 </button>
+                {isAccountPanelOpen ? (
+                  <div className="account-panel" id="account-panel">
+                    <div className="account-panel-header">
+                      <strong>My Account</strong>
+                      <span>{user.email}</span>
+                    </div>
+                    <div className="account-panel-fields">
+                      <div className="account-field">
+                        <label htmlFor="account-first-name">First name</label>
+                        <input
+                          id="account-first-name"
+                          name="firstName"
+                          type="text"
+                          defaultValue={accountFields.firstName}
+                          placeholder="First name"
+                        />
+                      </div>
+                      <div className="account-field">
+                        <label htmlFor="account-last-name">Last name</label>
+                        <input
+                          id="account-last-name"
+                          name="lastName"
+                          type="text"
+                          defaultValue={accountFields.lastName}
+                          placeholder="Last name"
+                        />
+                      </div>
+                    </div>
+                    <div className="account-panel-actions">
+                      <button className="account-action" type="button">
+                        Reset password
+                      </button>
+                      <button className="nav-logout" type="button" onClick={logout}>
+                        Log out
+                      </button>
+                    </div>
+                  </div>
+                ) : null}
               </div>
             </div>
           ) : isRestoringSession && accessToken ? (

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, type PropsWithChildren } from 'react'
-import { Link, NavLink } from 'react-router-dom'
+import { Link, NavLink, useNavigate } from 'react-router-dom'
 import { useAuth } from '../auth/AuthContext'
 
 const guestNavItems = [
@@ -30,6 +30,7 @@ function splitDisplayName(displayName: string) {
 export function Layout({ children }: PropsWithChildren) {
   const { accessToken, isAuthenticated, isRestoringSession, logout, user } = useAuth()
   const [isAccountPanelOpen, setIsAccountPanelOpen] = useState(false)
+  const navigate = useNavigate()
 
   const accountFields = useMemo(() => {
     if (!user) {
@@ -38,6 +39,12 @@ export function Layout({ children }: PropsWithChildren) {
 
     return splitDisplayName(user.displayName)
   }, [user])
+
+  function handleLogout() {
+    setIsAccountPanelOpen(false)
+    logout()
+    navigate('/login', { replace: true })
+  }
 
   return (
     <>
@@ -97,7 +104,7 @@ export function Layout({ children }: PropsWithChildren) {
                       <button className="account-action" type="button">
                         Reset password
                       </button>
-                      <button className="nav-logout" type="button" onClick={logout}>
+                      <button className="nav-logout" type="button" onClick={handleLogout}>
                         Log out
                       </button>
                     </div>

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -48,11 +48,13 @@ export function LoginPage() {
     completeLoginSession,
     isAuthenticated,
     isRestoringSession,
+    logout,
     user,
   } = useAuth()
   const [values, setValues] = useState(initialValues)
   const [errors, setErrors] = useState<LoginFormErrors>({})
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [resetPasswordNotice, setResetPasswordNotice] = useState('')
 
   const formNoticeId = useId()
   const titleId = 'login-title'
@@ -76,6 +78,10 @@ export function LoginPage() {
         form: undefined,
       }
     })
+
+    if (resetPasswordNotice) {
+      setResetPasswordNotice('')
+    }
   }
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -158,28 +164,16 @@ export function LoginPage() {
   return (
     <AuthPage titleId={titleId}>
         {isAuthenticated && user ? (
-          <div className="auth-state" role="status" aria-live="polite">
-            <AuthPageHeader
-              description={
-                user.email
-                  ? `The login for ${user.email} completed successfully.`
-                  : 'Your login completed successfully.'
-              }
-              eyebrow="Login Complete"
-              title="Your session is active."
-              titleId={titleId}
-            />
-            <p className="auth-copy">
-              The shared frontend auth session has stored your access token and can restore this
-              user across refreshes.
-            </p>
+          <div className="auth-state auth-state-welcome" role="status" aria-live="polite">
+            <div className="eyebrow">Login Complete</div>
+            <h1 className="auth-title" id={titleId}>
+              Welcome
+            </h1>
+            <p className="auth-welcome-name">{user.displayName}</p>
             <div className="auth-actions">
-              <Link className="demo-link" to="/">
-                Back to Home
-              </Link>
-              <Link className="secondary-link" to="/register">
-                Create another account
-              </Link>
+              <button className="demo-link auth-submit" type="button" onClick={logout}>
+                Log out
+              </button>
             </div>
           </div>
         ) : isRestoringSession && accessToken ? (
@@ -254,6 +248,12 @@ export function LoginPage() {
                 </div>
               ) : null}
 
+              {resetPasswordNotice ? (
+                <div className="form-note" role="status">
+                  {resetPasswordNotice}
+                </div>
+              ) : null}
+
               <button
                 className="demo-link auth-submit"
                 type="submit"
@@ -262,6 +262,21 @@ export function LoginPage() {
                 {isSubmitting ? 'Signing in...' : 'Sign in'}
               </button>
             </form>
+
+            <p className="auth-footnote">
+              Forgot your password?{' '}
+              <button
+                className="auth-link-button"
+                type="button"
+                onClick={() =>
+                  setResetPasswordNotice(
+                    'Password reset is not connected yet, but this option is now available in the frontend.',
+                  )
+                }
+              >
+                Reset it here
+              </button>
+            </p>
 
             <p className="auth-footnote">
               Need an account?{' '}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,6 +1,6 @@
 import { useId, useState } from 'react'
 import type { FormEvent } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { AuthPage, AuthPageHeader } from '../components/AuthPage'
 import { useAuth, type AuthenticatedUser } from '../auth/AuthContext'
 import { buildApiUrl } from '../lib/api'
@@ -51,6 +51,7 @@ export function LoginPage() {
     logout,
     user,
   } = useAuth()
+  const navigate = useNavigate()
   const [values, setValues] = useState(initialValues)
   const [errors, setErrors] = useState<LoginFormErrors>({})
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -161,6 +162,11 @@ export function LoginPage() {
     }
   }
 
+  function handleLogout() {
+    logout()
+    navigate('/login', { replace: true })
+  }
+
   return (
     <AuthPage titleId={titleId}>
         {isAuthenticated && user ? (
@@ -171,7 +177,7 @@ export function LoginPage() {
             </h1>
             <p className="auth-welcome-name">{user.displayName}</p>
             <div className="auth-actions">
-              <button className="demo-link auth-submit" type="button" onClick={logout}>
+              <button className="demo-link auth-submit" type="button" onClick={handleLogout}>
                 Log out
               </button>
             </div>

--- a/src/pages/SettingsPage.test.tsx
+++ b/src/pages/SettingsPage.test.tsx
@@ -49,11 +49,15 @@ describe('SettingsPage', () => {
 
     render(<SettingsPage />)
 
-    expect(screen.getByRole('heading', { name: /profile settings/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /profile details/i, level: 1 })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: /profile details/i, level: 2 })).not.toBeInTheDocument()
+    expect(
+      screen.getByText(/review the account details currently tied to your mage profile/i),
+    ).toBeInTheDocument()
+    expect(screen.getByLabelText(/email/i)).toHaveValue('artist@example.com')
     expect(screen.getByLabelText(/first name/i)).toHaveValue('Preset')
     expect(screen.getByLabelText(/last name/i)).toHaveValue('Artist')
-    expect(screen.getByText('artist@example.com')).toBeInTheDocument()
-    expect(screen.getByText('LOCAL')).toBeInTheDocument()
+    expect(screen.queryByText('LOCAL')).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: /reset password/i })).toBeInTheDocument()
   })
 

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -41,71 +41,49 @@ export function SettingsPage() {
 
   return (
     <main className="page-stack settings-page">
-      <section className="surface surface--page-header">
-        <div className="eyebrow">Settings</div>
-        <h1>Profile settings</h1>
-        <p className="page-lead">
-          Review the creator name tied to your account and keep password recovery close at hand.
-        </p>
-      </section>
-
       <section className="surface surface--page-panel">
-        <div className="settings-layout">
-          <section className="surface surface--soft settings-section" aria-labelledby="settings-profile-title">
-            <div className="settings-section__header">
-              <h2 id="settings-profile-title">Profile details</h2>
-              <p>These fields are seeded from the display name on your current account.</p>
+        <div className="eyebrow">Settings</div>
+        <h1 className="settings-title">Profile details</h1>
+        <p className="settings-lead">
+          Review the account details currently tied to your MAGE profile.
+        </p>
+
+        <section className="surface surface--soft settings-section" aria-label="Profile details">
+          <div className="settings-fields">
+            <div className="field-group">
+              <label htmlFor="settings-email">Email</label>
+              <input id="settings-email" name="email" readOnly type="email" value={user.email} />
             </div>
 
-            <div className="settings-form-grid">
-              <div className="field-group">
-                <label htmlFor="settings-first-name">First name</label>
-                <input
-                  id="settings-first-name"
-                  name="firstName"
-                  onChange={(event) => setFirstName(event.target.value)}
-                  placeholder="First name"
-                  type="text"
-                  value={firstName}
-                />
-              </div>
-
-              <div className="field-group">
-                <label htmlFor="settings-last-name">Last name</label>
-                <input
-                  id="settings-last-name"
-                  name="lastName"
-                  onChange={(event) => setLastName(event.target.value)}
-                  placeholder="Last name"
-                  type="text"
-                  value={lastName}
-                />
-              </div>
-            </div>
-          </section>
-
-          <section className="surface surface--soft settings-section" aria-labelledby="settings-account-title">
-            <div className="settings-section__header">
-              <h2 id="settings-account-title">Account access</h2>
-              <p>Keep your sign-in details visible in one place and trigger password recovery when needed.</p>
+            <div className="field-group">
+              <label htmlFor="settings-first-name">First name</label>
+              <input
+                id="settings-first-name"
+                name="firstName"
+                onChange={(event) => setFirstName(event.target.value)}
+                placeholder="First name"
+                type="text"
+                value={firstName}
+              />
             </div>
 
-            <dl className="settings-account-list">
-              <div>
-                <dt>Email</dt>
-                <dd>{user.email}</dd>
-              </div>
-              <div>
-                <dt>Sign-in provider</dt>
-                <dd>{user.authProvider}</dd>
-              </div>
-            </dl>
+            <div className="field-group">
+              <label htmlFor="settings-last-name">Last name</label>
+              <input
+                id="settings-last-name"
+                name="lastName"
+                onChange={(event) => setLastName(event.target.value)}
+                placeholder="Last name"
+                type="text"
+                value={lastName}
+              />
+            </div>
 
             <button className="preset-secondary-button settings-reset-button" type="button">
               Reset password
             </button>
-          </section>
-        </div>
+          </div>
+        </section>
       </section>
     </main>
   )

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useAuth } from '../auth/AuthContext'
 
 function splitDisplayName(displayName: string) {
@@ -18,14 +18,6 @@ function splitDisplayName(displayName: string) {
 
 export function SettingsPage() {
   const { user } = useAuth()
-  const [firstName, setFirstName] = useState('')
-  const [lastName, setLastName] = useState('')
-
-  useEffect(() => {
-    const nextNameFields = splitDisplayName(user?.displayName ?? '')
-    setFirstName(nextNameFields.firstName)
-    setLastName(nextNameFields.lastName)
-  }, [user?.displayName])
 
   if (!user) {
     return (
@@ -48,43 +40,70 @@ export function SettingsPage() {
           Review the account details currently tied to your MAGE profile.
         </p>
 
-        <section className="surface surface--soft settings-section" aria-label="Profile details">
-          <div className="settings-fields">
-            <div className="field-group">
-              <label htmlFor="settings-email">Email</label>
-              <input id="settings-email" name="email" readOnly type="email" value={user.email} />
-            </div>
-
-            <div className="field-group">
-              <label htmlFor="settings-first-name">First name</label>
-              <input
-                id="settings-first-name"
-                name="firstName"
-                onChange={(event) => setFirstName(event.target.value)}
-                placeholder="First name"
-                type="text"
-                value={firstName}
-              />
-            </div>
-
-            <div className="field-group">
-              <label htmlFor="settings-last-name">Last name</label>
-              <input
-                id="settings-last-name"
-                name="lastName"
-                onChange={(event) => setLastName(event.target.value)}
-                placeholder="Last name"
-                type="text"
-                value={lastName}
-              />
-            </div>
-
-            <button className="preset-secondary-button settings-reset-button" type="button">
-              Reset password
-            </button>
-          </div>
-        </section>
+        <ProfileDetailsForm
+          key={`${user.email}:${user.displayName}`}
+          displayName={user.displayName}
+          email={user.email}
+        />
       </section>
     </main>
+  )
+}
+
+type ProfileDetailsFormProps = {
+  displayName: string
+  email: string
+}
+
+function ProfileDetailsForm({ displayName, email }: ProfileDetailsFormProps) {
+  const [nameFields, setNameFields] = useState(() => splitDisplayName(displayName))
+
+  return (
+    <section className="surface surface--soft settings-section" aria-label="Profile details">
+      <div className="settings-fields">
+        <div className="field-group">
+          <label htmlFor="settings-email">Email</label>
+          <input id="settings-email" name="email" readOnly type="email" value={email} />
+        </div>
+
+        <div className="field-group">
+          <label htmlFor="settings-first-name">First name</label>
+          <input
+            id="settings-first-name"
+            name="firstName"
+            onChange={(event) =>
+              setNameFields((currentFields) => ({
+                ...currentFields,
+                firstName: event.target.value,
+              }))
+            }
+            placeholder="First name"
+            type="text"
+            value={nameFields.firstName}
+          />
+        </div>
+
+        <div className="field-group">
+          <label htmlFor="settings-last-name">Last name</label>
+          <input
+            id="settings-last-name"
+            name="lastName"
+            onChange={(event) =>
+              setNameFields((currentFields) => ({
+                ...currentFields,
+                lastName: event.target.value,
+              }))
+            }
+            placeholder="Last name"
+            type="text"
+            value={nameFields.lastName}
+          />
+        </div>
+
+        <button className="preset-secondary-button settings-reset-button" type="button">
+          Reset password
+        </button>
+      </div>
+    </section>
   )
 }


### PR DESCRIPTION
## Summary
- simplify the settings page into a tighter profile-details layout
- align the settings header with the create preset page structure
- remove the synchronous effect-based name-field initialization that triggered cascading render warnings

## What Changed
- kept the compact settings page with:
  - Settings eyebrow
  - Profile details title and short description
  - labeled Email, First name, Last name, and Reset password controls
- removed the duplicate inner profile-details heading/copy from the card
- replaced the `useEffect`-driven first/last-name state sync with a keyed `ProfileDetailsForm` that initializes from props without calling `setState` inside an effect

## Why
React was warning that the settings page was calling `setState` synchronously inside an effect when splitting `displayName` into first and last name. That pattern causes unnecessary extra renders and is not recommended.

## Testing
- npm.cmd test -- src/pages/SettingsPage.test.tsx

## Result
- the settings page stays visually simplified
- the first and last name fields still initialize from the current user display name
- the React cascading-render warning is removed
