### PR TITLE
Feat/npm engine create preset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "mage-frontend",
       "version": "0.0.0",
       "dependencies": {
-        "mage": "file:../NPM-engine/MAGE/mage-1.0.0.tgz",
+        "mage": "file:../mage-engine/mage-1.0.0.tgz",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.13.1"
@@ -4155,7 +4155,7 @@
     },
     "node_modules/mage": {
       "version": "1.0.0",
-      "resolved": "file:../NPM-engine/MAGE/mage-1.0.0.tgz",
+      "resolved": "file:../mage-engine/mage-1.0.0.tgz",
       "integrity": "sha512-dhTBQiXESn99tuOpeHR4CxYivqNx41AxJFr41IHqSY1lMKAgQzJgeCJz/UbQTEcZWDEwa8ezuMmUXjGw+dzLNw==",
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mage-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "mage": "file:../NPM-engine/MAGE/mage-1.0.0.tgz",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.13.1"
@@ -104,7 +105,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -119,7 +119,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
       "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -129,9 +128,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -161,7 +158,6 @@
       "version": "7.29.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
       "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -178,7 +174,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
@@ -195,7 +190,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -205,7 +199,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
       "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.6",
@@ -219,7 +212,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
@@ -237,7 +229,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -247,7 +238,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -257,7 +247,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -267,7 +256,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
       "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
@@ -281,7 +269,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
       "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -307,7 +294,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
@@ -322,7 +308,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
       "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -341,7 +326,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -502,6 +486,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1177,7 +1192,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1188,7 +1202,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -1199,7 +1212,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1209,18 +1221,285 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1228,6 +1507,60 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.2.tgz",
       "integrity": "sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/plugin-babel": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-6.1.0.tgz",
+      "integrity": "sha512-dFZNuFD2YRcoomP4oYf+DvQNSUA9ih+A3vUqopQx5EdtPGo3WBnQcI/S8pwpz91UsGfL0HsMSOlaMld8HrbubA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.18.6",
+        "@rollup/pluginutils": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "@types/babel__core": "^7.1.9",
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/babel__core": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1580,6 +1913,15 @@
         "win32"
       ]
     },
+    "node_modules/@shaderfrog/glsl-parser": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@shaderfrog/glsl-parser/-/glsl-parser-0.2.4.tgz",
+      "integrity": "sha512-zXkTyWRc0WqJFIlGVQqGgGGL/WZHnNSesXnH4tMJ4Q3prCjYdJOxajyw/7YBP6Epe+hCf8MTTGnuIljh3i42Ng==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1903,6 +2245,16 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -1933,7 +2285,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -1947,9 +2298,8 @@
       "version": "24.12.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1960,7 +2310,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2020,7 +2369,6 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -2407,7 +2755,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2507,7 +2854,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
       "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -2541,7 +2887,6 @@
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2557,7 +2902,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2586,7 +2930,6 @@
       "version": "1.0.30001777",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz",
       "integrity": "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2661,7 +3004,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
@@ -2738,7 +3080,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2776,6 +3117,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -2788,7 +3138,6 @@
       "version": "1.5.307",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
       "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/entities": {
@@ -2815,7 +3164,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2857,7 +3206,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2876,13 +3224,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
     "node_modules/eslint": {
       "version": "9.39.4",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3015,6 +3383,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -3045,7 +3426,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -3065,7 +3445,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -3106,7 +3485,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -3175,7 +3553,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3190,7 +3567,6 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3350,7 +3726,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -3421,7 +3796,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -3455,7 +3829,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -3488,6 +3861,255 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -3515,7 +4137,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -3530,6 +4151,96 @@
       "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/mage": {
+      "version": "1.0.0",
+      "resolved": "file:../NPM-engine/MAGE/mage-1.0.0.tgz",
+      "integrity": "sha512-dhTBQiXESn99tuOpeHR4CxYivqNx41AxJFr41IHqSY1lMKAgQzJgeCJz/UbQTEcZWDEwa8ezuMmUXjGw+dzLNw==",
+      "license": "ISC",
+      "dependencies": {
+        "mage": "file:mage-1.0.0.tgz",
+        "shader-park-core": "^0.2.8",
+        "three": "^0.183.2",
+        "tweakpane": "^4.0.5",
+        "vite": "^8.0.0"
+      }
+    },
+    "node_modules/mage/node_modules/vite": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.15",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
       }
     },
     "node_modules/magic-string": {
@@ -3576,14 +4287,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3609,7 +4318,6 @@
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/obug": {
@@ -3730,16 +4438,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3751,7 +4456,6 @@
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
       "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3831,7 +4535,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3841,7 +4544,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3929,11 +4631,50 @@
         "node": ">=4"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "license": "MIT"
+    },
     "node_modules/rollup": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -3997,7 +4738,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4007,6 +4747,29 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/shader-park-core": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/shader-park-core/-/shader-park-core-0.2.8.tgz",
