### PR TITLE
92 presigned s3 thumbnail browser uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The current app includes:
 - guest and authenticated account flows
 - a reusable browser-based MAGE player
 - preset listing and preset detail pages
-- a multi-section create preset editor with direct-to-S3 thumbnail uploads
+- a multi-section create preset editor with direct-to-object-storage thumbnail uploads
 - shared auth session restore and protected routes
 
 ## Tech Stack
@@ -158,7 +158,7 @@ Notes:
 
 - user preset listing
 - preset detail screen
-- create preset editor with scene, camera, motion, effects, pass-order, advanced sections, and staged direct-to-S3 thumbnail uploads that only commit on successful preset creation
+- create preset editor with scene, camera, motion, effects, pass-order, advanced sections, and staged direct-to-object-storage thumbnail uploads that only commit on successful preset creation
 - structured scene data authoring for the MAGE engine
 
 ## Engine Integration Notes

--- a/README.md
+++ b/README.md
@@ -121,15 +121,15 @@ See [docs/deployment.md](./docs/deployment.md) for the deployment contract and t
 
 ## Application Routes
 
-| Route | Access | Purpose |
-| --- | --- | --- |
-| `/` | Public | Landing page with embedded MAGE preview |
-| `/register` | Guest-only | Account registration |
-| `/login` | Guest-only | Account sign-in |
-| `/my-presets` | Authenticated | User preset library |
-| `/presets/:id` | Public route | Preset detail/player page |
-| `/create-preset` | Public route | Preset editor and live preview |
-| `/settings` | Authenticated | Account settings |
+| Route            | Access        | Purpose                                 |
+| ---------------- | ------------- | --------------------------------------- |
+| `/`              | Public        | Landing page with embedded MAGE preview |
+| `/register`      | Guest-only    | Account registration                    |
+| `/login`         | Guest-only    | Account sign-in                         |
+| `/my-presets`    | Authenticated | User preset library                     |
+| `/presets/:id`   | Public route  | Preset detail/player page               |
+| `/create-preset` | Public route  | Preset editor and live preview          |
+| `/settings`      | Authenticated | Account settings                        |
 
 Notes:
 
@@ -194,14 +194,3 @@ Additional project notes live in `docs/`:
 - [docs/login-page.md](./docs/login-page.md)
 - [docs/player-component.md](./docs/player-component.md)
 - [docs/registration-page.md](./docs/registration-page.md)
-
-## Development Notes
-
-- the frontend API helper automatically namespaces requests under `/api`
-- the create preset editor is tied to the current engine preset shape
-- production builds use normal Vite optimization behavior; Shader Park compatibility is handled by the checked-in `patch-package` patch rather than by disabling minification or tree-shaking
-- the engine package currently emits build warnings related to missing runtime assets and large bundle size
-
-## Status
-
-This repository is an active application repo, not a generated starter. The codebase is already wired to real auth flows, real preset routes, and the local MAGE engine package, and should be treated as the main browser client for ongoing frontend product work.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The current app includes:
 - guest and authenticated account flows
 - a reusable browser-based MAGE player
 - preset listing and preset detail pages
-- a multi-section create preset editor
+- a multi-section create preset editor with direct-to-S3 thumbnail uploads
 - shared auth session restore and protected routes
 
 ## Tech Stack
@@ -158,7 +158,7 @@ Notes:
 
 - user preset listing
 - preset detail screen
-- create preset editor with scene, camera, motion, effects, pass-order, and advanced sections
+- create preset editor with scene, camera, motion, effects, pass-order, advanced sections, and staged direct-to-S3 thumbnail uploads that only commit on successful preset creation
 - structured scene data authoring for the MAGE engine
 
 ## Engine Integration Notes

--- a/docs/create-preset-page.md
+++ b/docs/create-preset-page.md
@@ -40,7 +40,7 @@ Those sections write into a structured scene object built around:
 The page submits preset creation through:
 
 - `POST /api/presets/thumbnail/presign`
-- direct browser `PUT` to the returned S3 URL when a thumbnail is selected
+- direct browser `PUT` to the returned object-storage URL when a thumbnail is selected
 - `POST /api/presets`
 
 Current request body:

