### PR TITLE
Rewrite frontend README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,133 +1,199 @@
 # MAGE Frontend
 
-Frontend for the MAGE project, built with React, TypeScript, and Vite.
+The MAGE frontend is the React application for browsing, creating, and playing MAGE scenes in the browser. It provides account flows, preset management screens, the reusable in-app MAGE player, and the preset editor used to author scene data for the engine.
 
-Right now this app contains the first real account-management flows for the platform: registration and login pages backed by the Spring Boot authentication API plus a shared frontend auth session.
+## Overview
 
-## Run locally
+This repository contains the client-side application for the MAGE platform. It is built with React, TypeScript, and Vite, and integrates with:
 
-```bash
-npm install
-npm run dev
-```
+- the MAGE backend API for authentication and preset persistence
+- the local MAGE engine package for scene playback and preset preview
 
-Then open `http://localhost:5173`.
+The current app includes:
 
-## Local backend configuration
+- guest and authenticated account flows
+- a reusable browser-based MAGE player
+- preset listing and preset detail pages
+- a multi-section create preset editor
+- shared auth session restore and protected routes
 
-For local development, the Vite dev server proxies these backend routes to `http://localhost:8080`:
+## Tech Stack
 
-- `POST /auth/register`
-- `POST /auth/login`
-- `GET /users/me`
-- `/presets/*`
+- React 19
+- TypeScript
+- Vite
+- React Router 7
+- Vitest + Testing Library
+- ESLint
+- Local MAGE engine package via `../mage-engine/mage-1.0.0.tgz`
 
-With the proxy in place, the frontend can keep using same-origin requests such as `/auth/login` while the backend runs separately on port `8080`.
-
-No frontend environment variables are required for this local proxy-based setup.
-
-To run the backend locally, start the backend stack from the `mage-backend` repository with:
-
-```bash
-docker compose up --build
-```
-
-The backend quick-start and local run details are documented in `mage-backend/docs/getting-started.md`.
-
-`VITE_API_BASE_URL` is still supported for deployed or intentionally cross-origin setups. When it is set, the frontend sends requests directly to that origin instead of using the local Vite proxy:
+## Repository Structure
 
 ```text
-${VITE_API_BASE_URL}/auth/register
-${VITE_API_BASE_URL}/auth/login
-${VITE_API_BASE_URL}/users/me
+mage-frontend/
+|- docs/              Additional implementation notes
+|- public/            Static assets served by Vite
+|- src/
+|  |- auth/           Shared auth session and account context
+|  |- components/     Reusable UI and player components
+|  |- lib/            Scene editor helpers, API helpers, engine adapter
+|  |- pages/          Route-level screens
+|  |- test/           Shared test setup
+|  `- types/          Local type declarations
+|- .env.example
+|- package.json
+`- vite.config.ts
 ```
 
-Leave `VITE_API_BASE_URL` unset for normal localhost development so the proxy handles auth and current-user requests.
+## Prerequisites
 
-## Routing
+Before running the frontend locally, make sure you have:
 
-The app uses `react-router-dom` with `BrowserRouter` for clean client-side URLs.
+- a recent Node.js and npm installation
+- the MAGE engine package available at `../mage-engine/mage-1.0.0.tgz`
+- the backend API running locally if you want full auth and preset flows
 
-Available routes:
+The local workspace is expected to look roughly like this:
 
-- `/`
-- `/register`
-- `/login`
-- `/my-presets`
-- `/presets/:id`
-- `/create-preset`
+```text
+MAGE/
+|- mage-backend/
+|- mage-engine/
+`- mage-frontend/
+```
 
-Note: direct loads of nested routes in production require the host to rewrite unknown paths back to `index.html`.
+If `../mage-engine/mage-1.0.0.tgz` is missing, `npm install` in this repo will fail.
 
-## Registration page
+## Getting Started
 
-The registration flow lives at `/register` and currently supports:
+1. Install frontend dependencies:
 
-- display name, email, and password inputs
-- client-side validation before submission
-- loading and disabled submit state during the request
-- success confirmation after a successful registration
-- backend validation and conflict error messaging in the UI
-- responsive layout for desktop and mobile
+   ```bash
+   npm install
+   ```
 
-Additional implementation notes are in `docs/registration-page.md`.
+2. Start the backend on `http://localhost:8080`.
 
