### PR TITLE
Fix/production mage preview

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ARG VITE_API_BASE_URL=
 ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
 
 COPY package.json package-lock.json ./
+COPY patches ./patches
 COPY vendor ./vendor
 RUN npm ci
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Before running the frontend locally, make sure you have:
 
 The engine package used by the frontend is vendored inside this repository under `vendor/mage-engine/` so the app can build in CI and deployment environments without depending on a sibling workspace checkout.
 
+`npm install` and `npm ci` also reapply the checked-in `patch-package` patches during `postinstall`. That is currently required for the Shader Park production compatibility fix.
+
 ## Getting Started
 
 1. Install frontend dependencies:
@@ -171,6 +173,7 @@ There is one important implementation detail in the frontend today:
 
 - the package root export is not used directly
 - `@mage/engine` is aliased to `node_modules/mage/js/mage-lib.js`
+- `shader-park-core` is aliased to its ESM bundle and patched locally through `patch-package`
 - this keeps the frontend working with the current packaged engine layout
 
 If the engine package export surface changes, check:
@@ -178,6 +181,7 @@ If the engine package export surface changes, check:
 - [vite.config.ts](./vite.config.ts)
 - [tsconfig.app.json](./tsconfig.app.json)
 - [src/lib/magePlayerAdapter.ts](./src/lib/magePlayerAdapter.ts)
+- [patches/shader-park-core+0.2.8.patch](./patches/shader-park-core+0.2.8.patch)
 
 ## Documentation
 
@@ -195,6 +199,7 @@ Additional project notes live in `docs/`:
 
 - the frontend API helper automatically namespaces requests under `/api`
 - the create preset editor is tied to the current engine preset shape
+- production builds use normal Vite optimization behavior; Shader Park compatibility is handled by the checked-in `patch-package` patch rather than by disabling minification or tree-shaking
 - the engine package currently emits build warnings related to missing runtime assets and large bundle size
 
 ## Status

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -25,8 +25,11 @@ For the supported deployment path:
 The frontend repo includes:
 - a production `Dockerfile`
 - an nginx config with SPA fallback
+- a `postinstall` hook that reapplies local `patch-package` patches during `npm install` and `npm ci`
 
 SPA fallback is required because the app uses `BrowserRouter`, so direct loads of routes like `/login` and `/register` must return `index.html`.
+
+The Shader Park production compatibility fix is expected to come from that checked-in patching step, not from disabling Vite optimizations. Production builds should continue to use the normal `vite build` minification and tree-shaking behavior.
 
 ## Reverse Proxy Expectations
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -31,6 +31,8 @@ SPA fallback is required because the app uses `BrowserRouter`, so direct loads o
 
 The Shader Park production compatibility fix is expected to come from that checked-in patching step, not from disabling Vite optimizations. Production builds should continue to use the normal `vite build` minification and tree-shaking behavior.
 
+For container builds, the `patches/` directory must be copied into the image before `npm ci` runs. If `npm ci` runs before `patches/` is present, `patch-package` will not apply the Shader Park fix and the deployed bundle can regress to runtime errors such as `input is not defined`.
+
 ## Reverse Proxy Expectations
 
 At the public edge:

--- a/docs/engine-integration.md
+++ b/docs/engine-integration.md
@@ -30,6 +30,22 @@ Relevant files:
 - `tsconfig.app.json`
 - `src/types/mage-engine.d.ts`
 
