### PR TITLE
85 namespace frontend api routes under api to avoid page route collisions

### DIFF
--- a/docs/login-page.md
+++ b/docs/login-page.md
@@ -9,7 +9,7 @@ This page handles the local email-and-password sign-in flow in the frontend. It 
 ## API contract
 
 - Method: `POST`
-- Endpoint: `/auth/login`
+- Endpoint: `/api/auth/login`
 - Content type: `application/json`
 
 Request body:
@@ -21,11 +21,11 @@ Request body:
 }
 ```
 
-The page reads `VITE_API_BASE_URL` at runtime. When the variable is set, requests are sent to `${VITE_API_BASE_URL}/auth/login`. When it is not set, the page uses same-origin `/auth/login`.
+The page reads `VITE_API_BASE_URL` at runtime. When the variable is set, requests are sent to `${VITE_API_BASE_URL}/api/auth/login`. When it is not set, the page uses same-origin `/api/auth/login`.
 
-When a stored access token exists, the frontend bootstraps auth state by calling `${VITE_API_BASE_URL}/users/me` or same-origin `/users/me`.
+When a stored access token exists, the frontend bootstraps auth state by calling `${VITE_API_BASE_URL}/api/users/me` or same-origin `/api/users/me`.
 
-For normal localhost development, the Vite dev server proxies same-origin `/auth/login` and `/users/me` requests to `http://localhost:8080`.
+For normal localhost development, the Vite dev server proxies same-origin `/api` requests to `http://localhost:8080`.
 
 ## UI behavior
 
@@ -33,7 +33,7 @@ For normal localhost development, the Vite dev server proxies same-origin `/auth
 - Validates email format on the client
 - Disables the submit button while the request is in flight
 - Stores the returned `accessToken` in browser storage after a successful login response
-- Restores the authenticated user on refresh through `GET /users/me`
+- Restores the authenticated user on refresh through `GET /api/users/me`
 - Shows backend validation errors from `details`
 - Shows invalid-credential or generic form errors when login fails
 - Clears invalid or expired stored tokens automatically
@@ -45,7 +45,7 @@ The shared frontend auth provider currently:
 
 - persists the login `accessToken` in browser storage
 - boots auth state on app load
-- calls `GET /users/me` when a stored token exists
+- calls `GET /api/users/me` when a stored token exists
 - clears the stored token if the backend responds with `401`
 - provides a shared authenticated request helper that sends `Authorization: Bearer <accessToken>`
 - exposes logout that clears the stored token and shared auth state
@@ -62,7 +62,7 @@ The shared frontend auth provider currently:
 
 `src/auth/AuthContext.test.tsx` covers:
 
-- `GET /users/me` during app bootstrap when a stored token exists
+- `GET /api/users/me` during app bootstrap when a stored token exists
 - restoring the authenticated user from a valid stored session
 - clearing invalid stored tokens on `401`
 - logout clearing shared auth state and browser storage

--- a/docs/registration-page.md
+++ b/docs/registration-page.md
@@ -9,7 +9,7 @@ This page is the first implemented account-management flow in the frontend. It c
 ## API contract
 
 - Method: `POST`
-- Endpoint: `/auth/register`
+- Endpoint: `/api/auth/register`
 - Content type: `application/json`
 
 Request body:
@@ -22,9 +22,9 @@ Request body:
 }
 ```
 
-The page reads `VITE_API_BASE_URL` at runtime. When the variable is set, requests are sent to `${VITE_API_BASE_URL}/auth/register`. When it is not set, the page uses same-origin `/auth/register`.
+The page reads `VITE_API_BASE_URL` at runtime. When the variable is set, requests are sent to `${VITE_API_BASE_URL}/api/auth/register`. When it is not set, the page uses same-origin `/api/auth/register`.
 