-## Login page
+3. Start the frontend dev server:
 
-The login flow lives at `/login` and currently supports:
+   ```bash
+   npm run dev
+   ```
 
-- email and password inputs
-- client-side validation before submission
-- loading and disabled submit state during the request
-- storing the returned `accessToken` in shared frontend auth state
-- restoring the authenticated user on refresh through `GET /users/me`
-- backend validation and invalid-credential error messaging in the UI
-- logout from the shared app shell
-- responsive layout for desktop and mobile
+4. Open:
 
-The page submits credentials to `POST /auth/login`, persists the returned `accessToken`, and uses `GET /users/me` during app bootstrap when a stored token exists. Authenticated frontend requests can reuse the stored bearer token through the shared auth helper.
+   ```text
+   http://localhost:5173
+   ```
 
-Additional implementation notes are in `docs/login-page.md`.
+## Configuration
 
-## Player component
+The frontend supports one optional environment variable:
 
-The frontend now includes a reusable `MagePlayer` React component for embedding the MAGE
-engine inside normal page layouts.
+```bash
+VITE_API_BASE_URL=
+```
 
-- the component owns engine startup and disposal so pages do not call `initMAGE()` directly
-- pages pass a preset scene blob, typically `preset.sceneData`, through the `sceneBlob` prop
-- empty, loading, and invalid-preset states are rendered in the component instead of crashing
-- the home page includes a live player embed that exercises the wrapper in the browser
+Behavior:
 
-Usage notes and an example embed live in `docs/player-component.md`.
+- if `VITE_API_BASE_URL` is unset, the frontend uses the local Vite proxy and sends requests to `/api/*`
+- if `VITE_API_BASE_URL` is set, requests are sent directly to that origin
 
-## Preset detail page
+For local development, the Vite dev server proxies `/api` to:
 
-The preset detail flow lives at `/presets/:id` and currently supports:
+```text
+http://localhost:8080
+```
 
-- direct loads and internal navigation through the route param
-- fetching preset metadata, thumbnail references, and scene data from `GET /presets/{id}`
-- rendering the embedded `MagePlayer` with the fetched scene blob
-- clear invalid-link, auth-required, not-found, and unavailable states instead of a blank page
+That proxy is configured in [vite.config.ts](./vite.config.ts).
 
-In the current backend build, preset detail requests are still authenticated. The route remains
-deep-linkable, and signed-out users receive a clear sign-in-needed state instead of a broken page.
+## Available Scripts
 
-## Scripts
-
-- `npm run dev` starts the local development server
+- `npm run dev` starts the Vite development server
 - `npm run build` creates a production build
-- `npm run preview` previews the production build locally
+- `npm run preview` serves the production build locally
 - `npm run lint` runs ESLint
-- `npm run test` runs the frontend test suite with Vitest
+- `npm run test` runs the Vitest suite
 
-## Current status
+## Application Routes
 