+## Shader Park Runtime Compatibility
+
+The current engine package pulls in `shader-park-core` through the bundled browser-facing engine code. The frontend keeps one explicit compatibility patch for that dependency:
+
+- `patches/shader-park-core+0.2.8.patch`
+
+That patch exists because Shader Park executes generated code through `eval(...)` and expects a DSL helper surface to be reachable by name at runtime. Production bundling can otherwise break scene compilation with errors such as `input is not defined`, `time is not defined`, or `rotateY is not defined`.
+
+The frontend does not work around this by disabling Vite production optimizations. Instead:
+
+- `vite.config.ts` aliases `shader-park-core` to the installed ESM bundle
+- `patch-package` reapplies the checked-in Shader Park patch on `npm install` and `npm ci`
+- the patch temporarily exposes the required Shader Park helper bindings on `globalThis` during the `eval(...)` compile step and restores the previous global values afterward
+
+If the Shader Park version changes, revalidate that patch before assuming production builds will continue to render presets correctly.
+
 ## Frontend Boundary
 
 Pages should not import the engine directly. The intended boundary is:
@@ -63,6 +79,7 @@ These are current package-level caveats worth knowing before making engine-relat
 
 - the npm registry package named `mage` is not this engine, so the frontend must keep using the local tarball dependency
 - when the engine package changes, the vendored tarball in `vendor/mage-engine/` must be refreshed intentionally
+- when `shader-park-core` changes, `patches/shader-park-core+0.2.8.patch` must be reviewed and regenerated if needed
 - the packaged engine currently emits a build warning for a missing `controltips.png` runtime asset
 - `shader-park-core` emits `eval` warnings during build
 - the engine bundle is large enough to trigger Vite chunk-size warnings

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "mage-frontend",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "mage": "file:vendor/mage-engine/mage-1.0.0.tgz",
         "react": "^19.2.0",
