### PR TITLE
Prepare frontend for same-origin deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+.git
+.github
+.vscode
+.idea
+*.log
+.env.local
+.env.*
+!.env.example

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
-# Optional backend base URL for deployed or direct cross-origin API access.
+# Optional backend base URL.
 # Leave unset for local Vite proxy development.
+# For same-origin production deployments, leaving this unset still works because
+# the frontend defaults requests to /api/*.
+# If you want an explicit production build-time value, use:
+# VITE_API_BASE_URL=/api
 VITE_API_BASE_URL=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:20-bookworm-slim AS build
+WORKDIR /app
+
+ARG VITE_API_BASE_URL=
+ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
+
+COPY package.json package-lock.json ./
+COPY vendor ./vendor
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+FROM nginx:1.27-alpine
+COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The MAGE frontend is the React application for browsing, creating, and playing M
 This repository contains the client-side application for the MAGE platform. It is built with React, TypeScript, and Vite, and integrates with:
 
 - the MAGE backend API for authentication and preset persistence
-- the local MAGE engine package for scene playback and preset preview
+- the bundled local MAGE engine package for scene playback and preset preview
 
 The current app includes:
 
@@ -50,19 +50,9 @@ mage-frontend/
 Before running the frontend locally, make sure you have:
 
 - a recent Node.js and npm installation
-- the MAGE engine package available at `../mage-engine/mage-1.0.0.tgz`
 - the backend API running locally if you want full auth and preset flows
 