-- Landing page for the MAGE platform
-- Registration page connected to the backend registration endpoint
-- Login page connected to the backend login endpoint
-- Shared frontend auth session with token persistence, bootstrap restore, and logout
-- Reusable MAGE player component with a live home-page preview
-- Preset detail/player route backed by `GET /presets/{id}` and the shared player wrapper
-- Header navigation between pages without full page reloads
-- Live demo link: `https://bsiscoe.github.io/MAGE/`
+| Route | Access | Purpose |
+| --- | --- | --- |
+| `/` | Public | Landing page with embedded MAGE preview |
+| `/register` | Guest-only | Account registration |
+| `/login` | Guest-only | Account sign-in |
+| `/my-presets` | Authenticated | User preset library |
+| `/presets/:id` | Public route | Preset detail/player page |
+| `/create-preset` | Public route | Preset editor and live preview |
+| `/settings` | Authenticated | Account settings |
+
+Notes:
+
+- authenticated routes redirect through shared session restore
+- direct loads of nested routes in production require host rewrites back to `index.html`
+- preset creation depends on authenticated backend access when persisting data
+
+## Current Frontend Areas
+
+### Authentication
+
+- registration page with client-side validation
+- login page with bearer-token storage
+- session restore through `GET /api/users/me`
+- guest-only and protected route wrappers
+- account settings page with basic profile details
+
+### MAGE Playback
+
+- reusable `MagePlayer` React component
+- homepage preview powered by the shared player wrapper
+- preset detail page playback
+- create preset live preview
+
+### Preset Flows
+
+- user preset listing
+- preset detail screen
+- create preset editor with scene, camera, motion, effects, pass-order, and advanced sections
+- structured scene data authoring for the MAGE engine
+
+## Engine Integration Notes
+
+The frontend currently consumes the MAGE engine as a local package dependency:
+
+```json
+"mage": "file:../mage-engine/mage-1.0.0.tgz"
+```
+
+There is one important implementation detail in the frontend today:
+
+- the package root export is not used directly
+- `@mage/engine` is aliased to `node_modules/mage/js/mage-lib.js`
+- this keeps the frontend working with the current packaged engine layout
+
+If the engine package export surface changes, check:
+
+- [vite.config.ts](./vite.config.ts)
+- [tsconfig.app.json](./tsconfig.app.json)
+- [src/lib/magePlayerAdapter.ts](./src/lib/magePlayerAdapter.ts)
+
+## Documentation
+
+Additional project notes live in `docs/`:
+
+- [docs/README.md](./docs/README.md)
+- [docs/create-preset-page.md](./docs/create-preset-page.md)
+- [docs/engine-integration.md](./docs/engine-integration.md)
+- [docs/login-page.md](./docs/login-page.md)
+- [docs/player-component.md](./docs/player-component.md)
+- [docs/registration-page.md](./docs/registration-page.md)
+
+## Development Notes
+
+- the frontend API helper automatically namespaces requests under `/api`
+- the create preset editor is tied to the current engine preset shape
+- the engine package currently emits build warnings related to missing runtime assets and large bundle size
+
+## Status
+
+This repository is an active application repo, not a generated starter. The codebase is already wired to real auth flows, real preset routes, and the local MAGE engine package, and should be treated as the main browser client for ongoing frontend product work.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,24 @@
+# Frontend Docs
+
+This directory holds focused implementation notes for the MAGE frontend. The repository README covers setup, scripts, and the high-level project overview. These docs are meant to answer feature-specific questions without forcing readers to scan route code first.
+
+## Documents
+
+- [create-preset-page.md](./create-preset-page.md)  
+  Preset editor structure, submission flow, and current persistence limits.
+
+- [engine-integration.md](./engine-integration.md)  
+  Local engine package assumptions, aliasing, and current integration caveats.
+
+- [login-page.md](./login-page.md)  
+  Login flow behavior, session handling, and backend request shape.
+
+- [player-component.md](./player-component.md)  
+  `MagePlayer` usage, scene blob expectations, and integration rules.
+
+- [registration-page.md](./registration-page.md)  
+  Registration flow behavior, redirect path, and backend request shape.
+
+## Scope
+
+Use these docs when you need to understand a specific frontend area. Use the repository README when you need to install, run, lint, test, or build the project locally.