@@ -4554,7 +4555,7 @@
     "node_modules/mage": {
       "version": "1.0.0",
       "resolved": "file:vendor/mage-engine/mage-1.0.0.tgz",
-      "integrity": "sha512-dhTBQiXESn99tuOpeHR4CxYivqNx41AxJFr41IHqSY1lMKAgQzJgeCJz/UbQTEcZWDEwa8ezuMmUXjGw+dzLNw==",
+      "integrity": "sha512-WPQ7gDn68FipETf1csCv92nCgmX7wo8E5CYkq9OAsNCq0CsurzHlZ2lGCqVBciygfhB+rM0AnZNEZvPCSucE7w==",
       "license": "ISC",
       "dependencies": {
         "mage": "file:mage-1.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
         "jsdom": "^29.0.1",
+        "patch-package": "^8.0.1",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
         "vite": "^7.3.1",
@@ -2749,6 +2750,13 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2883,6 +2891,19 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
@@ -2914,6 +2935,56 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -2971,6 +3042,22 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/color-convert": {
@@ -3107,6 +3194,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3134,6 +3239,21 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.307",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
@@ -3153,12 +3273,45 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -3511,6 +3664,19 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -3526,6 +3692,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
       }
     },
     "node_modules/flat-cache": {
@@ -3549,6 +3725,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3563,6 +3754,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -3570,6 +3771,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob-parent": {
@@ -3598,6 +3838,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3606,6 +3866,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hermes-estree": {
@@ -3685,6 +3984,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3708,10 +4023,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3818,6 +4163,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -3837,6 +4202,29 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3845,6 +4233,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/levn": {
@@ -4253,12 +4651,49 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
@@ -4281,6 +4716,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {
@@ -4320,6 +4765,16 @@
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "license": "MIT"
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -4330,6 +4785,23 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -4405,6 +4877,49 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/path-exists": {
@@ -4749,6 +5264,24 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/shader-park-core": {
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/shader-park-core/-/shader-park-core-0.2.8.tgz",
@@ -4801,6 +5334,16 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -4950,6 +5493,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
@@ -5072,6 +5638,16 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -5383,6 +5959,22 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "devOptional": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "postinstall": "patch-package",
     "test": "vitest run",
     "preview": "vite preview"
   },
@@ -30,6 +31,7 @@
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
     "jsdom": "^29.0.1",
+    "patch-package": "^8.0.1",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
     "vite": "^7.3.1",

--- a/patches/shader-park-core+0.2.8.patch
+++ b/patches/shader-park-core+0.2.8.patch
@@ -1,0 +1,64 @@
+diff --git a/node_modules/shader-park-core/dist/shader-park-core.esm.js b/node_modules/shader-park-core/dist/shader-park-core.esm.js
+index 56ff647..4759cf2 100644
+--- a/node_modules/shader-park-core/dist/shader-park-core.esm.js
++++ b/node_modules/shader-park-core/dist/shader-park-core.esm.js
+@@ -45400,22 +45400,21 @@ function sculptToGLSL(userProvidedSrc) {
+     enable2DFlag = true;
+     return get2DCoords();
+   }
+-
+-  /*
+   function input2(name, x, y) {
+-  console.log('input2',name, x, y);
+-  let uniform = {name, type: 'vec2'};
+-  let out = x;
+-  if(y === undefined) {
+-  	uniform.value = x;
+-  } else {
+-  	out = new vec2(x, y, true);
+-  	uniform.value = out;
+-  }
+-  uniforms.push(uniform);
+-  return out;
++    var uniform = {
++      name: name,
++      type: "vec2"
++    };
++    var out = x;
++    if (y === undefined) {
++      uniform.value = x;
++    } else {
++      out = new vec2(x, y, true);
++      uniform.value = out;
++    }
++    uniforms.push(uniform);
++    return out;
+   }
+-  */
+ 
+   var error = undefined;
+   function revolve2D(sdf) {
+@@ -45526,7 +45525,22 @@ function sculptToGLSL(userProvidedSrc) {
+   var postGeneratedFunctions = replaceMathOps([getSpherical, fresnel, revolve2D, extrude2D, mirrorN, grid, repeatLinear, repeatRadial, scaleShape, vectorContourNoise].map(function (el) {
+     return el.toString();
+   }).join("\n"));
+-  eval(generatedJSFuncsSource + postGeneratedFunctions + userProvidedSrc);
++  var previousInput = globalThis.input;
++  var previousInput2D = globalThis.input2D;
++  var previousInput2 = globalThis.input2;
++  var previousMult = globalThis.mult;
++  globalThis.input = input;
++  globalThis.input2D = input2D;
++  globalThis.input2 = input2;
++  globalThis.mult = mult;
++  try {
++    eval(generatedJSFuncsSource + postGeneratedFunctions + userProvidedSrc);
++  } finally {
++    previousInput === undefined ? delete globalThis.input : globalThis.input = previousInput;
++    previousInput2D === undefined ? delete globalThis.input2D : globalThis.input2D = previousInput2D;
++    previousInput2 === undefined ? delete globalThis.input2 : globalThis.input2 = previousInput2;
++    previousMult === undefined ? delete globalThis.mult : globalThis.mult = previousMult;
++  }
+   if (enable2DFlag) {
+     setSDF(0);
+   }

--- a/patches/shader-park-core+0.2.8.patch
+++ b/patches/shader-park-core+0.2.8.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/shader-park-core/dist/shader-park-core.esm.js b/node_modules/shader-park-core/dist/shader-park-core.esm.js
-index 56ff647..4759cf2 100644
+index 56ff647..ec2ddb4 100644
 --- a/node_modules/shader-park-core/dist/shader-park-core.esm.js
 +++ b/node_modules/shader-park-core/dist/shader-park-core.esm.js
 @@ -45400,22 +45400,21 @@ function sculptToGLSL(userProvidedSrc) {
@@ -38,26 +38,88 @@ index 56ff647..4759cf2 100644
  
    var error = undefined;
    function revolve2D(sdf) {
-@@ -45526,7 +45525,22 @@ function sculptToGLSL(userProvidedSrc) {
+@@ -45526,7 +45525,84 @@ function sculptToGLSL(userProvidedSrc) {
    var postGeneratedFunctions = replaceMathOps([getSpherical, fresnel, revolve2D, extrude2D, mirrorN, grid, repeatLinear, repeatRadial, scaleShape, vectorContourNoise].map(function (el) {
      return el.toString();
    }).join("\n"));
 -  eval(generatedJSFuncsSource + postGeneratedFunctions + userProvidedSrc);
-+  var previousInput = globalThis.input;
-+  var previousInput2D = globalThis.input2D;
-+  var previousInput2 = globalThis.input2;
-+  var previousMult = globalThis.mult;
-+  globalThis.input = input;
-+  globalThis.input2D = input2D;
-+  globalThis.input2 = input2;
-+  globalThis.mult = mult;
++  var evalGlobals = {
++    time: time,
++    mouse: mouse,
++    normal: normal,
++    mouseIntersection: mouseIntersection,
++    getRayDirection: getRayDirection,
++    mixMat: mixMat,
++    resetMixColor: resetMixColor,
++    union: union,
++    difference: difference,
++    intersect: intersect,
++    blend: blend,
++    mixGeo: mixGeo,
++    overwrite: overwrite,
++    shape: shape,
++    mult: mult,
++    add: add,
++    sub: sub,
++    divide: divide,
++    setSDF: setSDF,
++    getSDF: getSDF,
++    extractSDF: extractSDF,
++    reset: reset,
++    displace: displace,
++    setSpace: setSpace,
++    repeat: repeat,
++    rotateX: rotateX,
++    rotateY: rotateY,
++    rotateZ: rotateZ,
++    mirrorX: mirrorX,
++    mirrorY: mirrorY,
++    mirrorZ: mirrorZ,
++    mirrorXYZ: mirrorXYZ,
++    flipX: flipX,
++    flipY: flipY,
++    flipZ: flipZ,
++    expand: expand,
++    shell: shell,
++    color: color,
++    reflectiveColor: reflectiveColor,
++    metal: metal,
++    shine: shine,
++    fresnel: fresnel,
++    lightDirection: lightDirection,
++    backgroundColor: backgroundColor,
++    noLighting: noLighting,
++    basicLighting: basicLighting,
++    occlusion: occlusion,
++    test: test,
++    input: input,
++    input2D: input2D,
++    getPixelCoord: getPixelCoord,
++    getResolution: getResolution,
++    get2DCoords: get2DCoords,
++    enable2D: enable2D,
++    input2: input2,
++    revolve2D: revolve2D,
++    extrude2D: extrude2D,
++    getSpherical: getSpherical,
++    mirrorN: mirrorN,
++    grid: grid,
++    repeatLinear: repeatLinear,
++    repeatRadial: repeatRadial,
++    scaleShape: scaleShape,
++    vectorContourNoise: vectorContourNoise
++  };
++  var previousEvalGlobals = {};
++  Object.keys(evalGlobals).forEach(function (key) {
++    previousEvalGlobals[key] = globalThis[key];
++    globalThis[key] = evalGlobals[key];
++  });
 +  try {
 +    eval(generatedJSFuncsSource + postGeneratedFunctions + userProvidedSrc);
 +  } finally {
-+    previousInput === undefined ? delete globalThis.input : globalThis.input = previousInput;
-+    previousInput2D === undefined ? delete globalThis.input2D : globalThis.input2D = previousInput2D;
-+    previousInput2 === undefined ? delete globalThis.input2 : globalThis.input2 = previousInput2;
-+    previousMult === undefined ? delete globalThis.mult : globalThis.mult = previousMult;
++    Object.keys(evalGlobals).forEach(function (key) {
++      previousEvalGlobals[key] === undefined ? delete globalThis[key] : globalThis[key] = previousEvalGlobals[key];
++    });
 +  }
    if (enable2DFlag) {
      setSDF(0);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,9 @@ import { fileURLToPath, URL } from 'node:url'
 const backendProxyTarget = 'http://localhost:8080'
 const workspaceRoot = fileURLToPath(new URL('..', import.meta.url))
 const mageEngineEntry = fileURLToPath(new URL('./node_modules/mage/js/mage-lib.js', import.meta.url))
+const shaderParkCoreEntry = fileURLToPath(
+  new URL('./node_modules/shader-park-core/dist/shader-park-core.esm.js', import.meta.url),
+)
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -12,6 +15,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@mage/engine': mageEngineEntry,
+      'shader-park-core': shaderParkCoreEntry,
     },
   },
   server: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,12 +18,6 @@ export default defineConfig({
       'shader-park-core': shaderParkCoreEntry,
     },
   },
-  build: {
-    minify: false,
-    rollupOptions: {
-      treeshake: false,
-    },
-  },
   server: {
     fs: {
       allow: [workspaceRoot],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,12 @@ export default defineConfig({
       'shader-park-core': shaderParkCoreEntry,
     },
   },
+  build: {
+    minify: false,
+    rollupOptions: {
+      treeshake: false,
+    },
+  },
   server: {
     fs: {
       allow: [workspaceRoot],


### PR DESCRIPTION
## Summary

This PR stabilizes frontend MAGE rendering in production builds and deployments.

It addresses two separate production-only failures:

1. the vendored MAGE engine could continue its render loop after `dispose()`, causing `Cannot set properties of null (setting 'time')`
2. Shader Park scene compilation could fail in optimized bundles because generated code is executed via `eval(...)` and expects a DSL/helper surface to be available by name at runtime

It also fixes the Docker/Coolify deployment path so the checked-in `patch-package` fix is actually applied during container builds.

## What Changed

### 1. Fix the vendored MAGE engine dispose/render race
- refreshed `vendor/mage-engine/mage-1.0.0.tgz`
- updated `package-lock.json` for the new vendored engine archive

The vendored engine now:
- tracks render-loop lifecycle explicitly
- avoids starting duplicate render loops
- cancels the scheduled animation frame on `dispose()`
- exits the render loop early if the engine has already been torn down

This fixes the production crash where the engine disposed internal state and then a queued frame still tried to write `#state.time`.

### 2. Stabilize Shader Park in production builds
- added `patch-package` as a dev dependency
- added a `postinstall` hook so patches are reapplied on `npm install` / `npm ci`
- added and expanded `patches/shader-park-core+0.2.8.patch`
- aliased `shader-park-core` to its installed ESM bundle in `vite.config.ts`

The Shader Park patch now:
- restores `input2`
- exposes the required Shader Park helper/DSL bindings during the `eval(...)` compile step
- restores prior global values after evaluation

This covers the production-only runtime failures we were seeing from the Shader Park compile path, including errors like:
- `input is not defined`
- `input2 is not defined`
- `mult is not defined`
- `time is not defined`
- `rotateY is not defined`

### 3. Keep normal Vite production optimization enabled
- removed the temporary workaround that disabled minification/tree-shaking

Production compatibility now comes from the Shader Park patch itself, not from turning off Vite optimizations.

### 4. Fix Docker/Coolify builds so patches are actually applied
- updated the frontend `Dockerfile` to copy `patches/` before `npm ci`

Previously, `npm ci` ran before `patches/` existed in the image, so `patch-package` had nothing to apply during `postinstall`. That meant local production builds worked, but deployed Coolify images still shipped an unpatched Shader Park bundle.

## Docs Updated

Updated:
- `README.md`
- `docs/engine-integration.md`
- `docs/deployment.md`

Docs now describe:
- the vendored engine integration
- the Shader Park production compatibility patch
- the fact that normal Vite optimization remains enabled
- the Docker requirement that `patches/` must be copied before `npm ci`

## Validation

- `npm test`
- `npm run build`
- `vite preview`

Also verified the deployment mismatch directly by comparing the live Coolify-served bundle with the local built bundle and confirming the deployed asset did not contain the Shader Park patch before the Dockerfile fix.