-For normal localhost development, the Vite dev server proxies same-origin `/auth/register` requests to `http://localhost:8080`.
+For normal localhost development, the Vite dev server proxies same-origin `/api` requests to `http://localhost:8080`.
 
 ## UI behavior
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+import App from './App'
+
+vi.mock('./components/Layout', () => ({
+  Layout: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('./pages/HomePage', () => ({
+  HomePage: () => <div>Home page</div>,
+}))
+
+vi.mock('./pages/LoginPage', () => ({
+  LoginPage: () => <div>Login page</div>,
+}))
+
+vi.mock('./pages/MyPresetsPage', () => ({
+  MyPresetsPage: () => <div>My presets page</div>,
+}))
+
+vi.mock('./pages/PresetDetailPage', () => ({
+  PresetDetailPage: () => <div>Preset detail page</div>,
+}))
+
+vi.mock('./pages/RegisterPage', () => ({
+  RegisterPage: () => <div>Register page</div>,
+}))
+
+vi.mock('./pages/CreatePresetPage', () => ({
+  CreatePresetPage: () => <div>Create preset page</div>,
+}))
+
+vi.mock('./pages/SettingsPage', () => ({
+  SettingsPage: () => <div>Settings page</div>,
+}))
+
+describe('App routing', () => {
+  it('allows direct preset detail visits without redirecting to login', async () => {
+    render(
+      <MemoryRouter initialEntries={['/presets/12']}>
+        <App />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('Preset detail page')).toBeInTheDocument()
+    expect(screen.queryByText('Login page')).not.toBeInTheDocument()
+  })
+
+  it('keeps settings behind authentication', async () => {
+    render(
+      <MemoryRouter initialEntries={['/settings']}>
+        <App />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Login page')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByText('Settings page')).not.toBeInTheDocument()
+  })
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,11 +53,7 @@ function App() {
           />
           <Route
             path="/presets/:id"
-            element={
-              <ProtectedRoute>
-                <PresetDetailPage />
-              </ProtectedRoute>
-            }
+            element={<PresetDetailPage />}
           />
           <Route path="/register" element={<RegisterPage />} />
           <Route path="/create-preset" element={<CreatePresetPage />} />

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { buildApiUrl } from './api'
+
+describe('buildApiUrl', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('prefixes relative paths with /api when no base url is configured', () => {
+    expect(buildApiUrl('/users/me')).toBe('/api/users/me')
+    expect(buildApiUrl('auth/login')).toBe('/api/auth/login')
+  })
+
+  it('does not duplicate an existing /api prefix', () => {
+    expect(buildApiUrl('/api/presets/12')).toBe('/api/presets/12')
+  })
+
+  it('joins the configured base url with the normalized api path', () => {
+    vi.stubEnv('VITE_API_BASE_URL', 'https://mage.example.com/')
+
+    expect(buildApiUrl('/presets/12')).toBe('https://mage.example.com/api/presets/12')
+  })
+
+  it('does not double-prefix /api when the configured base url already includes it', () => {
+    vi.stubEnv('VITE_API_BASE_URL', 'https://mage.example.com/api')
+
+    expect(buildApiUrl('/presets/12')).toBe('https://mage.example.com/api/presets/12')
+  })
+})

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,9 +1,27 @@
-export function buildApiUrl(path: string) {
-  const baseUrl = import.meta.env.VITE_API_BASE_URL?.trim()
+function normalizeApiPath(path: string) {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
 
-  if (!baseUrl) {
-    return path
+  if (normalizedPath === '/api' || normalizedPath.startsWith('/api/')) {
+    return normalizedPath
   }
 
-  return `${baseUrl.replace(/\/+$/, '')}${path.startsWith('/') ? path : `/${path}`}`
+  return `/api${normalizedPath}`
+}
+
+export function buildApiUrl(path: string) {
+  const baseUrl = import.meta.env.VITE_API_BASE_URL?.trim()
+  const apiPath = normalizeApiPath(path)
+
+  if (!baseUrl) {
+    return apiPath
+  }
+
+  const normalizedBaseUrl = baseUrl.replace(/\/+$/, '')
+
+  if (normalizedBaseUrl.endsWith('/api') && (apiPath === '/api' || apiPath.startsWith('/api/'))) {
+    const apiSuffix = apiPath.slice('/api'.length)
+    return apiSuffix ? `${normalizedBaseUrl}${apiSuffix}` : normalizedBaseUrl
+  }
+
+  return `${normalizedBaseUrl}${apiPath}`
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,15 +19,7 @@ export default defineConfig({
       allow: [workspaceRoot],
     },
     proxy: {
-      '/auth': {
-        target: backendProxyTarget,
-        changeOrigin: true,
-      },
-      '/users': {
-        target: backendProxyTarget,
-        changeOrigin: true,
-      },
-      '/presets': {
+      '/api': {
         target: backendProxyTarget,
         changeOrigin: true,
       },


### PR DESCRIPTION
## Summary
- move frontend API traffic to `/api/...` so page routes and API routes no longer collide in development
- make `/presets/:id` a public app route so direct preset detail visits render the player page instead of redirecting to login
- update frontend auth docs so the written API contract matches the new `/api` routing

## Problem
The frontend used `/presets/...` both for the React preset player route and for backend API requests. In local development, Vite proxied `/presets/**` to the backend, so direct browser visits to `/presets/:id` returned raw JSON instead of the React app. The route was also still wrapped in `ProtectedRoute`, which blocked signed-out public preset viewing in the UI. The docs were also still describing the old unprefixed auth endpoints.

## What Changed
- updated `buildApiUrl` to normalize app API requests under `/api`
- changed the Vite dev proxy to forward only `/api` to the backend
- removed `ProtectedRoute` from `/presets/:id`
- added tests for:
  - `/api` URL prefixing
  - direct preset detail route access without login redirect
  - preserving auth protection for `/settings`
- updated login and registration docs to describe `/api/auth/...` and `/api/users/me`

## Testing
- npm.cmd test -- src\lib\api.test.ts src\App.test.tsx src\pages\PresetDetailPage.test.tsx src\pages\MyPresetsPage.test.tsx src\auth\AuthContext.test.tsx src\pages\CreatePresetPage.test.tsx src\pages\RegisterPage.test.tsx
- npm.cmd run build