--- a/docs/create-preset-page.md
+++ b/docs/create-preset-page.md
@@ -1,0 +1,88 @@
+# Create Preset Page
+
+## Overview
+
+The create preset page is the frontend editor for building MAGE scene data and previewing it live in the browser. It is organized into editor sections that map to the engine's current preset shape while keeping the UI approachable for normal users.
+
+Route:
+
+- `/create-preset`
+
+## Related Files
+
+- `src/pages/CreatePresetPage.tsx`
+- `src/lib/presetEditor.ts`
+- `src/lib/embeddedShaderPresets.ts`
+- `src/components/PresetEditorControls.tsx`
+- `src/pages/CreatePresetPage.test.tsx`
+
+## Editor Sections
+
+The page is split into:
+
+- `Scene`
+- `Camera`
+- `Motion`
+- `Effects`
+- `Pass Order`
+- `Advanced`
+
+Those sections write into a structured scene object built around:
+
+- `visualizer`
+- `controls`
+- `intent`
+- `fx`
+- `state`
+
+## Submission Flow
+
+The page submits preset creation through:
+
+- `POST /api/presets`
+
+Current request body:
+
+```json
+{
+  "name": "Preset Name",
+  "sceneData": {
+    "visualizer": {},
+    "controls": {},
+    "intent": {},
+    "fx": {},
+    "state": {}
+  }
+}
+```
+
+Submission uses `authenticatedFetch()`, so the save action requires a valid signed-in session even though the route itself is not currently wrapped in a protected route.
+
+## Live Preview
+
+The page uses the shared `MagePlayer` component for inline preview. Edits update the structured scene data, and the preview reflects the current in-memory scene blob rather than waiting for a saved backend record.
+
+## Current Data Model Notes
+
+- shader choices currently come from the embedded engine presets hardcoded in `src/lib/embeddedShaderPresets.ts`
+- skybox choices are exposed as bundled skybox ids
+- pass ordering is supported, with `outputPass` pinned last
+- several advanced engine values are surfaced as raw numeric fields for debugging and schema completeness
+
+## Current Limitations
+
+The page includes metadata controls beyond the persisted payload, but not all of them are saved yet.
+
+At the moment:
+
+- `name` and `sceneData` are submitted
+- description, playlist, and thumbnail picker state are UI-only
+- some engine passes exist in the stack but do not have fully persisted boolean support in the compact preset schema
+
+If preset persistence expands on the backend, this page is a likely place for follow-up wiring.
+
+## Tests
+
+Main coverage lives in:
+
+- `src/pages/CreatePresetPage.test.tsx`

--- a/docs/engine-integration.md
+++ b/docs/engine-integration.md
@@ -1,0 +1,78 @@
+# Engine Integration
+
+## Overview
+
+The frontend consumes the MAGE engine through a local packaged dependency, not a public npm package from the registry. This is an important repository assumption.
+
+## Package Source
+
+The current dependency in `package.json` is:
+
+```json
+"mage": "file:../mage-engine/mage-1.0.0.tgz"
+```
+
+The workspace is expected to contain:
+
+```text
+MAGE/
+|- mage-backend/
+|- mage-engine/
+`- mage-frontend/
+```
+
+If the `mage-engine` folder or tarball is missing, local installs will fail.
+
+## Why The Frontend Uses An Alias
+
+The frontend does not import the package root directly. Instead, `@mage/engine` is aliased to:
+
+```text
+node_modules/mage/js/mage-lib.js
+```
+
+This alias exists because the current packaged engine layout is not cleanly consumable from its root export.
+
+Relevant files:
+
+- `vite.config.ts`
+- `tsconfig.app.json`
+- `src/types/mage-engine.d.ts`
+
+## Frontend Boundary
+
+Pages should not import the engine directly. The intended boundary is:
+
+- page code -> `MagePlayer`
+- `MagePlayer` -> `magePlayerAdapter`
+- `magePlayerAdapter` -> `@mage/engine`
+
+Relevant files:
+
+- `src/components/MagePlayer.tsx`
+- `src/lib/magePlayerAdapter.ts`
+
+## Scene Data Expectations
+
+The player adapter treats a value as renderable scene data if it contains at least one recognized engine branch such as:
+
+- `visualizer`
+- `controls`
+- `intent`
+- `fx`
+- `state`
+- `settings`
+- `audioPath`
+
+That keeps route components simple and allows backend `sceneData` payloads to be passed through directly.
+
+## Current Caveats
+
+These are current package-level caveats worth knowing before making engine-related changes:
+
+- the npm registry package named `mage` is not this engine, so the frontend must keep using the local tarball dependency
+- the packaged engine currently emits a build warning for a missing `controltips.png` runtime asset
+- `shader-park-core` emits `eval` warnings during build
+- the engine bundle is large enough to trigger Vite chunk-size warnings
+
+These warnings do not currently block the frontend build, but they are useful context when debugging engine-related issues.

--- a/docs/login-page.md
+++ b/docs/login-page.md
@@ -1,18 +1,34 @@
 # Login Page
 
-The login page is available at `/login`.
+## Overview
 
-## Purpose
+The login page handles local email-and-password sign-in for the frontend. It validates credentials on the client, exchanges them for a bearer token through the backend, and hands the resulting session to the shared auth provider.
 
-This page handles the local email-and-password sign-in flow in the frontend. It validates credentials on the client, submits them to the backend login endpoint, persists the returned access token, and restores the signed-in user through the shared auth session.
+Route:
 
-## API contract
+- `/login`
 
-- Method: `POST`
-- Endpoint: `/api/auth/login`
-- Content type: `application/json`
+Access:
 
-Request body:
+- guest-only
+- authenticated users are redirected to `/settings`
+
+## Related Files
+
+- `src/pages/LoginPage.tsx`
+- `src/auth/AuthContext.tsx`
+- `src/lib/api.ts`
+- `src/lib/authForm.ts`
+- `src/pages/LoginPage.test.tsx`
+- `src/auth/AuthContext.test.tsx`
+
+## Request Flow
+
+Primary request:
+
+- `POST /api/auth/login`
+
+Expected request body:
 
 ```json
 {
@@ -21,54 +37,54 @@ Request body:
 }
 ```
 
-The page reads `VITE_API_BASE_URL` at runtime. When the variable is set, requests are sent to `${VITE_API_BASE_URL}/api/auth/login`. When it is not set, the page uses same-origin `/api/auth/login`.
+Session bootstrap request:
 
-When a stored access token exists, the frontend bootstraps auth state by calling `${VITE_API_BASE_URL}/api/users/me` or same-origin `/api/users/me`.
+- `GET /api/users/me`
 
-For normal localhost development, the Vite dev server proxies same-origin `/api` requests to `http://localhost:8080`.
+Requests are built through `buildApiUrl()`. For local development, leave `VITE_API_BASE_URL` unset and use the Vite `/api` proxy described in the repository README.
 