+      "integrity": "sha512-u6jJk7jFGUfhN0PF36ijsZt44e0Dk90Q8ZQPmxbZCIMykgdNO9aEXwOOZHRyvU5ur+nFVCXoFV7RKqhSejkK3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@rollup/plugin-babel": "^6.0.3",
+        "@shaderfrog/glsl-parser": "^0.2.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1",
+        "three": "^0.155.0"
+      },
+      "bin": {
+        "toMinimal": "converters/convertMinimalRender.js",
+        "toThreeJS": "converters/convertThreeJS.js"
+      }
+    },
+    "node_modules/shader-park-core/node_modules/three": {
+      "version": "0.155.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.155.0.tgz",
+      "integrity": "sha512-sNgCYmDijnIqkD/bMfk+1pHg3YzsxW7V2ChpuP6HCQ8NiZr3RufsXQr8M3SSUMjW4hG+sUk7YbyuY0DncaDTJQ==",
       "license": "MIT"
     },
     "node_modules/shebang-command": {
@@ -4039,11 +4802,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -4109,6 +4881,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/three": {
+      "version": "0.183.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.183.2.tgz",
+      "integrity": "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -4130,7 +4908,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -4212,6 +4989,22 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/tweakpane": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/tweakpane/-/tweakpane-4.0.5.tgz",
+      "integrity": "sha512-rxEXdSI+ArlG1RyO6FghC4ZUX8JkEfz8F3v1JuteXSV0pEtHJzyo07fcDG+NsJfN5L39kSbCYbB9cBGHyuI/tQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/cocopon"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4231,7 +5024,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4278,14 +5070,13 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4328,7 +5119,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4592,7 +5382,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yocto-queue": {
@@ -4614,7 +5403,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "mage": "file:../NPM-engine/MAGE/mage-1.0.0.tgz",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.13.1"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "mage": "file:../NPM-engine/MAGE/mage-1.0.0.tgz",
+    "mage": "file:../mage-engine/mage-1.0.0.tgz",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.13.1"

--- a/src/lib/embeddedShaderPresets.ts
+++ b/src/lib/embeddedShaderPresets.ts
@@ -1,0 +1,517 @@
+import type { ShaderPresetOption } from './presetEditor'
+
+export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
+  {
+    id: 'embedded-preset-0',
+    label: 'Prism Core',
+    description: 'Bundled NPM-engine preset with layered box frames and a reflective core sphere.',
+    shader: `
+      let size = input()
+      let pointerDown = input()
+      time = .3*time
+      size *= 1.3
+      rotateY(mouse.x * -2 * PI / 2 * (1+nsin(time)))
+      rotateX(mouse.y * 2 * PI / 2 * (1+nsin(time)))
+      metal(.5*size)
+      let rayDir = normalize(getRayDirection())
+      let clampedColor = vec3(rayDir.x+.2, rayDir.y+.25, rayDir.z+.2)
+      color(clampedColor)
+
+      rotateY(sin(getRayDirection().y*8*(ncos(sin(time)))+size))
+      rotateX(cos((getRayDirection().x*16*nsin(time)+size)))
+      rotateZ(ncos((getRayDirection().z*4*cos(time)+size)))
+      boxFrame(vec3(size), size*.1)
+      shine(0.8*size)
+      blend(nsin(time*(size))*0.1+0.1)
+      sphere(size/2-pointerDown*.3)
+      blend(ncos((time*(size)))*0.1+0.1)
+      boxFrame(vec3(size-.075*pointerDown), size)
+    `,
+  },
+  {
+    id: 'embedded-preset-1',
+    label: 'Steel Lattice',
+    description: 'Bundled NPM-engine preset built from stacked grids and box frames.',
+    shader: `
+      setMaxIterations(101);
+      setStepSize(0.7260629659452175);
+
+      let size = input();
+      let pointerDown = input();
+      time *= .1;
+      rotateY(mouse.x * -5 * PI / 2 + time - (pointerDown + 0.1));
+      rotateX(mouse.y * 5 * PI / 2 + time);
+
+      color(0.43262751221303614, 0.4925493880484813, 0.4820048306239232);
+
+      rotateX(getRayDirection().y * 1.2506225601940093 + time);
+      rotateY(getRayDirection().x * 1.2506225601940093 + time);
+      rotateZ(getRayDirection().z * 1.2506225601940093 + time);
+
+      metal(0.5870582642599769 * size);
+      shine(0.6708057727257557);
+
+      grid(
+        3,
+        size * 0.7174867540818692 - pointerDown * 0.05 / 3,
+        0.01 * size * 0.7174867540818692 - pointerDown * 0.05,
+      );
+      boxFrame(
+        vec3(size * 0.6287507765216367 - pointerDown * 0.05),
+        size * 0.6287507765216367 - pointerDown * 0.05 * 0.1,
+      );
+      boxFrame(
+        vec3(size * 0.6816361304019778 - pointerDown * 0.05),
+        size * 0.6816361304019778 - pointerDown * 0.05 * 0.1,
+      );
+
+      blend(nsin(time * size) * 0.22812291319767167);
+
+      boxFrame(vec3(size * 0.7), size * 0.05);
+    `,
+  },
+  {
+    id: 'embedded-preset-2',
+    label: 'Aqua Static',
+    description: 'Bundled NPM-engine preset with noisy box frames and layered grid distortion.',
+    shader: `
+      setMaxIterations(133);
+      setStepSize(0.8632297724861512);
+
+      let size = input();
+      let pointerDown = input();
+      time *= 0.131579219319508;
+      rotateY(mouse.x * -5 * PI / 2 + time - (pointerDown + 0.1));
+      rotateX(mouse.y * 5 * PI / 2 + time);
+
+      color(0.08256470259178794, 0.782309705948631, 0.763003005740327);
+
+      let s = getSpace();
+
+      rotateX(getRayDirection().y * 2.154824707715323 + time);
+      rotateY(getRayDirection().x * 2.583074645636565 + time);
+      rotateZ(getRayDirection().z * 2.9303390219795165 + time);
+
+      metal(0.5728721327171771 * size);
+      shine(0.36898649780731946);
+
+      expand(noise(s * 0.1080185521425232) * 0.39571611124777173);
+      boxFrame(
+        vec3(size * 0.8865473246350158 - pointerDown * 0.05),
+        size * 0.8865473246350158 - pointerDown * 0.05 * 0.1,
+      );
+      expand(noise(s * 1.768209282106819) * 0.030656382800295368);
+      boxFrame(
+        vec3(size * 0.6350550547291461 - pointerDown * 0.05),
+        size * 0.6350550547291461 - pointerDown * 0.05 * 0.1,
+      );
+      expand(noise(s * 0.22270041645902117) * 0.41792724482850996);
+      grid(
+        3,
+        size * 0.6596742230897178 - pointerDown * 0.05 / 3,
+        0.01 * size * 0.6596742230897178 - pointerDown * 0.05,
+      );
+
+      blend(nsin(time * size) * 0.280208045235598);
+
+      grid(1.99, size * 4, max(0.001, size * 0.003));
+    `,
+  },
+  {
+    id: 'embedded-preset-3',
+    label: 'Verdant Frames',
+    description: 'Bundled NPM-engine preset with twin box frames and green edge-lit motion.',
+    shader: `
+      setMaxIterations(71);
+      setStepSize(0.4414923770441956);
+
+      let size = input();
+      let pointerDown = input();
+      time *= .1;
+      rotateY(mouse.x * -5 * PI / 2 + time - (pointerDown + 0.1));
+      rotateX(mouse.y * 5 * PI / 2 + time);
+
+      color(0.14998612477802592, 0.47642472828922455, 0.0644383761978728);
+
+      rotateX(getRayDirection().y * 2.9789122078821793 + time);
+      rotateY(getRayDirection().x * 2.9789122078821793 + time);
+      rotateZ(getRayDirection().z * 2.9789122078821793 + time);
+
+      metal(0.6434036988763767 * size);
+      shine(0.34486068234140727);
+
+      boxFrame(
+        vec3(size * 0.8239408771788657 - pointerDown * 0.05),
+        size * 0.8239408771788657 - pointerDown * 0.05 * 0.1,
+      );
+      boxFrame(
+        vec3(size * 0.9606847874663808 - pointerDown * 0.05),
+        size * 0.9606847874663808 - pointerDown * 0.05 * 0.1,
+      );
+
+      blend(nsin(time * size) * 0.25980941491680876);
+
+      grid(2, size * 4, max(0.001, size * 0.003));
+    `,
+  },
+  {
+    id: 'embedded-preset-4',
+    label: 'Crimson Reactor',
+    description: 'Bundled NPM-engine preset with framed cylinders, a noisy core sphere, and a grid floor.',
+    shader: `
+      setMaxIterations(161);
+      setStepSize(0.7431197197400152);
+
+      let size = input();
+      let pointerDown = input();
+      time *= 0.15934458017140202;
+      rotateY(mouse.x * -5 * PI / 2 + time - (pointerDown + 0.1));
+      rotateX(mouse.y * 5 * PI / 2 + time);
+
+      color(0.8939736534961771, 0.15343539973164377, 0.2647498251648912);
+
+      let s = getSpace();
+
+      rotateX(getRayDirection().y * 2.4340193013105202 + time);
+      rotateY(getRayDirection().x * 1.7776157305492712 + time);
+      rotateZ(getRayDirection().z * 1.7322517724210127 + time);
+
+      metal(0.5135977939307566 * size);
+      shine(0.4793980848131761);
+
+      boxFrame(
+        vec3(size * 0.8161210436163664 - pointerDown * 0.05),
+        size * 0.8161210436163664 - pointerDown * 0.05 * 0.1,
+      );
+      cylinder(
+        size * 0.8534422954798347 - pointerDown * 0.05 / 4,
+        size * 0.8534422954798347 - pointerDown * 0.05,
+      );
+      cylinder(
+        size * 0.7693094322944559 - pointerDown * 0.05 / 4,
+        size * 0.7693094322944559 - pointerDown * 0.05,
+      );
+      expand(noise(s * 0.1959164091445773) * 0.09097642567410547);
+      sphere(size * 0.886879464900987 - pointerDown * 0.05 / 2);
+
+      blend(nsin(time * size) * 0.17222512677372692);
+
+      grid(1, size * 4, max(0.001, size * 0.003));
+    `,
+  },
+  {
+    id: 'embedded-preset-5',
+    label: 'Alloy Capsule',
+    description: 'Bundled NPM-engine preset combining a metallic cylinder shell with a central sphere.',
+    shader: `
+      setMaxIterations(56);
+      setStepSize(0.04586632133333666);
+
+      let size = input();
+      let pointerDown = input();
+      time *= .1;
+      rotateY(mouse.x * -5 * PI / 2 + time - (pointerDown + 0.1));
+      rotateX(mouse.y * 5 * PI / 2 + time);
+
+      color(0.24020625518667676, 0.2651915227911193, 0.21629480224767128);
+
+      rotateX(getRayDirection().y * 1.9599006869721014 + time);
+      rotateY(getRayDirection().x * 1.9599006869721014 + time);
+      rotateZ(getRayDirection().z * 1.9599006869721014 + time);
+
+      metal(0.6304962928840792 * size);
+      shine(0.6210181878056416);
+
+      cylinder(
+        size * 0.9446738625954518 - pointerDown * 0.05 / 4,
+        size * 0.9446738625954518 - pointerDown * 0.05,
+      );
+      sphere(size * 0.7023682612074287 - pointerDown * 0.05 / 2);
+
+      blend(nsin(time * size) * 0.11435451161014794);
+
+      sphere(size / 3);
+    `,
+  },
+  {
+    id: 'embedded-preset-6',
+    label: 'Redline Core',
+    description: 'Bundled NPM-engine preset with a dominant sphere, cylinder, and dense grid accent.',
+    shader: `
+      setMaxIterations(198);
+      setStepSize(0.8838993805155669);
+
+      let size = input();
+      let pointerDown = input();
+      time *= .1;
+      rotateY(mouse.x * -5 * PI / 2 + time - (pointerDown + 0.1));
+      rotateX(mouse.y * 5 * PI / 2 + time);
+
+      color(0.9514769334666449, 0.1077350724621205, 0);
+
+      rotateX(getRayDirection().y * 2.1969051528600634 + time);
+      rotateY(getRayDirection().x * 2.1969051528600634 + time);
+      rotateZ(getRayDirection().z * 2.1969051528600634 + time);
+
+      metal(0.7125574975041655 * size);
+      shine(0.5774589834819871);
+
+      sphere(size * 0.9935175302558173 - pointerDown * 0.05 / 2);
+      cylinder(
+        size * 0.9289837692896183 - pointerDown * 0.05 / 4,
+        size * 0.9289837692896183 - pointerDown * 0.05,
+      );
+      grid(
+        5,
+        size * 0.5167759726831176 - pointerDown * 0.05 / 3,
+        0.01 * size * 0.5167759726831176 - pointerDown * 0.05,
+      );
+
+      blend(nsin(time * size) * 0.22861033952631743);
+
+      grid(2, size * 4, max(0.001, size * 0.003));
+    `,
+  },
+  {
+    id: 'embedded-preset-7',
+    label: 'Violet Matrix',
+    description: 'Bundled NPM-engine preset with layered grids and a saturated violet sphere.',
+    shader: `
+      setMaxIterations(193);
+      setStepSize(0.7999169963821687);
+
+      let size = input();
+      let pointerDown = input();
+      time *= .1;
+      rotateY(mouse.x * -5 * PI / 2 + time - (pointerDown + 0.1));
+      rotateX(mouse.y * 5 * PI / 2 + time);
+
+      color(0.11460860093209857, 0.007694076675091144, 0.4671766017485241);
+
+      rotateX(getRayDirection().y * 2.0857194147559914 + time);
+      rotateY(getRayDirection().x * 2.0857194147559914 + time);
+      rotateZ(getRayDirection().z * 2.0857194147559914 + time);
+
+      metal(0.5711799571404537 * size);
+      shine(0.5590513531439385);
+
+      grid(
+        5,
+        size * 0.7173114499365616 - pointerDown * 0.05 / 3,
+        0.01 * size * 0.7173114499365616 - pointerDown * 0.05,
+      );
+      grid(
+        4,
+        size * 0.6514999435141519 - pointerDown * 0.05 / 3,
+        0.01 * size * 0.6514999435141519 - pointerDown * 0.05,
+      );
+      sphere(size * 0.7684034276974527 - pointerDown * 0.05 / 2);
+
+      blend(nsin(time * size) * 0.1017060511129565);
+
+      sphere(size / 3);
+    `,
+  },
+  {
+    id: 'embedded-preset-8',
+    label: 'Mint Halo',
+    description: 'Bundled NPM-engine preset with a torus frame, noisy grids, and a bright center sphere.',
+    shader: `
+      setMaxIterations(186);
+      setStepSize(0.8615043142034936);
+
+      let size = input();
+      let pointerDown = input();
+      time *= .1;
+      rotateY(mouse.x * -5 * PI / 2 + time - (pointerDown + 0.1));
+      rotateX(mouse.y * 5 * PI / 2 + time);
+
+      color(0.4050203196259186, 0.7752881097617492, 0.451950921258232);
+
+      rotateX(getRayDirection().y * 1.4049960809220177 + time);
+      rotateY(getRayDirection().x * 1.4049960809220177 + time);
+      rotateZ(getRayDirection().z * 1.4049960809220177 + time);
+
+      metal(0.6607251320316083 * size);
+      shine(0.6646852498948923);
+
+      torus(
+        size * 0.7885283144721178 - pointerDown * 0.05,
+        size * 0.7885283144721178 - pointerDown * 0.05 / 4,
+      );
+      grid(
+        3,
+        size * 0.5103440758834754 - pointerDown * 0.05 / 3,
+        0.01 * size * 0.5103440758834754 - pointerDown * 0.05,
+      );
+      boxFrame(
+        vec3(size * 0.57344769639438 - pointerDown * 0.05),
+        size * 0.57344769639438 - pointerDown * 0.05 * 0.1,
+      );
+      grid(
+        3,
+        size * 0.5749414312428847 - pointerDown * 0.05 / 3,
+        0.01 * size * 0.5749414312428847 - pointerDown * 0.05,
+      );
+      sphere(size * 0.6151950610078535 - pointerDown * 0.05 / 2);
+
+      blend(nsin(time * size) * 0.19517422836065718);
+
+      grid(1, size * 4, max(0.001, size * 0.003));
+    `,
+  },
+  {
+    id: 'embedded-preset-9',
+    label: 'Ember Grid',
+    description: 'Bundled NPM-engine preset with orange framing and a tight supporting grid.',
+    shader: `
+      setMaxIterations(56);
+      setStepSize(0.7549446257595138);
+
+      let size = input();
+      let pointerDown = input();
+      time *= .1;
+      rotateY(mouse.x * -5 * PI / 2 + time - (pointerDown + 0.1));
+      rotateX(mouse.y * 5 * PI / 2 + time);
+
+      color(0.9995767105459568, 0.3013572617092242, 0);
+
+      rotateX(getRayDirection().y * 2.7452866417099218 + time);
+      rotateY(getRayDirection().x * 2.7452866417099218 + time);
+      rotateZ(getRayDirection().z * 2.7452866417099218 + time);
+
+      metal(0.4757753414424941 * size);
+      shine(0.4905478148343774);
+
+      boxFrame(
+        vec3(size * 0.7439170606081622 - pointerDown * 0.05),
+        size * 0.7439170606081622 - pointerDown * 0.05 * 0.1,
+      );
+      grid(
+        3,
+        size * 0.508466039994321 - pointerDown * 0.05 / 3,
+        0.01 * size * 0.508466039994321 - pointerDown * 0.05,
+      );
+
+      blend(nsin(time * size) * 0.10155951925016898);
+
+      sphere(size / 3);
+    `,
+  },
+  {
+    id: 'embedded-preset-10',
+    label: 'Emerald Ring',
+    description: 'Bundled NPM-engine preset with a torus and box frame at maximum scale.',
+    shader: `
+      setMaxIterations(151);
+      setStepSize(0.26597607104610804);
+
+      let size = input();
+      let pointerDown = input();
+      time *= .1;
+      rotateY(mouse.x * -5 * PI / 2 + time - (pointerDown + 0.1));
+      rotateX(mouse.y * 5 * PI / 2 + time);
+
+      color(0.19651749597261697, 0.914203219207783, 0.24550611194053884);
+
+      rotateX(getRayDirection().y * 1.9938824658616179 + time);
+      rotateY(getRayDirection().x * 1.9938824658616179 + time);
+      rotateZ(getRayDirection().z * 1.9938824658616179 + time);
+
+      metal(0.31594207653292694 * size);
+      shine(0.3832572948846391);
+
+      torus(
+        size * 0.8810248079142805 - pointerDown * 0.05,
+        size * 0.8810248079142805 - pointerDown * 0.05 / 4,
+      );
+      boxFrame(
+        vec3(size * 0.8855044665503 - pointerDown * 0.05),
+        size * 0.8855044665503 - pointerDown * 0.05 * 0.1,
+      );
+
+      blend(nsin(time * size) * 0.11214341939632295);
+
+      grid(1, size * 4, max(0.001, size * 0.003));
+    `,
+  },
+  {
+    id: 'embedded-preset-11',
+    label: 'Spectrum Relay',
+    description: 'Bundled NPM-engine preset with color-from-ray direction and sparse mixed primitives.',
+    shader: `
+      setMaxIterations(96);
+      setStepSize(0.8497186712056144);
+
+      let size = input();
+      let pointerDown = input();
+      time *= 0.663750656570544;
+
+      color(getRayDirection().x, getRayDirection().y, getRayDirection().z);
+
+      let s = getSpace();
+
+      cylinder(
+        size * 0.6168195561594768 - pointerDown * 0.05 / 4,
+        size * 0.6168195561594768 - pointerDown * 0.05,
+      );
+      expand(noise(s * 0.7369379972723424) * 0.2843224929727242);
+      torus(
+        size * 0.8334445133920002 - pointerDown * 0.05,
+        size * 0.8334445133920002 - pointerDown * 0.05 / 4,
+      );
+      grid(
+        3,
+        size * 0.9954834969507702 - pointerDown * 0.05 / 3,
+        0.01 * size * 0.9954834969507702 - pointerDown * 0.05,
+      );
+
+      blend(nsin(time * size) * 0.1250996138241836);
+    `,
+  },
+  {
+    id: 'embedded-preset-12',
+    label: 'Chroma Storm',
+    description: 'Bundled NPM-engine preset with heavy noise expansion, mixed primitives, and rainbow ray coloring.',
+    shader: `
+      setMaxIterations(78);
+      setStepSize(0.7369359368566446);
+
+      let size = input();
+      let pointerDown = input();
+      time *= 0.9539348297232683;
+
+      rotateX(getRayDirection().y * 2.4510099887638064 + time * 2.4510099887638064);
+      rotateZ(getRayDirection().z * 1.329787985176121 + time * 1.329787985176121);
+
+      color(getRayDirection().x, getRayDirection().y, getRayDirection().z);
+
+      let s = getSpace();
+
+      expand(noise(s * 0.9106972929083885) * 0.3894969217119301);
+      sphere(size * 0.6061774521306397 - pointerDown * 0.05 / 2);
+      expand(noise(s * 1.9603753411504794) * 0.38739515373281597);
+      torus(
+        size * 0.5957939662981329 - pointerDown * 0.05,
+        size * 0.5957939662981329 - pointerDown * 0.05 / 4,
+      );
+      cylinder(
+        size * 0.7847176552581908 - pointerDown * 0.05 / 4,
+        size * 0.7847176552581908 - pointerDown * 0.05,
+      );
+      expand(noise(s * 0.5620060333649501) * 0.4766355635901381);
+      grid(
+        5,
+        size * 0.6803317673052074 - pointerDown * 0.05 / 3,
+        0.01 * size * 0.6803317673052074 - pointerDown * 0.05,
+      );
+      expand(noise(s * 1.6366720215270216) * 0.40304648326346637);
+      boxFrame(
+        vec3(size * 0.8080101969375488 - pointerDown * 0.05),
+        size * 0.8080101969375488 - pointerDown * 0.05 * 0.1,
+      );
+
+      blend(nsin(time * size) * 0.20502448998246994);
+    `,
+  },
+]

