### PR TITLE
Route auth flows into settings experience

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,8 +1,9 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { MemoryRouter } from 'react-router-dom'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import App from './App'
+import { AUTH_SESSION_STORAGE_KEY } from './auth/AuthContext'
 
 vi.mock('./components/Layout', () => ({
   Layout: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -37,6 +38,11 @@ vi.mock('./pages/SettingsPage', () => ({
 }))
 
 describe('App routing', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
   it('allows direct preset detail visits without redirecting to login', async () => {
     render(
       <MemoryRouter initialEntries={['/presets/12']}>
@@ -60,5 +66,93 @@ describe('App routing', () => {
     })
 
     expect(screen.queryByText('Settings page')).not.toBeInTheDocument()
+  })
+
+  it('redirects authenticated users away from login to settings', async () => {
+    window.localStorage.setItem(
+      AUTH_SESSION_STORAGE_KEY,
+      JSON.stringify({
+        accessToken: 'saved-token',
+        user: {
+          userId: 14,
+          email: 'user@example.com',
+          displayName: 'Existing User',
+          authProvider: 'LOCAL',
+        },
+      }),
+    )
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          userId: 14,
+          email: 'user@example.com',
+          displayName: 'Existing User',
+          authProvider: 'LOCAL',
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      ),
+    )
+
+    render(
+      <MemoryRouter initialEntries={['/login']}>
+        <App />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Settings page')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByText('Login page')).not.toBeInTheDocument()
+  })
+
+  it('redirects authenticated users away from register to settings', async () => {
+    window.localStorage.setItem(
+      AUTH_SESSION_STORAGE_KEY,
+      JSON.stringify({
+        accessToken: 'saved-token',
+        user: {
+          userId: 14,
+          email: 'user@example.com',
+          displayName: 'Existing User',
+          authProvider: 'LOCAL',
+        },
+      }),
+    )
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          userId: 14,
+          email: 'user@example.com',
+          displayName: 'Existing User',
+          authProvider: 'LOCAL',
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      ),
+    )
+
+    render(
+      <MemoryRouter initialEntries={['/register']}>
+        <App />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Settings page')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByText('Register page')).not.toBeInTheDocument()
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,21 +16,39 @@ type ProtectedRouteProps = {
   children: ReactElement
 }
 
+function SessionRestoreState() {
+  return (
+    <main className="card">
+      <div className="eyebrow">Session</div>
+      <h1>Checking your login...</h1>
+      <p className="sub">MAGE is restoring your account before opening this page.</p>
+    </main>
+  )
+}
+
 function ProtectedRoute({ children }: ProtectedRouteProps) {
   const { isAuthenticated, isRestoringSession } = useAuth()
 
   if (isRestoringSession) {
-    return (
-      <main className="card">
-        <div className="eyebrow">Session</div>
-        <h1>Checking your login...</h1>
-        <p className="sub">MAGE is restoring your account before opening this page.</p>
-      </main>
-    )
+    return <SessionRestoreState />
   }
 
   if (!isAuthenticated) {
     return <Navigate replace to="/login" />
+  }
+
+  return children
+}
+
+function GuestOnlyRoute({ children }: ProtectedRouteProps) {
+  const { isAuthenticated, isRestoringSession } = useAuth()
+
+  if (isRestoringSession) {
+    return <SessionRestoreState />
+  }
+
+  if (isAuthenticated) {
+    return <Navigate replace to="/settings" />
   }
 
   return children
@@ -42,7 +60,14 @@ function App() {
       <Layout>
         <Routes>
           <Route path="/" element={<HomePage />} />
-          <Route path="/login" element={<LoginPage />} />
+          <Route
+            path="/login"
+            element={
+              <GuestOnlyRoute>
+                <LoginPage />
+              </GuestOnlyRoute>
+            }
+          />
           <Route
             path="/my-presets"
             element={
@@ -55,7 +80,14 @@ function App() {
             path="/presets/:id"
             element={<PresetDetailPage />}
           />
-          <Route path="/register" element={<RegisterPage />} />
+          <Route
+            path="/register"
+            element={
+              <GuestOnlyRoute>
+                <RegisterPage />
+              </GuestOnlyRoute>
+            }
+          />
           <Route path="/create-preset" element={<CreatePresetPage />} />
           <Route
             path="/settings"

--- a/src/pages/LoginPage.test.tsx
+++ b/src/pages/LoginPage.test.tsx
@@ -1,16 +1,33 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { describe, expect, it, vi } from 'vitest'
 import { AUTH_SESSION_STORAGE_KEY, AuthProvider } from '../auth/AuthContext'
 import { buildApiUrl } from '../lib/api'
 import { LoginPage } from './LoginPage'
 
-function renderLoginPage() {
+type RenderLoginPageOptions = {
+  locationState?: {
+    registrationEmail?: string
+    registrationNotice?: string
+  }
+}
+
+function renderLoginPage(options: RenderLoginPageOptions = {}) {
   return render(
-    <MemoryRouter>
+    <MemoryRouter
+      initialEntries={[
+        {
+          pathname: '/login',
+          state: options.locationState,
+        },
+      ]}
+    >
       <AuthProvider>
-        <LoginPage />
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/settings" element={<div>Settings page</div>} />
+        </Routes>
       </AuthProvider>
     </MemoryRouter>,
   )
@@ -43,7 +60,7 @@ describe('LoginPage', () => {
     expect(fetchSpy).not.toHaveBeenCalled()
   })
 
-  it('submits trimmed values, disables the button while loading, and shows success', async () => {
+  it('submits trimmed values, disables the button while loading, and routes to settings', async () => {
     let resolveResponse: ((value: Response) => void) | undefined
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
       () =>
@@ -91,12 +108,22 @@ describe('LoginPage', () => {
       ),
     )
 
-    expect(
-      await screen.findByRole('heading', { name: /^welcome$/i }),
-    ).toBeInTheDocument()
-    expect(screen.getByText('Existing User')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /log out/i })).toBeInTheDocument()
+    expect(await screen.findByText('Settings page')).toBeInTheDocument()
     expect(window.localStorage.getItem(AUTH_SESSION_STORAGE_KEY)).toContain('issued-login-token')
+  })
+
+  it('prefills the email and shows the registration handoff notice', () => {
+    renderLoginPage({
+      locationState: {
+        registrationEmail: 'new-user@example.com',
+        registrationNotice: 'Account created. Sign in to open your profile.',
+      },
+    })
+
+    expect(screen.getByLabelText(/^email$/i)).toHaveValue('new-user@example.com')
+    expect(
+      screen.getByText('Account created. Sign in to open your profile.'),
+    ).toBeInTheDocument()
   })
 
   it('shows backend invalid-credential errors clearly to the user', async () => {

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,6 +1,6 @@
 import { useId, useState } from 'react'
 import type { FormEvent } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, Navigate, useLocation, useNavigate } from 'react-router-dom'
 import { AuthPage, AuthPageHeader } from '../components/AuthPage'
 import { useAuth, type AuthenticatedUser } from '../auth/AuthContext'
 import { buildApiUrl } from '../lib/api'
@@ -21,9 +21,31 @@ type LoginResponse = {
   accessToken?: string
 }
 
+type LoginLocationState = {
+  registrationEmail?: string
+  registrationNotice?: string
+}
+
 const initialValues: LoginFormValues = {
   email: '',
   password: '',
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function readLoginLocationState(state: unknown): LoginLocationState {
+  if (!isRecord(state)) {
+    return {}
+  }
+
+  return {
+    registrationEmail:
+      typeof state.registrationEmail === 'string' ? state.registrationEmail : undefined,
+    registrationNotice:
+      typeof state.registrationNotice === 'string' ? state.registrationNotice : undefined,
+  }
 }
 
 function validateLoginForm(values: LoginFormValues): LoginFormErrors {
@@ -48,19 +70,25 @@ export function LoginPage() {
     completeLoginSession,
     isAuthenticated,
     isRestoringSession,
-    logout,
-    user,
   } = useAuth()
+  const location = useLocation()
   const navigate = useNavigate()
-  const [values, setValues] = useState(initialValues)
+  const loginLocationState = readLoginLocationState(location.state)
+  const [values, setValues] = useState<LoginFormValues>(() => ({
+    ...initialValues,
+    email: loginLocationState.registrationEmail ?? '',
+  }))
   const [errors, setErrors] = useState<LoginFormErrors>({})
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [resetPasswordNotice, setResetPasswordNotice] = useState('')
+  const [registrationNotice, setRegistrationNotice] = useState(
+    loginLocationState.registrationNotice ?? '',
+  )
 
   const formNoticeId = useId()
   const titleId = 'login-title'
 
-  const isSubmitDisabled = isSubmitting || isAuthenticated
+  const isSubmitDisabled = isSubmitting
 
   function handleChange(field: keyof LoginFormValues, nextValue: string) {
     setValues((currentValues) => ({
@@ -82,6 +110,10 @@ export function LoginPage() {
 
     if (resetPasswordNotice) {
       setResetPasswordNotice('')
+    }
+
+    if (registrationNotice) {
+      setRegistrationNotice('')
     }
   }
 
@@ -153,6 +185,7 @@ export function LoginPage() {
         user: authenticatedUser,
       })
       setValues(initialValues)
+      navigate('/settings', { replace: true })
     } catch {
       setErrors({
         form: 'Login is unavailable right now. Please try again in a moment.',
@@ -162,27 +195,13 @@ export function LoginPage() {
     }
   }
 
-  function handleLogout() {
-    logout()
-    navigate('/login', { replace: true })
+  if (isAuthenticated) {
+    return <Navigate replace to="/settings" />
   }
 
   return (
     <AuthPage titleId={titleId}>
-        {isAuthenticated && user ? (
-          <div className="auth-state auth-state-welcome" role="status" aria-live="polite">
-            <div className="eyebrow">Login Complete</div>
-            <h1 className="auth-title" id={titleId}>
-              Welcome
-            </h1>
-            <p className="auth-welcome-name">{user.displayName}</p>
-            <div className="auth-actions">
-              <button className="demo-link auth-submit" type="button" onClick={handleLogout}>
-                Log out
-              </button>
-            </div>
-          </div>
-        ) : isRestoringSession && accessToken ? (
+        {isRestoringSession && accessToken ? (
           <div className="auth-state" role="status" aria-live="polite">
             <AuthPageHeader
               description="MAGE found a stored access token and is verifying it with the backend."
@@ -251,6 +270,12 @@ export function LoginPage() {
               {errors.form ? (
                 <div className="form-alert" id={formNoticeId} role="alert">
                   {errors.form}
+                </div>
+              ) : null}
+
+              {registrationNotice ? (
+                <div className="form-note" role="status">
+                  {registrationNotice}
                 </div>
               ) : null}
 

--- a/src/pages/RegisterPage.test.tsx
+++ b/src/pages/RegisterPage.test.tsx
@@ -1,14 +1,21 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { describe, expect, it, vi } from 'vitest'
+import { AuthProvider } from '../auth/AuthContext'
 import { buildApiUrl } from '../lib/api'
+import { LoginPage } from './LoginPage'
 import { RegisterPage } from './RegisterPage'
 
 function renderRegisterPage() {
   return render(
-    <MemoryRouter>
-      <RegisterPage />
+    <MemoryRouter initialEntries={['/register']}>
+      <AuthProvider>
+        <Routes>
+          <Route path="/register" element={<RegisterPage />} />
+          <Route path="/login" element={<LoginPage />} />
+        </Routes>
+      </AuthProvider>
     </MemoryRouter>,
   )
 }
@@ -34,7 +41,7 @@ describe('RegisterPage', () => {
     expect(fetchSpy).not.toHaveBeenCalled()
   })
 
-  it('submits trimmed values, disables the button while loading, and shows success', async () => {
+  it('submits trimmed values, disables the button while loading, and hands the user into login', async () => {
     let resolveResponse: ((value: Response) => void) | undefined
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
       () =>
@@ -74,10 +81,11 @@ describe('RegisterPage', () => {
       }),
     )
 
+    expect(await screen.findByRole('heading', { name: /^login$/i })).toBeInTheDocument()
+    expect(screen.getByLabelText(/^email$/i)).toHaveValue('user@example.com')
     expect(
-      await screen.findByRole('heading', { name: /your account request was submitted/i }),
+      screen.getByText('Account created. Sign in to open your profile.'),
     ).toBeInTheDocument()
-    expect(screen.getByText(/registration for user@example.com completed successfully/i)).toBeInTheDocument()
   })
 
   it('shows backend conflict errors clearly to the user', async () => {

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -1,6 +1,6 @@
 import { useId, useState } from 'react'
 import type { FormEvent } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { AuthPage, AuthPageHeader } from '../components/AuthPage'
 import { buildApiUrl } from '../lib/api'
 import { emailPattern, parseApiError } from '../lib/authForm'
@@ -52,16 +52,15 @@ function validateRegistrationForm(values: RegistrationFormValues): RegistrationF
 }
 
 export function RegisterPage() {
+  const navigate = useNavigate()
   const [values, setValues] = useState(initialValues)
   const [errors, setErrors] = useState<RegistrationFormErrors>({})
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [isSuccess, setIsSuccess] = useState(false)
-  const [successEmail, setSuccessEmail] = useState('')
 
   const formErrorId = useId()
   const titleId = 'register-title'
 
-  const isSubmitDisabled = isSubmitting || isSuccess
+  const isSubmitDisabled = isSubmitting
 
   function handleChange(field: keyof RegistrationFormValues, nextValue: string) {
     setValues((currentValues) => ({
@@ -131,9 +130,14 @@ export function RegisterPage() {
       }
 
       const payload = (await response.json().catch(() => null)) as RegistrationResponse | null
-      setIsSuccess(true)
-      setSuccessEmail(payload?.email ?? trimmedValues.email)
       setValues(initialValues)
+      navigate('/login', {
+        replace: true,
+        state: {
+          registrationEmail: payload?.email ?? trimmedValues.email,
+          registrationNotice: 'Account created. Sign in to open your profile.',
+        },
+      })
     } catch {
       setErrors({
         form: 'Registration is unavailable right now. Please try again in a moment.',
@@ -145,121 +149,98 @@ export function RegisterPage() {
 
   return (
     <AuthPage titleId={titleId}>
-        {isSuccess ? (
-          <div className="auth-state" role="status" aria-live="polite">
-            <AuthPageHeader
-              description={
-                successEmail
-                  ? `The registration for ${successEmail} completed successfully.`
-                  : 'Your registration completed successfully.'
-              }
-              eyebrow="Registration Complete"
-              title="Your account request was submitted."
-              titleId={titleId}
-            />
-            <div className="auth-actions">
-              <Link className="demo-link" to="/login">
-                Continue to Login
-              </Link>
-              <Link className="secondary-link" to="/">
-                Back to Home
-              </Link>
-            </div>
-          </div>
-        ) : (
-          <>
-            <AuthPageHeader
-              description="Use your email address to create a local account for the MAGE platform."
-              eyebrow="Create Account"
-              title="Register"
-              titleId={titleId}
-            />
+        <>
+          <AuthPageHeader
+            description="Use your email address to create a local account for the MAGE platform."
+            eyebrow="Create Account"
+            title="Register"
+            titleId={titleId}
+          />
 
-            <form className="auth-form" noValidate onSubmit={handleSubmit}>
-              <div className="field-group">
-                <label htmlFor="displayName">Display name</label>
-                <input
-                  id="displayName"
-                  name="displayName"
-                  type="text"
-                  autoComplete="nickname"
-                  required
-                  minLength={2}
-                  value={values.displayName}
-                  onChange={(event) => handleChange('displayName', event.target.value)}
-                  aria-invalid={Boolean(errors.displayName)}
-                  aria-describedby={errors.displayName ? 'displayName-error' : undefined}
-                  placeholder="Mir Ahnaf Ali"
-                />
-                {errors.displayName ? (
-                  <p className="field-error" id="displayName-error" role="alert">
-                    {errors.displayName}
-                  </p>
-                ) : null}
-              </div>
-
-              <div className="field-group">
-                <label htmlFor="email">Email</label>
-                <input
-                  id="email"
-                  name="email"
-                  type="email"
-                  autoComplete="email"
-                  required
-                  value={values.email}
-                  onChange={(event) => handleChange('email', event.target.value)}
-                  aria-invalid={Boolean(errors.email)}
-                  aria-describedby={errors.email ? 'email-error' : undefined}
-                  placeholder="you@example.com"
-                />
-                {errors.email ? (
-                  <p className="field-error" id="email-error" role="alert">
-                    {errors.email}
-                  </p>
-                ) : null}
-              </div>
-
-              <div className="field-group">
-                <label htmlFor="password">Password</label>
-                <input
-                  id="password"
-                  name="password"
-                  type="password"
-                  autoComplete="new-password"
-                  required
-                  minLength={8}
-                  value={values.password}
-                  onChange={(event) => handleChange('password', event.target.value)}
-                  aria-invalid={Boolean(errors.password)}
-                  aria-describedby={errors.password ? 'password-error' : undefined}
-                  placeholder="At least 8 characters"
-                />
-                {errors.password ? (
-                  <p className="field-error" id="password-error" role="alert">
-                    {errors.password}
-                  </p>
-                ) : null}
-              </div>
-
-              {errors.form ? (
-                <div className="form-alert" id={formErrorId} role="alert">
-                  {errors.form}
-                </div>
+          <form className="auth-form" noValidate onSubmit={handleSubmit}>
+            <div className="field-group">
+              <label htmlFor="displayName">Display name</label>
+              <input
+                id="displayName"
+                name="displayName"
+                type="text"
+                autoComplete="nickname"
+                required
+                minLength={2}
+                value={values.displayName}
+                onChange={(event) => handleChange('displayName', event.target.value)}
+                aria-invalid={Boolean(errors.displayName)}
+                aria-describedby={errors.displayName ? 'displayName-error' : undefined}
+                placeholder="Mir Ahnaf Ali"
+              />
+              {errors.displayName ? (
+                <p className="field-error" id="displayName-error" role="alert">
+                  {errors.displayName}
+                </p>
               ) : null}
+            </div>
 
-              <button className="demo-link auth-submit" type="submit" disabled={isSubmitDisabled}>
-                {isSubmitting ? 'Creating account...' : 'Create account'}
-              </button>
-            </form>
+            <div className="field-group">
+              <label htmlFor="email">Email</label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                autoComplete="email"
+                required
+                value={values.email}
+                onChange={(event) => handleChange('email', event.target.value)}
+                aria-invalid={Boolean(errors.email)}
+                aria-describedby={errors.email ? 'email-error' : undefined}
+                placeholder="you@example.com"
+              />
+              {errors.email ? (
+                <p className="field-error" id="email-error" role="alert">
+                  {errors.email}
+                </p>
+              ) : null}
+            </div>
 
-            <p className="auth-footnote">
-              Already have an account?{' '}
-              <Link className="secondary-link" to="/login">
-                Go to login
-              </Link>
-            </p>
-          </>
-        )}
+            <div className="field-group">
+              <label htmlFor="password">Password</label>
+              <input
+                id="password"
+                name="password"
+                type="password"
+                autoComplete="new-password"
+                required
+                minLength={8}
+                value={values.password}
+                onChange={(event) => handleChange('password', event.target.value)}
+                aria-invalid={Boolean(errors.password)}
+                aria-describedby={errors.password ? 'password-error' : undefined}
+                placeholder="At least 8 characters"
+              />
+              {errors.password ? (
+                <p className="field-error" id="password-error" role="alert">
+                  {errors.password}
+                </p>
+              ) : null}
+            </div>
+
+            {errors.form ? (
+              <div className="form-alert" id={formErrorId} role="alert">
+                {errors.form}
+              </div>
+            ) : null}
+
+            <button className="demo-link auth-submit" type="submit" disabled={isSubmitDisabled}>
+              {isSubmitting ? 'Creating account...' : 'Create account'}
+            </button>
+          </form>
+
+          <p className="auth-footnote">
+            Already have an account?{' '}
+            <Link className="secondary-link" to="/login">
+              Go to login
+            </Link>
+          </p>
+        </>
     </AuthPage>
   )
 }


### PR DESCRIPTION
## Summary
- route successful login into the authenticated settings page instead of leaving users on a page-local success state
- hand successful registration directly into the login flow with a prefilled email and clear next-step notice
- prevent already signed-in users from lingering on `/login` and `/register` by redirecting them to `/settings`

## Problem
The authenticated account experience was only partially wired. Users could sign in and restore a session, but successful login stayed on `/login`, registration ended on a local success screen, and already signed-in users could still sit on guest-only auth routes.

## What Changed
- added a guest-only route guard for `/login` and `/register`
- kept the existing protected-route behavior for authenticated pages
- updated `LoginPage` so a successful sign-in:
  - stores the authenticated session
  - navigates to `/settings`
- updated `LoginPage` to accept registration handoff state:
  - prefills the email field
  - shows a sign-in next-step notice
- updated `RegisterPage` so a successful registration:
  - navigates directly to `/login`
  - carries the registered email into the login form
  - shows a clear handoff message instead of a standalone success screen
- added routing tests that verify authenticated users are redirected away from `/login` and `/register`
- updated login and registration page tests to cover the new route-based flow

## Testing
- npm.cmd test -- src/auth/AuthContext.test.tsx src/App.test.tsx src/pages/LoginPage.test.tsx src/pages/RegisterPage.test.tsx src/pages/MyPresetsPage.test.tsx src/pages/CreatePresetPage.test.tsx
- npm.cmd run build

## Result
- successful login navigates to an authenticated route
- the authenticated page continues to use backend-backed current-user data
- unauthenticated access to `/settings` still redirects to `/login`
- already authenticated users no longer remain on `/login` or `/register`
- registration now hands the user cleanly into the sign-in flow