-## UI behavior
+## User-Facing Behavior
 
-- Requires email and password before submission
-- Validates email format on the client
-- Disables the submit button while the request is in flight
-- Stores the returned `accessToken` in browser storage after a successful login response
-- Restores the authenticated user on refresh through `GET /api/users/me`
-- Shows backend validation errors from `details`
-- Shows invalid-credential or generic form errors when login fails
-- Clears invalid or expired stored tokens automatically
-- Shows logout in the shared app header when the user is signed in
+- validates required fields before submission
+- validates email format on the client
+- disables the submit button while the request is in flight
+- stores the issued `accessToken` and user snapshot through `completeLoginSession()`
+- redirects to `/settings` after a successful login
+- shows field-level and form-level backend errors when available
+- shows a registration success notice when arriving from the registration flow
+- clears stale or invalid stored sessions when `/api/users/me` returns `401`
 
-## Shared auth session
+## Auth Session Notes
 
-The shared frontend auth provider currently:
+The shared auth provider stores session data under:
 
-- persists the login `accessToken` in browser storage
-- boots auth state on app load
-- calls `GET /api/users/me` when a stored token exists
-- clears the stored token if the backend responds with `401`
-- provides a shared authenticated request helper that sends `Authorization: Bearer <accessToken>`
-- exposes logout that clears the stored token and shared auth state
+```text
+mage.auth.session
+```
 
-## Test coverage
+That provider is responsible for:
 
-`src/pages/LoginPage.test.tsx` covers:
+- persisting the access token
+- restoring the session on app startup
+- verifying the stored token through `GET /api/users/me`
+- exposing `authenticatedFetch()` for protected API calls
+- clearing auth state on logout or invalid-token responses
 
-- client-side validation without network submission
-- successful submission, including loading, auth-session storage, and success states
-- request payload trimming and endpoint usage
-- invalid-credential error handling from the backend
-- backend validation-detail handling for the form fields
+## Failure Modes
 