--- a/src/lib/embeddedShaderPresets.ts
+++ b/src/lib/embeddedShaderPresets.ts
@@ -4,7 +4,7 @@ export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
   {
     id: 'embedded-preset-0',
     label: 'Prism Core',
-    description: 'Bundled NPM-engine preset with layered box frames and a reflective core sphere.',
+    description: 'Bundled engine preset with layered box frames and a reflective core sphere.',
     shader: `
       let size = input()
       let pointerDown = input()
@@ -31,7 +31,7 @@ export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
   {
     id: 'embedded-preset-1',
     label: 'Steel Lattice',
-    description: 'Bundled NPM-engine preset built from stacked grids and box frames.',
+    description: 'Bundled engine preset built from stacked grids and box frames.',
     shader: `
       setMaxIterations(101);
       setStepSize(0.7260629659452175);
@@ -73,7 +73,7 @@ export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
   {
     id: 'embedded-preset-2',
     label: 'Aqua Static',
-    description: 'Bundled NPM-engine preset with noisy box frames and layered grid distortion.',
+    description: 'Bundled engine preset with noisy box frames and layered grid distortion.',
     shader: `
       setMaxIterations(133);
       setStepSize(0.8632297724861512);
@@ -120,7 +120,7 @@ export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
   {
     id: 'embedded-preset-3',
     label: 'Verdant Frames',
-    description: 'Bundled NPM-engine preset with twin box frames and green edge-lit motion.',
+    description: 'Bundled engine preset with twin box frames and green edge-lit motion.',
     shader: `
       setMaxIterations(71);
       setStepSize(0.4414923770441956);
@@ -157,7 +157,7 @@ export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
   {
     id: 'embedded-preset-4',
     label: 'Crimson Reactor',
-    description: 'Bundled NPM-engine preset with framed cylinders, a noisy core sphere, and a grid floor.',
+    description: 'Bundled engine preset with framed cylinders, a noisy core sphere, and a grid floor.',
     shader: `
       setMaxIterations(161);
       setStepSize(0.7431197197400152);
@@ -202,7 +202,7 @@ export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
   {
     id: 'embedded-preset-5',
     label: 'Alloy Capsule',
-    description: 'Bundled NPM-engine preset combining a metallic cylinder shell with a central sphere.',
+    description: 'Bundled engine preset combining a metallic cylinder shell with a central sphere.',
     shader: `
       setMaxIterations(56);
       setStepSize(0.04586632133333666);
@@ -236,7 +236,7 @@ export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
   {
     id: 'embedded-preset-6',
     label: 'Redline Core',
-    description: 'Bundled NPM-engine preset with a dominant sphere, cylinder, and dense grid accent.',
+    description: 'Bundled engine preset with a dominant sphere, cylinder, and dense grid accent.',
     shader: `
       setMaxIterations(198);
       setStepSize(0.8838993805155669);
@@ -275,7 +275,7 @@ export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
   {
     id: 'embedded-preset-7',
     label: 'Violet Matrix',
-    description: 'Bundled NPM-engine preset with layered grids and a saturated violet sphere.',
+    description: 'Bundled engine preset with layered grids and a saturated violet sphere.',
     shader: `
       setMaxIterations(193);
       setStepSize(0.7999169963821687);
@@ -315,7 +315,7 @@ export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
   {
     id: 'embedded-preset-8',
     label: 'Mint Halo',
-    description: 'Bundled NPM-engine preset with a torus frame, noisy grids, and a bright center sphere.',
+    description: 'Bundled engine preset with a torus frame, noisy grids, and a bright center sphere.',
     shader: `
       setMaxIterations(186);
       setStepSize(0.8615043142034936);
@@ -363,7 +363,7 @@ export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
   {
     id: 'embedded-preset-9',
     label: 'Ember Grid',
-    description: 'Bundled NPM-engine preset with orange framing and a tight supporting grid.',
+    description: 'Bundled engine preset with orange framing and a tight supporting grid.',
     shader: `
       setMaxIterations(56);
       setStepSize(0.7549446257595138);
@@ -401,7 +401,7 @@ export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
   {
     id: 'embedded-preset-10',
     label: 'Emerald Ring',
-    description: 'Bundled NPM-engine preset with a torus and box frame at maximum scale.',
+    description: 'Bundled engine preset with a torus and box frame at maximum scale.',
     shader: `
       setMaxIterations(151);
       setStepSize(0.26597607104610804);
@@ -438,7 +438,7 @@ export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
   {
     id: 'embedded-preset-11',
     label: 'Spectrum Relay',
-    description: 'Bundled NPM-engine preset with color-from-ray direction and sparse mixed primitives.',
+    description: 'Bundled engine preset with color-from-ray direction and sparse mixed primitives.',
     shader: `
       setMaxIterations(96);
       setStepSize(0.8497186712056144);
@@ -472,7 +472,7 @@ export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
   {
     id: 'embedded-preset-12',
     label: 'Chroma Storm',
-    description: 'Bundled NPM-engine preset with heavy noise expansion, mixed primitives, and rainbow ray coloring.',
+    description: 'Bundled engine preset with heavy noise expansion, mixed primitives, and rainbow ray coloring.',
     shader: `
       setMaxIterations(78);
       setStepSize(0.7369359368566446);

--- a/src/lib/magePlayerAdapter.ts
+++ b/src/lib/magePlayerAdapter.ts
@@ -19,13 +19,9 @@ type MageEngineModule = {
   initMAGE: (config: {
     autoStart?: boolean
     canvas: HTMLCanvasElement
-    options?: {
-      log?: boolean
-    }
+    log?: boolean
     withControls?: boolean
-  }) => {
-    engine: MageEngineBridge
-  }
+  }) => MageEngineBridge
 }
 
 export type MageSceneBlob = Record<string, unknown>
@@ -67,13 +63,11 @@ export async function createMagePlayer(
   options: { log?: boolean } = {},
 ): Promise<MagePlayerController> {
   const { initMAGE } = await loadMageEngineModule()
-  const { engine } = initMAGE({
+  const engine = initMAGE({
     canvas,
     withControls: false,
     autoStart: false,
-    options: {
-      log: options.log ?? false,
-    },
+    log: options.log ?? false,
   })
 
   engine.start()

--- a/src/lib/presetEditor.ts
+++ b/src/lib/presetEditor.ts
@@ -1,3 +1,5 @@
+import { EMBEDDED_SHADER_PRESETS } from './embeddedShaderPresets'
+
 export type PresetSceneData = Record<string, unknown>
 
 export type Vector3Value = {
@@ -92,6 +94,8 @@ export type SceneEditorModel = {
     autoRotateSpeed: number
     base_speed: number
     camTilt: number
+    camOrientationMode: number
+    camOrientationSpeed: number
     easing_speed: number
     fov: number
     minimizing_factor: number
@@ -152,96 +156,12 @@ export const PASS_LABELS: Record<PresetPassId, string> = {
   toonShader: 'Toon',
 }
 
-export const SHADER_PRESETS: ShaderPresetOption[] = [
-  {
-    id: 'aurora-drift',
-    label: 'Aurora Drift',
-    description: 'Layered rings and soft bloom-friendly motion.',
-    shader: `
-      let size = input()
-      let pointerDown = input()
-      time = 0.24 * time
-      size *= 1.1
-      rotateY(mouse.x * -PI * (1.0 + nsin(time)))
-      rotateX(mouse.y * PI * (1.0 + nsin(time)))
-      let rayDir = normalize(getRayDirection())
-      color(vec3(rayDir.x + 0.24, rayDir.y + 0.34, rayDir.z + 0.42))
-      metal(0.45 * size)
-      shine(0.72)
-      rotateY(sin(getRayDirection().y * 7.0 + time))
-      rotateX(cos(getRayDirection().x * 12.0 + time))
-      blend(0.12 + 0.08 * nsin(time * 2.0))
-      boxFrame(vec3(size), size * 0.08)
-      sphere(size * 0.44 - pointerDown * 0.18)
-    `,
-  },
-  {
-    id: 'signal-bloom',
-    label: 'Signal Bloom',
-    description: 'Dense geometric pulses that respond well to glow.',
-    shader: `
-      let size = input()
-      let pointerDown = input()
-      time *= 0.18
-      rotateY(time + mouse.x * PI * 0.7)
-      rotateX(mouse.y * PI * 0.6)
-      color(vec3(0.92, 0.47 + 0.16 * nsin(time), 0.36 + 0.14 * ncos(time)))
-      metal(0.36)
-      shine(0.86)
-      blend(0.08 + 0.04 * nsin(time * 3.0))
-      boxFrame(vec3(size * 0.82 + 0.36), 0.08 + pointerDown * 0.05)
-      rotateZ(time * 0.7)
-      boxFrame(vec3(size * 0.56 + 0.22), 0.03)
-      sphere(0.32 + 0.04 * nsin(time * 4.0))
-    `,
-  },
-  {
-    id: 'glacier-echo',
-    label: 'Glacier Echo',
-    description: 'Cool, reflective framing with slower rotation.',
-    shader: `
-      let size = input()
-      let pointerDown = input()
-      time *= 0.14
-      rotateY(time * 0.4 + mouse.x * PI * 0.5)
-      rotateX(mouse.y * PI * 0.35)
-      let rayDir = normalize(getRayDirection())
-      color(vec3(0.32 + rayDir.z * 0.2, 0.74, 0.96))
-      metal(0.62)
-      shine(0.94)
-      blend(0.06 + 0.03 * ncos(time * 2.0))
-      sphere(0.46 + 0.05 * nsin(time * 2.0) - pointerDown * 0.08)
-      boxFrame(vec3(size * 0.92 + 0.34), 0.04)
-      rotateZ(time * 0.35)
-      boxFrame(vec3(size * 0.64 + 0.18), 0.025)
-    `,
-  },
-  {
-    id: 'solar-thread',
-    label: 'Solar Thread',
-    description: 'Warm radial framing with quick directional motion.',
-    shader: `
-      let size = input()
-      let pointerDown = input()
-      time *= 0.28
-      rotateY(time * 0.9 + mouse.x * PI)
-      rotateX(mouse.y * PI * 0.45)
-      color(vec3(0.98, 0.68 + 0.14 * nsin(time), 0.24))
-      metal(0.4)
-      shine(0.8)
-      blend(0.1 + 0.05 * nsin(time * 5.0))
-      boxFrame(vec3(size * 0.7 + 0.5), 0.06)
-      rotateZ(time * 1.2)
-      boxFrame(vec3(size * 0.5 + 0.24), 0.02 + pointerDown * 0.01)
-      sphere(0.22 + 0.08 * ncos(time * 3.0))
-    `,
-  },
-]
+export const SHADER_PRESETS: ShaderPresetOption[] = [...EMBEDDED_SHADER_PRESETS]
 
 export const TONE_MAPPING_OPTIONS: ToneMappingOption[] = [
   {
     value: 0,
-    label: 'None',
+    label: 'NoTone',
     description: 'No extra tone mapping on the final output.',
   },
   {
@@ -300,6 +220,8 @@ const DEFAULT_SCENE_DATA: SceneEditorModel = {
     base_speed: 0.2,
     easing_speed: 0.6,
     camTilt: 0,
+    camOrientationMode: 0,
+    camOrientationSpeed: 1,
     autoRotate: true,
     autoRotateSpeed: 0.2,
     fov: 75,
@@ -530,6 +452,14 @@ export function getSceneEditorModel(sceneData: PresetSceneData): SceneEditorMode
       base_speed: readNumber(intent.base_speed, defaults.intent.base_speed),
       easing_speed: readNumber(intent.easing_speed, defaults.intent.easing_speed),
       camTilt: readNumber(intent.camTilt, defaults.intent.camTilt),
+      camOrientationMode: readNumber(
+        intent.camOrientationMode,
+        defaults.intent.camOrientationMode,
+      ),
+      camOrientationSpeed: readNumber(
+        intent.camOrientationSpeed,
+        defaults.intent.camOrientationSpeed,
+      ),
       autoRotate: readBoolean(intent.autoRotate, defaults.intent.autoRotate),
       autoRotateSpeed: readNumber(intent.autoRotateSpeed, defaults.intent.autoRotateSpeed),
       fov: readNumber(intent.fov, defaults.intent.fov),

--- a/src/pages/CreatePresetPage.test.tsx
+++ b/src/pages/CreatePresetPage.test.tsx
@@ -56,7 +56,7 @@ function renderCreatePresetPage() {
 }
 
 describe('CreatePresetPage', () => {
-  it('renders the curated editor with the full section menu available', async () => {
+  it('renders the expanded NPM-engine editor with the full section menu available', async () => {
     storeSession()
 
     vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
@@ -75,10 +75,13 @@ describe('CreatePresetPage', () => {
     expect(screen.queryByRole('heading', { name: /^camera$/i })).not.toBeInTheDocument()
     expect(screen.queryByRole('heading', { name: /^motion$/i })).not.toBeInTheDocument()
     expect(screen.queryByRole('heading', { name: /^effects$/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('option', { name: /^prism core$/i })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: /^chroma storm$/i })).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: /^aurora drift$/i })).not.toBeInTheDocument()
     expect(screen.getByRole('option', { name: /pass order/i })).toBeInTheDocument()
-    expect(screen.queryByRole('option', { name: /advanced/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('option', { name: /advanced/i })).toBeInTheDocument()
     expect(screen.queryByLabelText(/scene data json/i)).not.toBeInTheDocument()
-    expect(screen.queryByLabelText(/custom shader/i)).not.toBeInTheDocument()
+    expect(screen.getByLabelText(/custom shader/i)).toBeInTheDocument()
     expect(screen.getByTestId('mage-player')).toHaveTextContent('preview-ready')
   })
 
@@ -116,7 +119,7 @@ describe('CreatePresetPage', () => {
     expect(screen.queryByRole('button', { name: /a\/b testing/i })).not.toBeInTheDocument()
   })
 
-  it('keeps the Motion section focused on the controls that affect the preset most directly', async () => {
+  it('keeps the Motion section focused on the persisted NPM-engine motion controls', async () => {
     storeSession()
 
     vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
@@ -133,13 +136,15 @@ describe('CreatePresetPage', () => {
 
     expect(screen.getByRole('heading', { name: /^motion$/i })).toBeInTheDocument()
     expect(screen.getByLabelText(/auto rotate/i)).toBeInTheDocument()
-    expect(screen.getByLabelText(/distortion/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/time multiplier/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/audio gain/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/audio curve/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/pointer release hold/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/base speed/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/easing speed/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/rotation speed/i)).toBeInTheDocument()
-    expect(screen.queryByLabelText(/time speed/i)).not.toBeInTheDocument()
-    expect(screen.queryByLabelText(/smoothness/i)).not.toBeInTheDocument()
-    expect(screen.queryByLabelText(/compression/i)).not.toBeInTheDocument()
-    expect(screen.queryByLabelText(/intensity/i)).not.toBeInTheDocument()
-    expect(screen.queryByLabelText(/interaction boost/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/camera orientation mode/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/scene data json/i)).not.toBeInTheDocument()
   })
 
   it('splits pass ordering into its own section and groups effects into categorized cards', async () => {
@@ -166,6 +171,7 @@ describe('CreatePresetPage', () => {
     expect(screen.getByText(/^gamma correction$/i)).toBeInTheDocument()
     expect(screen.getByText(/sharp digital breakups and instability/i)).toBeInTheDocument()
     expect(screen.queryByText(/^additional passes$/i)).not.toBeInTheDocument()
+    expect(screen.getByText(/^output pass$/i)).toBeInTheDocument()
 
     fireEvent.change(screen.getByLabelText(/jump to section/i), { target: { value: 'pass-order' } })
 
@@ -199,7 +205,7 @@ describe('CreatePresetPage', () => {
     await user.type(screen.getByLabelText(/preset name/i), 'Aurora Drift')
     fireEvent.change(screen.getByLabelText(/jump to section/i), { target: { value: 'camera' } })
     expect(screen.getByRole('heading', { name: /^camera$/i })).toBeInTheDocument()
-    fireEvent.change(screen.getByLabelText(/camera tilt/i), { target: { value: '90' } })
+    fireEvent.change(screen.getByLabelText(/camera orientation/i), { target: { value: '90' } })
     await user.click(screen.getByRole('button', { name: /create preset/i }))
 
     await waitFor(() => expect(submittedBody).not.toBeNull())
@@ -220,5 +226,27 @@ describe('CreatePresetPage', () => {
     expect(intent.camTilt).toBeCloseTo(Math.PI / 2, 5)
     expect(passOrder.at(-1)).toBe('outputPass')
     expect(await screen.findByText('My Presets')).toBeInTheDocument()
+  })
+
+  it('surfaces advanced NPM-engine fields and the raw JSON editor in the Advanced section', async () => {
+    storeSession()
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      if (input === buildApiUrl('/users/me')) {
+        return Promise.resolve(jsonResponse(storedUser))
+      }
+
+      throw new Error(`Unexpected request: ${String(input)}`)
+    })
+
+    renderCreatePresetPage()
+
+    fireEvent.change(screen.getByLabelText(/jump to section/i), { target: { value: 'advanced' } })
+
+    expect(screen.getByRole('heading', { name: /^advanced$/i })).toBeInTheDocument()
+    expect(screen.getByLabelText(/camera orientation mode/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/camera orientation speed/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/scene data json/i)).toBeInTheDocument()
+    expect(screen.getByText(/stack-only passes/i)).toBeInTheDocument()
   })
 })

--- a/src/pages/CreatePresetPage.test.tsx
+++ b/src/pages/CreatePresetPage.test.tsx
@@ -56,7 +56,7 @@ function renderCreatePresetPage() {
 }
 
 describe('CreatePresetPage', () => {
-  it('renders the expanded NPM-engine editor with the full section menu available', async () => {
+  it('renders the expanded MAGE engine editor with the full section menu available', async () => {
     storeSession()
 
     vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
@@ -119,7 +119,7 @@ describe('CreatePresetPage', () => {
     expect(screen.queryByRole('button', { name: /a\/b testing/i })).not.toBeInTheDocument()
   })
 
-  it('keeps the Motion section focused on the persisted NPM-engine motion controls', async () => {
+  it('keeps the Motion section focused on the persisted MAGE engine motion controls', async () => {
     storeSession()
 
     vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
@@ -228,7 +228,7 @@ describe('CreatePresetPage', () => {
     expect(await screen.findByText('My Presets')).toBeInTheDocument()
   })
 
-  it('surfaces advanced NPM-engine fields and the raw JSON editor in the Advanced section', async () => {
+  it('surfaces advanced MAGE engine fields and the raw JSON editor in the Advanced section', async () => {
     storeSession()
 
     vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {

--- a/src/pages/CreatePresetPage.tsx
+++ b/src/pages/CreatePresetPage.tsx
@@ -79,6 +79,10 @@ const EDITOR_SECTIONS: EditorSectionConfig[] = [
     id: "pass-order",
     title: "Pass Order",
   },
+  {
+    id: "advanced",
+    title: "Advanced",
+  },
 ];
 
 const initialSceneData = sanitizeSceneData(createDefaultSceneData());
@@ -179,6 +183,12 @@ const passFlagsById: Partial<Record<PresetPassId, PersistedPassFlag>> = {
   technicolorShader: "technicolor",
 };
 
+const stackOnlyPassLabels = [
+  PASS_LABELS.copyShader,
+  PASS_LABELS.bleachBypassShader,
+  PASS_LABELS.toonShader,
+].join(", ");
+
 function buildShaderOptions(currentShader: string) {
   const matchedPreset = SHADER_PRESETS.find(
     (preset) => preset.shader.trim() === currentShader.trim(),
@@ -250,7 +260,7 @@ function buildToneMappingOptions(currentMethod: number) {
 
 function describePassState(passId: PresetPassId, sceneModel: SceneEditorModel) {
   if (passId === "outputPass") {
-    return "Fixed last";
+    return sceneModel.fx.passes.outputPass ? "Enabled" : "Disabled";
   }
 
   if (passId === "bloom") {
@@ -260,7 +270,7 @@ function describePassState(passId: PresetPassId, sceneModel: SceneEditorModel) {
   const flag = passFlagsById[passId];
 
   if (!flag) {
-    return "Order only";
+    return "Stack only";
   }
 
   return sceneModel.fx.passes[flag] ? "Enabled" : "Disabled";
@@ -624,7 +634,7 @@ export function CreatePresetPage() {
                           Upload File
                         </strong>
                         <span className="preset-thumbnail-choice__description">
-                          Bring in a custom still from your device.
+                          Use a custom image.
                         </span>
                       </button>
 
@@ -642,7 +652,7 @@ export function CreatePresetPage() {
                           Auto-generated
                         </strong>
                         <span className="preset-thumbnail-choice__description">
-                          Start from a generated cover treatment.
+                          Start from a generated cover.
                         </span>
                       </button>
                     </div>
@@ -725,7 +735,7 @@ export function CreatePresetPage() {
 
             {sectionMenuValue === "scene" ? (
               <PresetSection
-                description="Visual identity, environment, and scale."
+                description="Choose the visual style, background environment, and overall size of the scene."
                 title="Scene"
               >
                 <div className="preset-editor-grid preset-editor-grid--3">
@@ -788,12 +798,32 @@ export function CreatePresetPage() {
                     value={sceneModel.visualizer.scale}
                   />
                 </div>
+
+                <div className="field-group">
+                  <label htmlFor="shader-source">Custom Shader</label>
+                  <textarea
+                    className="preset-textarea"
+                    id="shader-source"
+                    onChange={(event) =>
+                      updateBranch("visualizer", (currentVisualizer) => ({
+                        ...currentVisualizer,
+                        shader: event.currentTarget.value,
+                      }))
+                    }
+                    rows={12}
+                    value={sceneModel.visualizer.shader}
+                  />
+                  <p className="field-hint">
+                    This is the actual `visualizer.shader` source that ships in
+                    the preset. Choosing a shader above swaps this text.
+                  </p>
+                </div>
               </PresetSection>
             ) : null}
 
             {sectionMenuValue === "camera" ? (
               <PresetSection
-                description="Position, framing, and lens."
+                description="Set the starting view, framing, and lens settings for the scene."
                 title="Camera"
               >
                 <div className="preset-editor-grid preset-editor-grid--2">
@@ -827,7 +857,7 @@ export function CreatePresetPage() {
                     description="How wide the camera lens feels."
                     formatValue={(value) => formatFixed(value, 0)}
                     id="field-of-view"
-                    label="Field of View"
+                    label="FOV"
                     max={359}
                     min={1}
                     onChange={(nextValue) =>
@@ -844,7 +874,7 @@ export function CreatePresetPage() {
                     description="Displayed in degrees while the engine still stores radians."
                     formatValue={formatDegrees}
                     id="camera-tilt"
-                    label="Camera Tilt"
+                    label="Camera Orientation"
                     max={360}
                     min={0}
                     onChange={(nextValue) =>
@@ -876,10 +906,72 @@ export function CreatePresetPage() {
 
             {sectionMenuValue === "motion" ? (
               <PresetSection
-                description="Rotation and visual shaping."
+                description="Adjust how the scene moves and how strongly it responds to audio and input."
                 title="Motion"
               >
                 <div className="preset-editor-grid preset-editor-grid--2">
+                  <NumberField
+                    description="Overall engine time multiplier."
+                    id="time-multiplier"
+                    label="Time Multiplier"
+                    onChange={(nextValue) =>
+                      updateBranch("intent", (currentIntent) => ({
+                        ...currentIntent,
+                        time_multiplier: nextValue,
+                      }))
+                    }
+                    step={0.05}
+                    value={sceneModel.intent.time_multiplier}
+                  />
+
+                  <SliderField
+                    description="Scales the incoming audio signal before the engine applies its response curve."
+                    id="audio-gain"
+                    label="Audio Gain"
+                    max={2}
+                    min={0.01}
+                    onChange={(nextValue) =>
+                      updateBranch("intent", (currentIntent) => ({
+                        ...currentIntent,
+                        minimizing_factor: nextValue,
+                      }))
+                    }
+                    step={0.01}
+                    value={sceneModel.intent.minimizing_factor}
+                  />
+
+                  <SliderField
+                    description="Shapes how sharply the audio response ramps up. Higher values make peaks more selective."
+                    id="audio-curve"
+                    label="Audio Curve"
+                    max={10}
+                    min={1}
+                    onChange={(nextValue) =>
+                      updateBranch("intent", (currentIntent) => ({
+                        ...currentIntent,
+                        power_factor: nextValue,
+                      }))
+                    }
+                    step={0.1}
+                    value={sceneModel.intent.power_factor}
+                  />
+
+                  <SliderField
+                    description="Controls how much pointer-down influence lingers after release for shaders that read pointer input."
+                    id="pointer-release-hold"
+                    label="Pointer Release Hold"
+                    max={1}
+                    min={0}
+                    onChange={(nextValue) =>
+                      updateBranch("intent", (currentIntent) => ({
+                        ...currentIntent,
+                        pointerDownMultiplier: nextValue,
+                      }))
+                    }
+                    step={0.01}
+                    value={sceneModel.intent.pointerDownMultiplier}
+                  />
+
                   <SliderField
                     description="How quickly the auto rotation travels when enabled."
                     id="rotation-speed"
@@ -897,9 +989,9 @@ export function CreatePresetPage() {
                   />
 
                   <SliderField
-                    description="This shapes and distorts the visual more than it changes speed."
+                    description="Base audio-reactive speed shaping used by the engine."
                     id="base-speed"
-                    label="Distortion"
+                    label="Base Speed"
                     max={0.9}
                     min={0.01}
                     onChange={(nextValue) =>
@@ -910,6 +1002,22 @@ export function CreatePresetPage() {
                     }
                     step={0.01}
                     value={sceneModel.intent.base_speed}
+                  />
+
+                  <SliderField
+                    description="How quickly the reactive size settles toward its latest value."
+                    id="easing-speed"
+                    label="Easing Speed"
+                    max={0.9}
+                    min={0.01}
+                    onChange={(nextValue) =>
+                      updateBranch("intent", (currentIntent) => ({
+                        ...currentIntent,
+                        easing_speed: nextValue,
+                      }))
+                    }
+                    step={0.01}
+                    value={sceneModel.intent.easing_speed}
                   />
 
                   <div className="preset-editor-grid__item--full">
@@ -932,7 +1040,7 @@ export function CreatePresetPage() {
 
             {sectionMenuValue === "effects" ? (
               <PresetSection
-                description="Post-processing and final image shaping."
+                description="Add glow, color treatment, distortion, and other finishing effects."
                 title="Effects"
               >
                 <div className="preset-effects-grid">
@@ -1014,19 +1122,29 @@ export function CreatePresetPage() {
                       </EffectCard>
 
                       <EffectCard
-                        description="Choose the final output roll-off using named tone-mapping options."
+                        description="Control the final output pass and its tone-mapping response."
+                        enabled={sceneModel.fx.passes.outputPass}
+                        onToggle={(nextValue) =>
+                          updateBranch("fx", (currentFx) => ({
+                            ...currentFx,
+                            passes: {
+                              ...currentFx.passes,
+                              outputPass: nextValue,
+                            },
+                          }))
+                        }
                         footer={
                           <p className="preset-effect-footnote">
                             {selectedToneMapping.description}
                           </p>
                         }
-                        title="Tone Mapping"
+                        title="Output Pass"
                       >
                         <div className="preset-editor-grid preset-editor-grid--2">
                           <SelectField
-                            description="Switch between filmic output curves without using numeric ids."
+                            description="Switch between the renderer tone-mapping methods used by NPM-engine."
                             id="tone-mapping-method"
-                            label="Method"
+                            label="Tone Mapping"
                             onChange={(nextValue) =>
                               updateBranch("fx", (currentFx) => ({
                                 ...currentFx,
@@ -1321,7 +1439,7 @@ export function CreatePresetPage() {
 
             {sectionMenuValue === "pass-order" ? (
               <PresetSection
-                description="Reorder the effect stack to control how the image is built. Output stays pinned last."
+                description="Change the order of effects to control how the final image is layered. Output always stays last."
                 title="Pass Order"
               >
                 <ol className="preset-pass-order">
@@ -1366,118 +1484,65 @@ export function CreatePresetPage() {
 
             {sectionMenuValue === "advanced" ? (
               <PresetSection
-                description="Raw engine controls and scene data."
+                description="Edit advanced settings, startup values, and raw preset JSON."
                 title="Advanced"
               >
                 <div className="preset-advanced-stack">
-                  <div className="field-group">
-                    <label>Motion Tuning</label>
-                    <p className="field-hint">
-                      Lower-level motion controls that stay out of the main
-                      authoring flow.
-                    </p>
-                  </div>
-
                   <div className="preset-editor-grid preset-editor-grid--2">
                     <NumberField
-                      description="Overall engine time multiplier."
-                      id="time-speed"
-                      label="Time Speed"
-                      onChange={(nextValue) =>
-                        updateBranch("intent", (currentIntent) => ({
-                          ...currentIntent,
-                          time_multiplier: nextValue,
-                        }))
-                      }
-                      step={0.05}
-                      value={sceneModel.intent.time_multiplier}
-                    />
-
-                    <SliderField
-                      description="How quickly movement eases toward its target."
-                      id="smoothness"
-                      label="Smoothness"
-                      max={0.9}
-                      min={0.01}
-                      onChange={(nextValue) =>
-                        updateBranch("intent", (currentIntent) => ({
-                          ...currentIntent,
-                          easing_speed: nextValue,
-                        }))
-                      }
-                      step={0.01}
-                      value={sceneModel.intent.easing_speed}
-                    />
-
-                    <SliderField
-                      description="Compresses the movement range for tighter motion."
-                      id="compression"
-                      label="Compression"
-                      max={2}
-                      min={0.01}
-                      onChange={(nextValue) =>
-                        updateBranch("intent", (currentIntent) => ({
-                          ...currentIntent,
-                          minimizing_factor: nextValue,
-                        }))
-                      }
-                      step={0.01}
-                      value={sceneModel.intent.minimizing_factor}
-                    />
-
-                    <SliderField
-                      description="Boosts the overall energy of the response."
-                      id="intensity"
-                      label="Intensity"
-                      max={10}
-                      min={1}
-                      onChange={(nextValue) =>
-                        updateBranch("intent", (currentIntent) => ({
-                          ...currentIntent,
-                          power_factor: nextValue,
-                        }))
-                      }
-                      step={0.1}
-                      value={sceneModel.intent.power_factor}
-                    />
-
-                    <SliderField
-                      description="Extra motion added during interaction or pointer pressure."
-                      id="interaction-boost"
-                      label="Interaction Boost"
-                      max={1}
+                      description="Experimental compact-preset field exported by the library."
+                      id="camera-orientation-mode"
+                      label="Camera Orientation Mode"
                       min={0}
                       onChange={(nextValue) =>
                         updateBranch("intent", (currentIntent) => ({
                           ...currentIntent,
-                          pointerDownMultiplier: nextValue,
+                          camOrientationMode: Math.max(
+                            0,
+                            Math.round(nextValue),
+                          ),
                         }))
                       }
-                      step={0.01}
-                      value={sceneModel.intent.pointerDownMultiplier}
+                      step={1}
+                      value={sceneModel.intent.camOrientationMode}
+                    />
+
+                    <NumberField
+                      description="Experimental compact-preset field exported by the library."
+                      id="camera-orientation-speed"
+                      label="Camera Orientation Speed"
+                      min={0}
+                      onChange={(nextValue) =>
+                        updateBranch("intent", (currentIntent) => ({
+                          ...currentIntent,
+                          camOrientationSpeed: nextValue,
+                        }))
+                      }
+                      step={0.1}
+                      value={sceneModel.intent.camOrientationSpeed}
                     />
                   </div>
+
+                  <EffectCard
+                    description="These passes exist in the NPM-engine effect stack, but the compact preset schema does not persist booleans for them yet."
+                    title="Stack-only Passes"
+                  >
+                    <p className="field-hint">
+                      {stackOnlyPassLabels} can still be reordered in{" "}
+                      <strong>Pass Order</strong>. Their enable state is not
+                      currently stored by compact preset JSON, so this page
+                      keeps them informational instead of pretending they are
+                      fully supported.
+                    </p>
+                  </EffectCard>
 
                   <div className="field-group">
-                    <label htmlFor="shader-source">Custom Shader</label>
-                    <textarea
-                      className="preset-textarea"
-                      id="shader-source"
-                      onChange={(event) =>
-                        updateBranch("visualizer", (currentVisualizer) => ({
-                          ...currentVisualizer,
-                          shader: event.currentTarget.value,
-                        }))
-                      }
-                      rows={10}
-                      value={sceneModel.visualizer.shader}
-                    />
+                    <label>Runtime State</label>
                     <p className="field-hint">
-                      Use this only when the preset needs shader code beyond the
-                      curated presets.
+                      Seed low-level engine values for debugging or for presets
+                      that depend on non-default startup state.
                     </p>
                   </div>
-
                   <div className="preset-editor-grid preset-editor-grid--3">
                     <NumberField
                       description="Low-level runtime state."

--- a/src/pages/CreatePresetPage.tsx
+++ b/src/pages/CreatePresetPage.tsx
@@ -1142,7 +1142,7 @@ export function CreatePresetPage() {
                       >
                         <div className="preset-editor-grid preset-editor-grid--2">
                           <SelectField
-                            description="Switch between the renderer tone-mapping methods used by NPM-engine."
+                            description="Switch between the renderer tone-mapping methods used by the MAGE engine."
                             id="tone-mapping-method"
                             label="Tone Mapping"
                             onChange={(nextValue) =>
@@ -1524,7 +1524,7 @@ export function CreatePresetPage() {
                   </div>
 
                   <EffectCard
-                    description="These passes exist in the NPM-engine effect stack, but the compact preset schema does not persist booleans for them yet."
+                    description="These passes exist in the MAGE engine effect stack, but the compact preset schema does not persist booleans for them yet."
                     title="Stack-only Passes"
                   >
                     <p className="field-hint">

--- a/src/types/mage-engine.d.ts
+++ b/src/types/mage-engine.d.ts
@@ -8,11 +8,7 @@ declare module '@mage/engine' {
   export function initMAGE(config: {
     autoStart?: boolean
     canvas: HTMLCanvasElement
-    options?: {
-      log?: boolean
-    }
+    log?: boolean
     withControls?: boolean
-  }): {
-    engine: MageEngine
-  }
+  }): MageEngine
 }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -9,7 +9,7 @@
     "types": ["vite/client"],
     "skipLibCheck": true,
     "paths": {
-      "@mage/engine": ["../mage-engine/mage-engine.mjs"]
+      "@mage/engine": ["./node_modules/mage/js/mage-lib.js"]
     },
 
     /* Bundler mode */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import { fileURLToPath, URL } from 'node:url'
 
 const backendProxyTarget = 'http://localhost:8080'
 const workspaceRoot = fileURLToPath(new URL('..', import.meta.url))
-const mageEngineEntry = fileURLToPath(new URL('../mage-engine/mage-engine.mjs', import.meta.url))
+const mageEngineEntry = fileURLToPath(new URL('./node_modules/mage/js/mage-lib.js', import.meta.url))
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary

This PR updates the frontend to use the new local MAGE engine package and expands the Create Preset flow to match the engine’s current preset surface while keeping the existing page layout and overall feel.

## What Changed

- switched the frontend engine integration to the local packaged engine in `../mage-engine/mage-1.0.0.tgz`
- aliased `@mage/engine` to `node_modules/mage/js/mage-lib.js` because the package root export is broken
- updated the shared MAGE player adapter/types so homepage, preset detail, and create preset preview all run against the packaged engine
- expanded `CreatePresetPage` to support the engine’s current preset shape:
  - `visualizer`
  - `controls`
  - `intent`
  - `fx`
  - `state`
- reorganized the create preset UI into:
  - Scene
  - Camera
  - Motion
  - Effects
  - Pass Order
  - Advanced
- exposed the relevant engine-backed settings across those sections, including:
  - shader selection + editable shader source
  - skybox selection
  - camera position/target/zoom/FOV/orientation
  - motion/audio-response controls
  - bloom, tone mapping, RGB shift, afterimage, colorify, kaleidoscope, and other pass toggles
  - pass ordering
  - advanced runtime/json fields
- hardcoded the embedded engine shaders into the frontend for now and gave them user-facing names

## Notes

- the packaged engine still has upstream issues:
  - broken root export
  - missing `controltips.png` at build time
  - large bundle size / `shader-park-core` eval warnings

## Verification

- `npm test -- CreatePresetPage`
- `npm run build`