--- a/docs/create-preset-page.md
+++ b/docs/create-preset-page.md
@@ -39,6 +39,8 @@ Those sections write into a structured scene object built around:
 
 The page submits preset creation through:
 
+- `POST /api/presets/thumbnail/presign`
+- direct browser `PUT` to the returned S3 URL when a thumbnail is selected
 - `POST /api/presets`
 
 Current request body:
@@ -52,11 +54,14 @@ Current request body:
     "intent": {},
     "fx": {},
     "state": {}
-  }
+  },
+  "thumbnailObjectKey": "presets/pending/42/thumbnails/abc123.png"
 }
 ```
 
-Submission uses `authenticatedFetch()`, so the save action requires a valid signed-in session even though the route itself is not currently wrapped in a protected route.
+Submission uses `authenticatedFetch()` for backend calls, so the save action requires a valid signed-in session even though the route itself is not currently wrapped in a protected route.
+
+If a thumbnail is selected, the page uploads it before sending the create request. That means a failed thumbnail upload blocks preset creation instead of leaving behind a saved preset without a thumbnail.
 
 ## Live Preview
 
@@ -76,7 +81,8 @@ The page includes metadata controls beyond the persisted payload, but not all of
 At the moment:
 
 - `name` and `sceneData` are submitted
-- description, playlist, and thumbnail picker state are UI-only
+- thumbnail uploads are staged first and only committed when the final preset create request succeeds
+- description and playlist are still UI-only
 - some engine passes exist in the stack but do not have fully persisted boolean support in the compact preset schema
 
 If preset persistence expands on the backend, this page is a likely place for follow-up wiring.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -12,6 +12,8 @@ The intended production contract is:
 
 This keeps deployment aligned with the current auth flow and avoids introducing CORS requirements into the supported path.
 
+The one exception is preset thumbnail uploads: when a user selects a thumbnail in the create preset flow, the browser uploads that file directly to S3 using a presigned `PUT` URL issued by the backend.
+
 ## Build-Time API Configuration
 
 The frontend builds API URLs through `buildApiUrl()` in `src/lib/api.ts`.
@@ -19,6 +21,7 @@ The frontend builds API URLs through `buildApiUrl()` in `src/lib/api.ts`.
 For the supported deployment path:
 - leaving `VITE_API_BASE_URL` unset works because requests default to `/api/*`
 - setting `VITE_API_BASE_URL=/api` at build time also works if you want the deployment configuration to be explicit
+- no extra frontend env var is required for thumbnail delivery because the backend persists the final CloudFront-backed `thumbnailRef` URL
 
 ## Container Notes
 
@@ -39,6 +42,7 @@ At the public edge:
 
 - `/` and client routes should go to the frontend container
 - `/api/*` should go to the backend container
+- direct thumbnail uploads should go from the browser to S3, not through the frontend or backend containers
 
 Example:
 
@@ -53,4 +57,4 @@ None of this changes local development:
 
 - `npm run dev` still uses the Vite `/api` proxy
 - local auth flows still target `http://localhost:8080` through that proxy
-- no deployment-only configuration is required for standard local work
+- local thumbnail uploads require the S3 bucket CORS rules to allow your local frontend origin, such as `http://localhost:5173`

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -12,7 +12,7 @@ The intended production contract is:
 
 This keeps deployment aligned with the current auth flow and avoids introducing CORS requirements into the supported path.
 
-The one exception is preset thumbnail uploads: when a user selects a thumbnail in the create preset flow, the browser uploads that file directly to S3 using a presigned `PUT` URL issued by the backend.
+The one exception is preset thumbnail uploads: when a user selects a thumbnail in the create preset flow, the browser uploads that file directly to the configured object-storage provider using a presigned `PUT` URL issued by the backend.
 
 ## Build-Time API Configuration
 
@@ -21,7 +21,7 @@ The frontend builds API URLs through `buildApiUrl()` in `src/lib/api.ts`.
 For the supported deployment path:
 - leaving `VITE_API_BASE_URL` unset works because requests default to `/api/*`
 - setting `VITE_API_BASE_URL=/api` at build time also works if you want the deployment configuration to be explicit
-- no extra frontend env var is required for thumbnail delivery because the backend persists the final CloudFront-backed `thumbnailRef` URL
+- no extra frontend env var is required for thumbnail delivery because the backend persists the final public `thumbnailRef` URL
 
 ## Container Notes
 
@@ -42,7 +42,7 @@ At the public edge:
 
 - `/` and client routes should go to the frontend container
 - `/api/*` should go to the backend container
-- direct thumbnail uploads should go from the browser to S3, not through the frontend or backend containers
+- direct thumbnail uploads should go from the browser to the configured object-storage provider, not through the frontend or backend containers
 
 Example:
 
@@ -57,4 +57,4 @@ None of this changes local development:
 
 - `npm run dev` still uses the Vite `/api` proxy
 - local auth flows still target `http://localhost:8080` through that proxy
-- local thumbnail uploads require the S3 bucket CORS rules to allow your local frontend origin, such as `http://localhost:5173`
+- local thumbnail uploads require the active provider CORS rules to allow your local frontend origin, such as `http://localhost:5173`

--- a/src/lib/presetThumbnailUpload.ts
+++ b/src/lib/presetThumbnailUpload.ts
@@ -1,0 +1,49 @@
+import { parseApiError } from "./authForm";
+
+type AuthenticatedFetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+type PresignedThumbnailUploadResponse = {
+  objectKey: string;
+  uploadUrl: string;
+  method: string;
+  headers?: Record<string, string>;
+};
+
+export async function uploadNewPresetThumbnail(
+  authenticatedFetch: AuthenticatedFetch,
+  file: File,
+) {
+  const presignResponse = await authenticatedFetch("/presets/thumbnail/presign", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      filename: file.name,
+      contentType: file.type,
+      sizeBytes: file.size,
+    }),
+  });
+
+  if (!presignResponse.ok) {
+    const apiError = await parseApiError(presignResponse);
+    throw new Error(
+      apiError?.message ?? "Failed to prepare the thumbnail upload.",
+    );
+  }
+
+  const presignedUpload =
+    (await presignResponse.json()) as PresignedThumbnailUploadResponse;
+  const uploadResponse = await fetch(presignedUpload.uploadUrl, {
+    method: presignedUpload.method || "PUT",
+    headers: presignedUpload.headers,
+    body: file,
+  });
+
+  if (!uploadResponse.ok) {
+    throw new Error("Failed to upload the thumbnail file to storage.");
+  }
+
+  return presignedUpload.objectKey;
+}

--- a/src/pages/CreatePresetPage.test.tsx
+++ b/src/pages/CreatePresetPage.test.tsx
@@ -228,6 +228,124 @@ describe('CreatePresetPage', () => {
     expect(await screen.findByText('My Presets')).toBeInTheDocument()
   })
 
+  it('uploads a selected thumbnail before the preset create request is sent', async () => {
+    storeSession()
+
+    const uploadedFiles: File[] = []
+    let presignBody: Record<string, unknown> | null = null
+    let createBody: Record<string, unknown> | null = null
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      if (input === buildApiUrl('/users/me')) {
+        return Promise.resolve(jsonResponse(storedUser))
+      }
+
+      if (input === buildApiUrl('/presets/thumbnail/presign')) {
+        presignBody = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
+        return Promise.resolve(
+          jsonResponse({
+            objectKey: 'presets/pending/8/thumbnails/abc123.png',
+            uploadUrl: 'https://upload.example.com/presets/pending/8/thumbnails/abc123.png',
+            method: 'PUT',
+            headers: {
+              'Content-Type': 'image/png',
+            },
+          }),
+        )
+      }
+
+      if (input === 'https://upload.example.com/presets/pending/8/thumbnails/abc123.png') {
+        if (init?.body instanceof File) {
+          uploadedFiles.push(init.body)
+        }
+
+        return Promise.resolve(new Response(null, { status: 200 }))
+      }
+
+      if (input === buildApiUrl('/presets')) {
+        createBody = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
+        return Promise.resolve(jsonResponse({ presetId: 18 }, 201))
+      }
+
+      throw new Error(`Unexpected request: ${String(input)}`)
+    })
+
+    const user = userEvent.setup()
+
+    renderCreatePresetPage()
+
+    await user.type(screen.getByLabelText(/preset name/i), 'Aurora Drift')
+    fireEvent.change(screen.getByLabelText(/upload thumbnail file/i), {
+      target: {
+        files: [new File(['cover'], 'cover.png', { type: 'image/png' })],
+      },
+    })
+    await user.click(screen.getByRole('button', { name: /create preset/i }))
+
+    await waitFor(() => expect(presignBody).not.toBeNull())
+
+    expect(presignBody).toMatchObject({
+      filename: 'cover.png',
+      contentType: 'image/png',
+      sizeBytes: 5,
+    })
+    expect(uploadedFiles).toHaveLength(1)
+    expect(uploadedFiles[0].name).toBe('cover.png')
+    expect(createBody).toMatchObject({
+      name: 'Aurora Drift',
+      thumbnailObjectKey: 'presets/pending/8/thumbnails/abc123.png',
+    })
+    expect(await screen.findByText('My Presets')).toBeInTheDocument()
+  })
+
+  it('does not create the preset when thumbnail upload preparation fails', async () => {
+    storeSession()
+
+    let createAttempted = false
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      if (input === buildApiUrl('/users/me')) {
+        return Promise.resolve(jsonResponse(storedUser))
+      }
+
+      if (input === buildApiUrl('/presets/thumbnail/presign')) {
+        return Promise.resolve(
+          jsonResponse(
+            {
+              code: 'THUMBNAIL_STORAGE_UNAVAILABLE',
+              message: 'Thumbnail storage is unavailable right now.',
+            },
+            503,
+          ),
+        )
+      }
+
+      if (input === buildApiUrl('/presets')) {
+        createAttempted = true
+        return Promise.resolve(jsonResponse({ presetId: 18 }, 201))
+      }
+
+      throw new Error(`Unexpected request: ${String(input)}`)
+    })
+
+    const user = userEvent.setup()
+
+    renderCreatePresetPage()
+
+    await user.type(screen.getByLabelText(/preset name/i), 'Aurora Drift')
+    fireEvent.change(screen.getByLabelText(/upload thumbnail file/i), {
+      target: {
+        files: [new File(['cover'], 'cover.png', { type: 'image/png' })],
+      },
+    })
+    await user.click(screen.getByRole('button', { name: /create preset/i }))
+
+    expect(
+      await screen.findByText(/thumbnail storage is unavailable right now\./i),
+    ).toBeInTheDocument()
+    expect(createAttempted).toBe(false)
+  })
+
   it('surfaces advanced MAGE engine fields and the raw JSON editor in the Advanced section', async () => {
     storeSession()
 

--- a/src/pages/CreatePresetPage.tsx
+++ b/src/pages/CreatePresetPage.tsx
@@ -14,6 +14,7 @@ import {
   Vector3Field,
 } from "../components/PresetEditorControls";
 import { parseApiError } from "../lib/authForm";
+import { uploadNewPresetThumbnail } from "../lib/presetThumbnailUpload";
 import {
   createDefaultSceneData,
   getSceneEditorModel,
@@ -34,7 +35,7 @@ import {
 } from "../lib/presetEditor";
 
 type CreatePresetFormErrors = Partial<
-  Record<"form" | "name" | "sceneData", string>
+  Record<"form" | "name" | "sceneData" | "thumbnail", string>
 >;
 type EditorSectionId =
   | "advanced"
@@ -44,7 +45,7 @@ type EditorSectionId =
   | "pass-order"
   | "scene";
 type EffectCategoryId = "color" | "finish" | "pattern" | "trail";
-type ThumbnailMode = "auto" | "upload";
+type ThumbnailMode = "skip" | "upload";
 
 type AdditionalPassConfig = {
   category: EffectCategoryId;
@@ -188,6 +189,13 @@ const stackOnlyPassLabels = [
   PASS_LABELS.bleachBypassShader,
   PASS_LABELS.toonShader,
 ].join(", ");
+const ALLOWED_THUMBNAIL_CONTENT_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+]);
+const MAX_THUMBNAIL_BYTES = 5 * 1024 * 1024;
 
 function buildShaderOptions(currentShader: string) {
   const matchedPreset = SHADER_PRESETS.find(
@@ -305,6 +313,26 @@ function validateForm(name: string, sceneDataText: string) {
   };
 }
 
+function validateThumbnailFile(file: File | null) {
+  if (!file) {
+    return "Select a thumbnail image to upload.";
+  }
+
+  if (!ALLOWED_THUMBNAIL_CONTENT_TYPES.has(file.type)) {
+    return "Thumbnail must be a jpeg, png, webp, or gif image.";
+  }
+
+  if (file.size <= 0) {
+    return "Thumbnail file must not be empty.";
+  }
+
+  if (file.size > MAX_THUMBNAIL_BYTES) {
+    return "Thumbnail must not exceed 5 MB.";
+  }
+
+  return null;
+}
+
 export function CreatePresetPage() {
   const { authenticatedFetch } = useAuth();
   const navigate = useNavigate();
@@ -313,7 +341,8 @@ export function CreatePresetPage() {
     useState<EditorSectionId>("scene");
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
-  const [thumbnailMode, setThumbnailMode] = useState<ThumbnailMode>("auto");
+  const [thumbnailMode, setThumbnailMode] = useState<ThumbnailMode>("skip");
+  const [thumbnailFile, setThumbnailFile] = useState<File | null>(null);
   const [thumbnailFileName, setThumbnailFileName] = useState("");
   const [playlistValue, setPlaylistValue] = useState("");
   const [sceneData, setSceneData] = useState<PresetSceneData>(initialSceneData);
@@ -381,6 +410,14 @@ export function CreatePresetPage() {
     });
   }
 
+  function clearThumbnailSelection() {
+    setThumbnailFile(null);
+    setThumbnailFileName("");
+    if (thumbnailFileInputRef.current) {
+      thumbnailFileInputRef.current.value = "";
+    }
+  }
+
   function applySceneData(nextSceneData: PresetSceneData) {
     const sanitizedSceneData = sanitizeSceneData(nextSceneData);
     setSceneData(sanitizedSceneData);
@@ -404,6 +441,14 @@ export function CreatePresetPage() {
 
   function handleThumbnailModeChange(nextValue: ThumbnailMode) {
     setThumbnailMode(nextValue);
+    if (nextValue === "skip") {
+      clearThumbnailSelection();
+    }
+    setErrors((currentErrors) => ({
+      ...currentErrors,
+      thumbnail: undefined,
+      form: undefined,
+    }));
   }
 
   function handleThumbnailUploadClick() {
@@ -425,7 +470,13 @@ export function CreatePresetPage() {
     }
 
     setThumbnailMode("upload");
+    setThumbnailFile(nextFile);
     setThumbnailFileName(nextFile.name);
+    setErrors((currentErrors) => ({
+      ...currentErrors,
+      thumbnail: undefined,
+      form: undefined,
+    }));
   }
 
   function handleSectionJump(nextSectionId: EditorSectionId) {
@@ -498,6 +549,12 @@ export function CreatePresetPage() {
       trimmedName,
       sceneDataText,
     );
+    const nextThumbnailError =
+      thumbnailMode === "upload" ? validateThumbnailFile(thumbnailFile) : null;
+
+    if (nextThumbnailError) {
+      nextErrors.thumbnail = nextThumbnailError;
+    }
 
     if (Object.keys(nextErrors).length > 0) {
       setErrors(nextErrors);
@@ -510,12 +567,18 @@ export function CreatePresetPage() {
     setErrors({});
 
     try {
+      const thumbnailObjectKey =
+        thumbnailMode === "upload" && thumbnailFile
+          ? await uploadNewPresetThumbnail(authenticatedFetch, thumbnailFile)
+          : undefined;
+
       const response = await authenticatedFetch("/presets", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           name: trimmedName,
           sceneData: sanitizedSceneData,
+          thumbnailObjectKey,
         }),
       });
 
@@ -532,9 +595,12 @@ export function CreatePresetPage() {
       }
 
       navigate("/my-presets");
-    } catch {
+    } catch (error) {
       setErrors({
-        form: "Preset creation is unavailable right now. Please try again in a moment.",
+        form:
+          error instanceof Error && error.message.trim()
+            ? error.message
+            : "Preset creation is unavailable right now. Please try again in a moment.",
       });
     } finally {
       setIsSubmitting(false);
@@ -608,7 +674,7 @@ export function CreatePresetPage() {
                   <label htmlFor={thumbnailInputId}>Thumbnail</label>
                   <div className="preset-thumbnail-picker">
                     <input
-                      accept="image/*"
+                      accept="image/jpeg,image/png,image/webp,image/gif"
                       aria-label="Upload thumbnail file"
                       className="preset-thumbnail-input"
                       id={thumbnailInputId}
@@ -640,19 +706,19 @@ export function CreatePresetPage() {
 
                       <button
                         className={`preset-thumbnail-choice${
-                          thumbnailMode === "auto" ? " is-selected" : ""
+                          thumbnailMode === "skip" ? " is-selected" : ""
                         }`}
-                        onClick={() => handleThumbnailModeChange("auto")}
+                        onClick={() => handleThumbnailModeChange("skip")}
                         type="button"
                       >
                         <span className="preset-thumbnail-choice__eyebrow">
-                          Quick Pick
+                          Optional
                         </span>
                         <strong className="preset-thumbnail-choice__title">
-                          Auto-generated
+                          Skip for Now
                         </strong>
                         <span className="preset-thumbnail-choice__description">
-                          Start from a generated cover.
+                          Create the preset without a thumbnail.
                         </span>
                       </button>
                     </div>
@@ -662,6 +728,16 @@ export function CreatePresetPage() {
                         Selected file: <strong>{thumbnailFileName}</strong>
                       </p>
                     ) : null}
+                    {errors.thumbnail ? (
+                      <p className="field-error" role="alert">
+                        {errors.thumbnail}
+                      </p>
+                    ) : (
+                      <p className="field-hint">
+                        Uploads go directly to S3 and are finalized after the
+                        preset is created.
+                      </p>
+                    )}
                   </div>
                 </div>
 


### PR DESCRIPTION
## Summary

This PR updates the frontend preset creation flow so thumbnails are uploaded first through a staged presigned upload, and the preset is only created after the upload succeeds.

## What Changed

### 1. Make preset creation atomic from the user’s perspective
The create preset page now uploads the thumbnail before creating the preset.

New flow:
- request a staged thumbnail upload from the backend
- upload the selected file directly from the browser to object storage
- submit `POST /api/presets` with the returned `thumbnailObjectKey`

This means:
- if thumbnail upload fails, the preset is not created
- users see a blocking error and can retry
- the old “preset created but thumbnail upload failed” partial-success path is removed

### 2. Add a dedicated frontend helper for staged thumbnail uploads
Added upload orchestration in:
- `src/lib/presetThumbnailUpload.ts`

This helper handles:
- presign request
- direct browser upload to object storage
- returning the staged object key back to the create flow

### 3. Update create preset UI behavior and tests
Updated:
- `src/pages/CreatePresetPage.tsx`
- `src/pages/CreatePresetPage.test.tsx`

The page now:
- validates thumbnail selection before upload
- blocks preset creation when staged upload fails
- sends `thumbnailObjectKey` instead of depending on the old backend-local upload flow

### 4. Update frontend docs
Updated:
- `README.md`
- `docs/create-preset-page.md`
- `docs/deployment.md`

These docs now describe:
- staged thumbnail upload behavior
- provider-agnostic object storage wording
- the fact that the frontend does not need a storage-specific env var because the backend persists the final public `thumbnailRef`

## Validation

Ran:
- `npm test -- --run`
- `npm run build`
- `npm run lint`

## Notes

No additional frontend env vars are required for the storage provider switch.

The frontend still relies on the backend to:
- issue the presigned upload
- persist the final thumbnail URL
- decide whether storage is backed by AWS S3 or MinIO
