### PR TITLE
Fix production shader preset rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "prebuild": "patch-package",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "postinstall": "patch-package",

--- a/patches/shader-park-core+0.2.8.patch
+++ b/patches/shader-park-core+0.2.8.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/shader-park-core/dist/shader-park-core.esm.js b/node_modules/shader-park-core/dist/shader-park-core.esm.js
-index 56ff647..ec2ddb4 100644
+index 56ff647..184b0b2 100644
 --- a/node_modules/shader-park-core/dist/shader-park-core.esm.js
 +++ b/node_modules/shader-park-core/dist/shader-park-core.esm.js
 @@ -45400,22 +45400,21 @@ function sculptToGLSL(userProvidedSrc) {
@@ -38,7 +38,7 @@ index 56ff647..ec2ddb4 100644
  
    var error = undefined;
    function revolve2D(sdf) {
-@@ -45526,7 +45525,84 @@ function sculptToGLSL(userProvidedSrc) {
+@@ -45526,7 +45525,91 @@ function sculptToGLSL(userProvidedSrc) {
    var postGeneratedFunctions = replaceMathOps([getSpherical, fresnel, revolve2D, extrude2D, mirrorN, grid, repeatLinear, repeatRadial, scaleShape, vectorContourNoise].map(function (el) {
      return el.toString();
    }).join("\n"));
@@ -67,6 +67,7 @@ index 56ff647..ec2ddb4 100644
 +    extractSDF: extractSDF,
 +    reset: reset,
 +    displace: displace,
++    getSpace: getSpace,
 +    setSpace: setSpace,
 +    repeat: repeat,
 +    rotateX: rotateX,
@@ -94,6 +95,10 @@ index 56ff647..ec2ddb4 100644
 +    test: test,
 +    input: input,
 +    input2D: input2D,
++    setStepSize: setStepSize,
++    setGeometryQuality: setGeometryQuality,
++    setMaxIterations: setMaxIterations,
++    setMaxReflections: setMaxReflections,
 +    getPixelCoord: getPixelCoord,
 +    getResolution: getResolution,
 +    get2DCoords: get2DCoords,
@@ -104,6 +109,8 @@ index 56ff647..ec2ddb4 100644
 +    getSpherical: getSpherical,
 +    mirrorN: mirrorN,
 +    grid: grid,
++    torus: torus,
++    cylinder: cylinder,
 +    repeatLinear: repeatLinear,
 +    repeatRadial: repeatRadial,
 +    scaleShape: scaleShape,


### PR DESCRIPTION
## Summary

Fixes production-only shader preset rendering failures in the preset editor/player preview.

## What changed

- expanded the `shader-park-core` patch so the eval runtime exposes the helper bindings used by the bundled presets
- added a `prebuild` step to run `patch-package` before every production build
- kept the fix scoped to the frontend build/runtime path only

## Why

In `npm run dev`, the bundled shader presets rendered correctly, but in `npm run build && npm run preview` several presets failed while simpler ones still worked.

The failing presets depended on Shader Park helpers and primitives that were not available in the patched production eval scope, including:
- `getSpace`
- `setStepSize`
- `setGeometryQuality`
- `setMaxIterations`
- `setMaxReflections`
- `torus`
- `cylinder`

This PR makes the production build reapply the patch reliably and extends the patch to cover the helpers used by the remaining presets.

## Verified

- `npm run build`
- `npm test -- --run src/pages/CreatePresetPage.test.tsx`

Production preview smoke check after build:
- `Crimson Reactor` renders
- `Alloy Capsule` renders
- `Redline Core` renders
- `Emerald Ring` renders
- `Spectrum Relay` renders
- `Chroma Storm` renders

## Notes

- this PR only addresses frontend production shader rendering
- no backend changes are included
- deploy targets should do a fresh rebuild so the updated patch is applied during build