-`src/auth/AuthContext.test.tsx` covers:
+- `401` from login is surfaced as an invalid-credentials error
+- missing `accessToken` in an otherwise successful response is treated as a frontend error
+- network failures show a generic unavailable message
+- invalid stored sessions are removed automatically during auth bootstrap
 
-- `GET /api/users/me` during app bootstrap when a stored token exists
-- restoring the authenticated user from a valid stored session
-- clearing invalid stored tokens on `401`
-- logout clearing shared auth state and browser storage
-- authenticated requests sending the bearer token and clearing auth state on `401`
+## Tests
 
-Run the tests with:
+Main coverage lives in:
+
+- `src/pages/LoginPage.test.tsx`
+- `src/auth/AuthContext.test.tsx`
+
+Run them with:
 
 ```bash
 npm run test

--- a/docs/player-component.md
+++ b/docs/player-component.md
@@ -1,17 +1,31 @@
 # Player Component
 
-## Purpose
+## Overview
 
-`MagePlayer` is the frontend boundary for embedding the engine in React pages. It keeps
-engine-specific setup out of page components and accepts a preset scene blob through a single
-`sceneBlob` prop.
+`MagePlayer` is the React boundary for rendering MAGE scenes in the browser. Pages should pass a scene blob into the component and let the shared adapter handle engine startup, scene loading, and disposal.
 
-## Example
+## Related Files
+
+- `src/components/MagePlayer.tsx`
+- `src/lib/magePlayerAdapter.ts`
+- `src/types/mage-engine.d.ts`
+- `src/components/MagePlayer.test.tsx`
+
+## Public Interface
+
+`MagePlayer` accepts:
+
+- `sceneBlob`: `MageSceneBlob | null | undefined`
+- `ariaLabel?`: optional canvas label
+- `className?`: optional wrapper class
+- `log?`: optional engine logging flag
+
+Example:
 
 ```tsx
 import { MagePlayer } from '../components/MagePlayer'
 
