### PR TITLE
Fix stale login success test expectations

### DIFF
--- a/src/pages/LoginPage.test.tsx
+++ b/src/pages/LoginPage.test.tsx
@@ -92,9 +92,10 @@ describe('LoginPage', () => {
     )
 
     expect(
-      await screen.findByRole('heading', { name: /your session is active/i }),
+      await screen.findByRole('heading', { name: /^welcome$/i }),
     ).toBeInTheDocument()
-    expect(screen.getByText(/login for user@example.com completed successfully/i)).toBeInTheDocument()
+    expect(screen.getByText('Existing User')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /log out/i })).toBeInTheDocument()
     expect(window.localStorage.getItem(AUTH_SESSION_STORAGE_KEY)).toContain('issued-login-token')
   })
 


### PR DESCRIPTION
## Summary
- update the login page success-path test to match the current signed-in UI
- keep coverage for trimmed login payloads, loading state, and auth session storage
- remove the outdated assertion that expected an older post-login success message

## Problem
`src/pages/LoginPage.test.tsx` was asserting an old success-state heading and message that the current `LoginPage` no longer renders. The component now shows the signed-in welcome state with the user's display name and a log out button, so the test was failing even though the login flow itself was working.

## What Changed
- replaced the outdated success assertions with checks for:
  - the `Welcome` heading
  - the authenticated user's display name
  - the `Log out` button
- kept the existing assertions for:
  - trimmed login request payload
  - disabled submit button during submission
  - access token persistence in local storage

## Testing
- npm.cmd test -- src/pages/LoginPage.test.tsx

## Result
- the login page test now reflects the current UI behavior
- the success-path test passes without changing the component behavior