-The local workspace is expected to look roughly like this:
-
-```text
-MAGE/
-|- mage-backend/
-|- mage-engine/
-`- mage-frontend/
-```
-
-If `../mage-engine/mage-1.0.0.tgz` is missing, `npm install` in this repo will fail.
+The engine package used by the frontend is vendored inside this repository under `vendor/mage-engine/` so the app can build in CI and deployment environments without depending on a sibling workspace checkout.
 
 ## Getting Started
 
@@ -98,6 +88,7 @@ Behavior:
 
 - if `VITE_API_BASE_URL` is unset, the frontend uses the local Vite proxy and sends requests to `/api/*`
 - if `VITE_API_BASE_URL` is set, requests are sent directly to that origin
+- for same-origin production deployments, leaving it unset or building with `VITE_API_BASE_URL=/api` both work
 
 For local development, the Vite dev server proxies `/api` to:
 
@@ -106,6 +97,17 @@ http://localhost:8080
 ```
 
 That proxy is configured in [vite.config.ts](./vite.config.ts).
+
+## Deployment
+
+The supported production strategy is same-origin deployment:
+
+- the frontend is served from the public app origin
+- `/api/*` is routed to the backend by the reverse proxy
+- browser auth traffic stays on one HTTPS origin
+- direct loads of client routes such as `/login` and `/register` require SPA fallback to `index.html`
+
+See [docs/deployment.md](./docs/deployment.md) for the deployment contract and the Coolify-oriented production notes.
 
 ## Available Scripts
 
@@ -162,7 +164,7 @@ Notes:
 The frontend currently consumes the MAGE engine as a local package dependency:
 
 ```json
-"mage": "file:../mage-engine/mage-1.0.0.tgz"
+"mage": "file:vendor/mage-engine/mage-1.0.0.tgz"
 ```
 
 There is one important implementation detail in the frontend today:
@@ -183,6 +185,7 @@ Additional project notes live in `docs/`:
 
 - [docs/README.md](./docs/README.md)
 - [docs/create-preset-page.md](./docs/create-preset-page.md)
+- [docs/deployment.md](./docs/deployment.md)
 - [docs/engine-integration.md](./docs/engine-integration.md)
 - [docs/login-page.md](./docs/login-page.md)
 - [docs/player-component.md](./docs/player-component.md)

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,11 @@
+server {
+  listen 80;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,9 @@ This directory holds focused implementation notes for the MAGE frontend. The rep
 - [create-preset-page.md](./create-preset-page.md)  
   Preset editor structure, submission flow, and current persistence limits.
 
+- [deployment.md](./deployment.md)  
+  Supported production deployment strategy, reverse-proxy expectations, and container notes.
+
 - [engine-integration.md](./engine-integration.md)  
   Local engine package assumptions, aliasing, and current integration caveats.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,51 @@
+# Frontend Deployment
+
+This repository is designed to be deployed with a same-origin routing setup.
+
+## Supported Production Model
+
+The intended production contract is:
+
+- the frontend is served from the public app origin
+- `/api/*` is routed to the backend by the reverse proxy
+- browser requests do not call a second public API origin directly
+
+This keeps deployment aligned with the current auth flow and avoids introducing CORS requirements into the supported path.
+
+## Build-Time API Configuration
+
+The frontend builds API URLs through `buildApiUrl()` in `src/lib/api.ts`.
+
+For the supported deployment path:
+- leaving `VITE_API_BASE_URL` unset works because requests default to `/api/*`
+- setting `VITE_API_BASE_URL=/api` at build time also works if you want the deployment configuration to be explicit
+
+## Container Notes
+
+The frontend repo includes:
+- a production `Dockerfile`
+- an nginx config with SPA fallback
+
+SPA fallback is required because the app uses `BrowserRouter`, so direct loads of routes like `/login` and `/register` must return `index.html`.
+
+## Reverse Proxy Expectations
+
+At the public edge:
+
+- `/` and client routes should go to the frontend container
+- `/api/*` should go to the backend container
+
+Example:
+
+```text
+https://mage.example.com/        -> frontend
+https://mage.example.com/api/*   -> backend
+```
+
+## Local Development
+
+None of this changes local development:
+
+- `npm run dev` still uses the Vite `/api` proxy
+- local auth flows still target `http://localhost:8080` through that proxy
+- no deployment-only configuration is required for standard local work

--- a/docs/engine-integration.md
+++ b/docs/engine-integration.md
@@ -2,26 +2,17 @@
 
 ## Overview
 
-The frontend consumes the MAGE engine through a local packaged dependency, not a public npm package from the registry. This is an important repository assumption.
+The frontend consumes the MAGE engine through a vendored packaged dependency, not a public npm package from the registry. This is an important repository assumption.
 
 ## Package Source
 
 The current dependency in `package.json` is:
 
 ```json
-"mage": "file:../mage-engine/mage-1.0.0.tgz"
+"mage": "file:vendor/mage-engine/mage-1.0.0.tgz"
 ```
 
-The workspace is expected to contain:
-
-```text
-MAGE/
-|- mage-backend/
-|- mage-engine/
-`- mage-frontend/
-```
-
-If the `mage-engine` folder or tarball is missing, local installs will fail.
+The tarball is kept inside this repository so local installs, CI, and production image builds do not depend on a sibling checkout.
 
 ## Why The Frontend Uses An Alias
 
@@ -71,6 +62,7 @@ That keeps route components simple and allows backend `sceneData` payloads to be
 These are current package-level caveats worth knowing before making engine-related changes:
 
 - the npm registry package named `mage` is not this engine, so the frontend must keep using the local tarball dependency
+- when the engine package changes, the vendored tarball in `vendor/mage-engine/` must be refreshed intentionally
 - the packaged engine currently emits a build warning for a missing `controltips.png` runtime asset
 - `shader-park-core` emits `eval` warnings during build
 - the engine bundle is large enough to trigger Vite chunk-size warnings

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "mage-frontend",
       "version": "0.0.0",
       "dependencies": {
-        "mage": "file:../mage-engine/mage-1.0.0.tgz",
+        "mage": "file:vendor/mage-engine/mage-1.0.0.tgz",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.13.1"
@@ -4155,7 +4155,7 @@
     },
     "node_modules/mage": {
       "version": "1.0.0",
-      "resolved": "file:../mage-engine/mage-1.0.0.tgz",
+      "resolved": "file:vendor/mage-engine/mage-1.0.0.tgz",
       "integrity": "sha512-dhTBQiXESn99tuOpeHR4CxYivqNx41AxJFr41IHqSY1lMKAgQzJgeCJz/UbQTEcZWDEwa8ezuMmUXjGw+dzLNw==",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "mage": "file:../mage-engine/mage-1.0.0.tgz",
+    "mage": "file:vendor/mage-engine/mage-1.0.0.tgz",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.13.1"

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -15,6 +15,12 @@ describe('buildApiUrl', () => {
     expect(buildApiUrl('/api/presets/12')).toBe('/api/presets/12')
   })
 
+  it('supports same-origin production routing when the base url is set to /api', () => {
+    vi.stubEnv('VITE_API_BASE_URL', '/api')
+
+    expect(buildApiUrl('/users/me')).toBe('/api/users/me')
+  })
+
   it('joins the configured base url with the normalized api path', () => {
     vi.stubEnv('VITE_API_BASE_URL', 'https://mage.example.com/')
 


### PR DESCRIPTION
## Summary

This PR prepares `mage-frontend` for the supported production deployment path: a same-origin setup where the frontend is served at the public app origin and `/api/*` is routed to the backend through the reverse proxy.

## What Changed

- vendored the local MAGE engine package into the frontend repo under `vendor/mage-engine/`
- updated the frontend dependency to install the engine from the vendored tarball instead of a sibling workspace path
- added a production frontend `Dockerfile`
- added an nginx config with SPA fallback so direct loads of `/login`, `/register`, and other client routes resolve to `index.html`
- added a frontend `.dockerignore`
- added deployment documentation for the same-origin reverse-proxy contract
- updated README and docs to document:
  - same-origin production routing
  - `/api` backend access
  - the vendored engine package assumption
- added test coverage for explicit `/api` base URL handling in production-style builds

## Why

The frontend previously depended on a sibling `mage-engine` checkout and did not include production container/routing assets. That made local development work, but left the repo incomplete for standalone deployment on infrastructure like Coolify.

This PR makes the frontend repo self-contained for deployment while keeping local Vite proxy development unchanged.

## Verification

- `npm install`
- `npm run test`
- `npm run lint`
- `npm run build`
- `docker build -t mage-frontend-deploy-test .`

## Notes

- local development still works the same way:
  - leave `VITE_API_BASE_URL` unset
  - use the Vite `/api` proxy
- supported production strategy is same-origin routing, not split-origin CORS