-export function PresetDetailsPage({ preset }: { preset: { name: string; sceneData: Record<string, unknown> } }) {
+export function PresetDetail({ preset }: { preset: { name: string; sceneData: Record<string, unknown> } }) {
   return (
     <section>
       <h1>{preset.name}</h1>
@@ -21,14 +35,37 @@ export function PresetDetailsPage({ preset }: { preset: { name: string; sceneDat
 }
 ```
 
-## Runtime behavior
+## Expected Scene Data
 
-- `sceneBlob={null}` or `undefined` shows the empty state and does not start the engine
-- a valid scene blob initializes the engine, starts rendering, and disposes cleanly on unmount
-- invalid scene data shows a recoverable error state instead of crashing the page
+The adapter accepts scene blobs that contain at least one engine-recognized root branch such as:
 
-## Integration notes
+- `visualizer`
+- `controls`
+- `intent`
+- `fx`
+- `state`
+- `settings`
+- `audioPath`
 
-- Pass the raw preset scene object returned by the backend. Do not call `initMAGE()` from page code.
-- Keep the engine boundary inside `src/lib/magePlayerAdapter.ts`.
-- If a page replaces the current preset, pass the next `sceneBlob` object to the same `MagePlayer` instance and let the component recreate the engine safely.
+Pages should pass the raw `sceneData` object returned by the backend instead of manually reshaping it in page code.
+
+## Runtime Behavior
+
+- `sceneBlob={null}` or `undefined` shows the empty state
+- the engine is created once the canvas mounts
+- the current scene is applied when both the player and a valid `sceneBlob` are available
+- invalid scene data produces a recoverable error overlay instead of crashing the page
+- the engine instance is disposed on unmount
+
+## Integration Rules
+
+- do not call `initMAGE()` directly from route components
+- keep engine-specific logic inside `src/lib/magePlayerAdapter.ts`
+- if a page swaps presets, pass the next `sceneBlob` to the same `MagePlayer` instance and let the component reload it
+- if engine wiring changes, update the adapter first and keep page code thin
+
+## Tests
+
+Main coverage lives in:
+
+- `src/components/MagePlayer.test.tsx`

--- a/docs/registration-page.md
+++ b/docs/registration-page.md
@@ -1,18 +1,32 @@
 # Registration Page
 
-The registration page is available at `/register`.
+## Overview
 
-## Purpose
+The registration page creates a local MAGE account through the backend auth API. It performs lightweight client-side validation, submits the registration payload, and then forwards the user to the login page instead of creating a logged-in session automatically.
 
-This page is the first implemented account-management flow in the frontend. It collects local-account credentials, validates them on the client, and submits them to the backend registration endpoint.
+Route:
 
-## API contract
+- `/register`
 
-- Method: `POST`
-- Endpoint: `/api/auth/register`
-- Content type: `application/json`
+Access:
 
-Request body:
+- guest-only
+- authenticated users are redirected away through the shared route guard
+
+## Related Files
+
+- `src/pages/RegisterPage.tsx`
+- `src/lib/api.ts`
+- `src/lib/authForm.ts`
+- `src/pages/RegisterPage.test.tsx`
+
+## Request Flow
+
+Primary request:
+
+- `POST /api/auth/register`
+
+Expected request body:
 
 ```json
 {
@@ -22,29 +36,40 @@ Request body:
 }
 ```
 
-The page reads `VITE_API_BASE_URL` at runtime. When the variable is set, requests are sent to `${VITE_API_BASE_URL}/api/auth/register`. When it is not set, the page uses same-origin `/api/auth/register`.
+Requests are built through `buildApiUrl()`. For local development, leave `VITE_API_BASE_URL` unset and use the Vite `/api` proxy described in the repository README.
 
-For normal localhost development, the Vite dev server proxies same-origin `/api` requests to `http://localhost:8080`.
+## User-Facing Behavior
 
-## UI behavior
+- validates display name, email, and password before submission
+- requires a minimum display-name length of `2`
+- requires a minimum password length of `8`
+- disables the submit button while the request is in flight
+- surfaces backend validation details when present
+- surfaces conflict responses such as duplicate-email registration
+- redirects to `/login` on success
+- passes the registered email and a success notice into login page state
 
-- Requires display name, email, and password before submission
-- Validates email format and minimum lengths on the client
-- Disables the submit button while the request is in flight
-- Shows a success state after a successful registration
-- Shows backend validation errors from `details`
-- Shows conflict or generic form errors when registration fails
+## Current Scope
 
-## Test coverage
+The registration page currently supports:
 
-`src/pages/RegisterPage.test.tsx` covers:
+- local account creation
+- client-side validation
+- backend error handling
+- post-registration redirect into login
 
-- client-side validation without network submission
-- successful submission, including loading and success states
-- request payload trimming and endpoint usage
-- conflict error handling from the backend
+It does not currently:
 
-Run the tests with:
+- create an authenticated session on success
+- support OAuth-based sign-up directly from this page
+
+## Tests
+
+Main coverage lives in:
+
+- `src/pages/RegisterPage.test.tsx`
+
+Run it with:
 
 ```bash
 npm run test


### PR DESCRIPTION
## Summary

This PR rewrites the frontend README and docs so the repository reads like a maintained application repo instead of a collection of feature notes.

## What Changed

- rewrote the root `README.md` with:
  - project overview
  - stack
  - repository structure
  - prerequisites
  - local setup
  - configuration
  - routes
  - engine integration notes
  - docs links
- rewrote the existing docs pages for:
  - login flow
  - registration flow
  - player component
- added new docs pages for:
  - create preset page
  - engine integration
  - docs index / docs README
- tightened the docs so they focus on repo-specific behavior and implementation constraints without repeating the main README too much

## Why

The previous docs had useful information, but they read more like incremental notes than a professional project documentation set. This update makes the repo easier to understand for someone new to the codebase, especially around:

- how auth/session restore works
- how the MAGE player is supposed to be used
- how the create preset page actually behaves today
- how the local `mage-engine` package is wired into the frontend
- what current limitations or caveats exist

## Notes

- this is a docs-only PR
- no product behavior or runtime code was changed

## Testing

- not run, docs-only change
