### PR TITLE
Rename presets to scenes frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # MAGE Frontend
 
-The MAGE frontend is the React application for browsing, creating, and playing MAGE scenes in the browser. It provides account flows, preset management screens, the reusable in-app MAGE player, and the preset editor used to author scene data for the engine.
+The MAGE frontend is the React application for browsing, creating, and playing MAGE scenes in the browser. It provides account flows, scene management screens, the reusable in-app MAGE player, and the scene editor used to author scene data for the engine.
 
 ## Overview
 
 This repository contains the client-side application for the MAGE platform. It is built with React, TypeScript, and Vite, and integrates with:
 
-- the MAGE backend API for authentication and preset persistence
-- the bundled local MAGE engine package for scene playback and preset preview
+- the MAGE backend API for authentication and scene persistence
+- the bundled local MAGE engine package for scene playback and scene preview
 
 The current app includes:
 
 - guest and authenticated account flows
 - a reusable browser-based MAGE player
-- preset listing and preset detail pages
-- a multi-section create preset editor with direct-to-object-storage thumbnail uploads
+- scene listing and scene detail pages
+- a multi-section create scene editor with direct-to-object-storage thumbnail uploads
 - shared auth session restore and protected routes
 
 ## Tech Stack
@@ -50,7 +50,7 @@ mage-frontend/
 Before running the frontend locally, make sure you have:
 
 - a recent Node.js and npm installation
-- the backend API running locally if you want full auth and preset flows
+- the backend API running locally if you want full auth and scene flows
 
 ## Getting Started
 
@@ -112,13 +112,13 @@ See [docs/deployment.md](./docs/deployment.md) for the deployment contract and t
 
 | Route            | Access        | Purpose                                               |
 | ---------------- | ------------- | ----------------------------------------------------- |
-| `/`              | Public        | Guest landing page or signed-in preset discovery home |
-| `/presets`       | Public        | Preset discovery with optional tag filter             |
+| `/`              | Public        | Guest landing page or signed-in scene discovery home |
+| `/scenes`       | Public        | Scene discovery with optional tag filter             |
 | `/register`      | Guest-only    | Account registration                                  |
 | `/login`         | Guest-only    | Account sign-in                                       |
-| `/my-presets`    | Authenticated | User preset library                                   |
-| `/presets/:id`   | Public route  | Preset detail/player page                             |
-| `/create-preset` | Public route  | Preset editor and live preview                        |
+| `/my-scenes`    | Authenticated | User scene library                                   |
+| `/scenes/:id`   | Public route  | Scene detail/player page                             |
+| `/create-scene` | Public route  | Scene editor and live preview                        |
 | `/settings`      | Authenticated | Account settings                                      |
 
 ## Documentation
@@ -126,7 +126,7 @@ See [docs/deployment.md](./docs/deployment.md) for the deployment contract and t
 Additional project notes live in `docs/`:
 
 - [docs/README.md](./docs/README.md)
-- [docs/create-preset-page.md](./docs/create-preset-page.md)
+- [docs/create-scene-page.md](./docs/create-scene-page.md)
 - [docs/deployment.md](./docs/deployment.md)
 - [docs/engine-integration.md](./docs/engine-integration.md)
 - [docs/login-page.md](./docs/login-page.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,8 +4,8 @@ This directory holds focused implementation notes for the MAGE frontend. The rep
 
 ## Documents
 
-- [create-preset-page.md](./create-preset-page.md)  
-  Preset editor structure, submission flow, and current persistence limits.
+- [create-scene-page.md](./create-scene-page.md)  
+  Scene editor structure, submission flow, and current persistence limits.
 
 - [deployment.md](./deployment.md)  
   Supported production deployment strategy, reverse-proxy expectations, and container notes.

--- a/docs/create-scene-page.md
+++ b/docs/create-scene-page.md
@@ -1,20 +1,20 @@
-# Create Preset Page
+# Create Scene Page
 
 ## Overview
 
-The create preset page is the frontend editor for building MAGE scene data and previewing it live in the browser.
+The create scene page is the frontend editor for building MAGE scene data and previewing it live in the browser.
 
 Route:
 
-- `/create-preset`
+- `/create-scene`
 
 ## Related Files
 
-- `src/pages/CreatePresetPage.tsx`
-- `src/lib/presetEditor.ts`
-- `src/lib/embeddedShaderPresets.ts`
-- `src/components/PresetEditorControls.tsx`
-- `src/pages/CreatePresetPage.test.tsx`
+- `src/pages/CreateScenePage.tsx`
+- `src/lib/sceneEditor.ts`
+- `src/lib/embeddedShaderScenes.ts`
+- `src/components/SceneEditorControls.tsx`
+- `src/pages/CreateScenePage.test.tsx`
 
 ## Editor Sections
 
@@ -37,17 +37,17 @@ Those sections write into a structured scene object built around:
 
 ## Submission Flow
 
-The page submits preset creation through:
+The page submits scene creation through:
 
-- `POST /api/presets/thumbnail/presign`
+- `POST /api/scenes/thumbnail/presign`
 - direct browser `PUT` to the returned object-storage URL when a thumbnail is selected
-- `POST /api/presets`
+- `POST /api/scenes`
 
 Current request body:
 
 ```json
 {
-  "name": "Preset Name",
+  "name": "Scene Name",
   "sceneData": {
     "visualizer": {},
     "controls": {},
@@ -55,13 +55,13 @@ Current request body:
     "fx": {},
     "state": {}
   },
-  "thumbnailObjectKey": "presets/pending/42/thumbnails/abc123.png"
+  "thumbnailObjectKey": "scenes/pending/42/thumbnails/abc123.png"
 }
 ```
 
 Submission uses `authenticatedFetch()` for backend calls, so the save action requires a valid signed-in session even though the route itself is not currently wrapped in a protected route.
 
-If a thumbnail is selected, the page uploads it before sending the create request. That means a failed thumbnail upload blocks preset creation instead of leaving behind a saved preset without a thumbnail.
+If a thumbnail is selected, the page uploads it before sending the create request. That means a failed thumbnail upload blocks scene creation instead of leaving behind a saved scene without a thumbnail.
 
 ## Live Preview
 
@@ -69,7 +69,7 @@ The page uses the shared `MagePlayer` component for inline preview. Edits update
 
 ## Current Data Model Notes
 
-- shader choices currently come from the embedded engine presets hardcoded in `src/lib/embeddedShaderPresets.ts`
+- shader choices currently come from the embedded engine scenes hardcoded in `src/lib/embeddedShaderScenes.ts`
 - skybox choices are exposed as bundled skybox ids
 - pass ordering is supported, with `outputPass` pinned last
 - several advanced engine values are surfaced as raw numeric fields for debugging and schema completeness
@@ -81,14 +81,14 @@ The page includes metadata controls beyond the persisted payload, but not all of
 At the moment:
 
 - `name` and `sceneData` are submitted
-- thumbnail uploads are staged first and only committed when the final preset create request succeeds
+- thumbnail uploads are staged first and only committed when the final scene create request succeeds
 - description and playlist are still UI-only
-- some engine passes exist in the stack but do not have fully persisted boolean support in the compact preset schema
+- some engine passes exist in the stack but do not have fully persisted boolean support in the compact scene schema
 
-If preset persistence expands on the backend, this page is a likely place for follow-up wiring.
+If scene persistence expands on the backend, this page is a likely place for follow-up wiring.
 
 ## Tests
 
 Main coverage lives in:
 
-- `src/pages/CreatePresetPage.test.tsx`
+- `src/pages/CreateScenePage.test.tsx`

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -12,7 +12,7 @@ The intended production contract is:
 
 This keeps deployment aligned with the current auth flow and avoids introducing CORS requirements into the supported path.
 
-The one exception is preset thumbnail uploads: when a user selects a thumbnail in the create preset flow, the browser uploads that file directly to the configured object-storage provider using a presigned `PUT` URL issued by the backend.
+The one exception is scene thumbnail uploads: when a user selects a thumbnail in the create scene flow, the browser uploads that file directly to the configured object-storage provider using a presigned `PUT` URL issued by the backend.
 
 ## Container Notes
 

--- a/docs/engine-integration.md
+++ b/docs/engine-integration.md
@@ -44,7 +44,7 @@ The frontend works around this by doing the following:
 - `patch-package` reapplies the checked-in Shader Park patch on `npm install` and `npm ci`
 - the patch temporarily exposes the required Shader Park helper bindings on `globalThis` during the `eval(...)` compile step and restores the previous global values afterward
 
-If the Shader Park version changes, revalidate that patch before assuming production builds will continue to render presets correctly.
+If the Shader Park version changes, revalidate that patch before assuming production builds will continue to render scenes correctly.
 
 ## Frontend Boundary
 

--- a/docs/player-component.md
+++ b/docs/player-component.md
@@ -25,17 +25,17 @@ Example:
 ```tsx
 import { MagePlayer } from "../components/MagePlayer";
 
-export function PresetDetail({
-  preset,
+export function SceneDetail({
+  scene,
 }: {
-  preset: { name: string; sceneData: Record<string, unknown> };
+  scene: { name: string; sceneData: Record<string, unknown> };
 }) {
   return (
     <section>
-      <h1>{preset.name}</h1>
+      <h1>{scene.name}</h1>
       <MagePlayer
-        ariaLabel={`${preset.name} preview`}
-        sceneBlob={preset.sceneData}
+        ariaLabel={`${scene.name} preview`}
+        sceneBlob={scene.sceneData}
       />
     </section>
   );
@@ -68,7 +68,7 @@ Pages should pass the raw `sceneData` object returned by the backend instead of 
 
 - do not call `initMAGE()` directly from route components
 - keep engine-specific logic inside `src/lib/magePlayerAdapter.ts`
-- if a page swaps presets, pass the next `sceneBlob` to the same `MagePlayer` instance and let the component reload it
+- if a page swaps scenes, pass the next `sceneBlob` to the same `MagePlayer` instance and let the component reload it
 
 ## Tests
 

--- a/src/App.css
+++ b/src/App.css
@@ -626,10 +626,10 @@
 .field-group input,
 .field-group textarea,
 .field-group select,
-.preset-select,
-.preset-number-input,
-.preset-slider__number,
-.preset-textarea {
+.scene-select,
+.scene-number-input,
+.scene-slider__number,
+.scene-textarea {
   width: 100%;
   min-height: 52px;
   padding: 0 16px;
@@ -644,34 +644,34 @@
 }
 
 .field-group textarea,
-.preset-textarea {
+.scene-textarea {
   padding: 14px 16px;
   resize: vertical;
 }
 
 .field-group input::placeholder,
 .field-group textarea::placeholder,
-.preset-textarea::placeholder {
+.scene-textarea::placeholder {
   color: rgba(155, 177, 171, 0.78);
 }
 
 .field-group input:hover,
 .field-group textarea:hover,
 .field-group select:hover,
-.preset-select:hover,
-.preset-number-input:hover,
-.preset-slider__number:hover,
-.preset-textarea:hover {
+.scene-select:hover,
+.scene-number-input:hover,
+.scene-slider__number:hover,
+.scene-textarea:hover {
   border-color: rgba(255, 255, 255, 0.18);
 }
 
 .field-group input:focus,
 .field-group textarea:focus,
 .field-group select:focus,
-.preset-select:focus,
-.preset-number-input:focus,
-.preset-slider__number:focus,
-.preset-textarea:focus {
+.scene-select:focus,
+.scene-number-input:focus,
+.scene-slider__number:focus,
+.scene-textarea:focus {
   outline: none;
   border-color: var(--accent);
   box-shadow: 0 0 0 4px rgba(99, 240, 214, 0.12);
@@ -680,10 +680,10 @@
 .field-group input[aria-invalid="true"],
 .field-group textarea[aria-invalid="true"],
 .field-group select[aria-invalid="true"],
-.preset-select[aria-invalid="true"],
-.preset-number-input[aria-invalid="true"],
-.preset-slider__number[aria-invalid="true"],
-.preset-textarea[aria-invalid="true"] {
+.scene-select[aria-invalid="true"],
+.scene-number-input[aria-invalid="true"],
+.scene-slider__number[aria-invalid="true"],
+.scene-textarea[aria-invalid="true"] {
   border-color: #ff8c99;
   box-shadow: 0 0 0 4px rgba(255, 140, 153, 0.12);
 }
@@ -824,18 +824,18 @@
   justify-self: start;
 }
 
-.preset-empty-state {
+.scene-empty-state {
   display: grid;
   gap: 14px;
 }
 
-.preset-grid {
+.scene-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 16px;
 }
 
-.preset-detail-page {
+.scene-detail-page {
   width: min(1440px, 100%);
   justify-self: center;
   align-self: start;
@@ -859,7 +859,7 @@
   position: relative;
 }
 
-.preset-detail-watch .mage-player-shell {
+.scene-detail-watch .mage-player-shell {
   width: 100%;
 }
 
@@ -868,7 +868,7 @@
   overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.1);
   background:
-    radial-gradient(circle at top left, var(--preset-accent, rgba(99, 240, 214, 0.22)), transparent 34%),
+    radial-gradient(circle at top left, var(--scene-accent, rgba(99, 240, 214, 0.22)), transparent 34%),
     linear-gradient(180deg, rgba(9, 21, 25, 0.92), rgba(3, 9, 12, 0.98));
   box-shadow: 0 30px 90px rgba(0, 0, 0, 0.32);
 }
@@ -919,13 +919,13 @@
   color: var(--accent);
 }
 
-.preset-detail-player,
-.preset-detail-player.mage-player {
+.scene-detail-player,
+.scene-detail-player.mage-player {
   width: 100%;
   height: 100%;
 }
 
-.preset-detail-stage .mage-player__viewport {
+.scene-detail-stage .mage-player__viewport {
   height: 100%;
   min-height: 0;
   aspect-ratio: auto;
@@ -935,11 +935,11 @@
   box-shadow: none;
 }
 
-.preset-detail-stage .mage-player__viewport::after {
+.scene-detail-stage .mage-player__viewport::after {
   display: none;
 }
 
-.preset-detail-stage .mage-player__overlay {
+.scene-detail-stage .mage-player__overlay {
   border-radius: inherit;
 }
 
@@ -954,13 +954,13 @@
   letter-spacing: -0.04em;
 }
 
-.preset-detail-header {
+.scene-detail-header {
   display: grid;
   gap: 12px;
   padding-top: 18px;
 }
 
-.preset-detail-social-row {
+.scene-detail-social-row {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
@@ -970,7 +970,7 @@
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-.preset-detail-social-row__creator {
+.scene-detail-social-row__creator {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -1026,14 +1026,14 @@
 }
 
 .mage-channel-card__copy strong,
-.preset-detail-comment__header strong {
+.scene-detail-comment__header strong {
   transition:
     color 0.18s ease,
     text-decoration-color 0.18s ease;
 }
 
 .mage-channel-card__copy strong:hover,
-.preset-detail-comment__header strong:hover {
+.scene-detail-comment__header strong:hover {
   color: #f5fbf9;
   cursor: pointer;
   text-decoration: underline;
@@ -1048,7 +1048,7 @@
   font-size: 0.9rem;
 }
 
-.preset-detail-follow-button {
+.scene-detail-follow-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1066,21 +1066,21 @@
     box-shadow 0.18s ease;
 }
 
-.preset-detail-follow-button:hover {
+.scene-detail-follow-button:hover {
   background: #ffffff;
   box-shadow: 0 12px 28px rgba(0, 0, 0, 0.22);
 }
 
-.preset-detail-action-row {
+.scene-detail-action-row {
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
   gap: 10px;
 }
 
-.preset-detail-action-chip,
-.preset-detail-sort-chip,
-.preset-detail-comment__action {
+.scene-detail-action-chip,
+.scene-detail-sort-chip,
+.scene-detail-comment__action {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1100,14 +1100,14 @@
     color 0.18s ease;
 }
 
-.preset-detail-action-chip:hover,
-.preset-detail-sort-chip:hover,
-.preset-detail-comment__action:hover {
+.scene-detail-action-chip:hover,
+.scene-detail-sort-chip:hover,
+.scene-detail-comment__action:hover {
   border-color: rgba(99, 240, 214, 0.28);
   background: rgba(255, 255, 255, 0.08);
 }
 
-.preset-detail-vote-button__icon {
+.scene-detail-vote-button__icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1116,13 +1116,13 @@
   color: var(--muted);
 }
 
-.preset-detail-vote-button__icon svg {
+.scene-detail-vote-button__icon svg {
   width: 100%;
   height: 100%;
 }
 
-.preset-detail-description-card,
-.preset-detail-comments-panel {
+.scene-detail-description-card,
+.scene-detail-comments-panel {
   margin-top: 18px;
   padding: 18px 20px;
   border-radius: 20px;
@@ -1131,48 +1131,48 @@
   box-shadow: 0 18px 50px rgba(0, 0, 0, 0.24);
 }
 
-.preset-detail-description-card__meta {
+.scene-detail-description-card__meta {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
   margin-bottom: 14px;
 }
 
-.preset-detail-description-card__meta strong {
+.scene-detail-description-card__meta strong {
   color: var(--text);
 }
 
-.preset-detail-description-card__meta span {
+.scene-detail-description-card__meta span {
   color: var(--muted);
 }
 
-.preset-detail-description-card p {
+.scene-detail-description-card p {
   margin: 0;
   color: var(--muted);
   line-height: 1.7;
 }
 
-.preset-detail-description-copy {
+.scene-detail-description-copy {
   display: grid;
   gap: 12px;
 }
 
-.preset-detail-description-copy[data-expanded="false"] p:first-child {
+.scene-detail-description-copy[data-expanded="false"] p:first-child {
   display: -webkit-box;
   overflow: hidden;
   -webkit-line-clamp: 4;
   -webkit-box-orient: vertical;
 }
 
-.preset-detail-description-copy[data-expanded="false"] p:not(:first-child) {
+.scene-detail-description-copy[data-expanded="false"] p:not(:first-child) {
   display: none;
 }
 
-.preset-detail-description-copy[data-expanded="true"] p + p {
+.scene-detail-description-copy[data-expanded="true"] p + p {
   margin-top: 12px;
 }
 
-.preset-detail-description-toggle {
+.scene-detail-description-toggle {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1190,11 +1190,11 @@
   cursor: pointer;
 }
 
-.preset-detail-description-toggle:hover {
+.scene-detail-description-toggle:hover {
   color: var(--accent);
 }
 
-.preset-detail-description-toggle__chevron {
+.scene-detail-description-toggle__chevron {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1203,23 +1203,23 @@
   transition: transform 0.18s ease;
 }
 
-.preset-detail-description-toggle__chevron svg {
+.scene-detail-description-toggle__chevron svg {
   width: 100%;
   height: 100%;
 }
 
-.preset-detail-description-toggle__chevron.is-expanded {
+.scene-detail-description-toggle__chevron.is-expanded {
   transform: rotate(180deg);
 }
 
-.preset-detail-note-grid {
+.scene-detail-note-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 12px;
   margin-top: 18px;
 }
 
-.preset-detail-note-grid__item {
+.scene-detail-note-grid__item {
   display: grid;
   gap: 6px;
   padding: 14px;
@@ -1228,14 +1228,14 @@
   border: 1px solid rgba(255, 255, 255, 0.06);
 }
 
-.preset-detail-note-grid__item span {
+.scene-detail-note-grid__item span {
   color: var(--muted);
   font-size: 0.82rem;
   text-transform: uppercase;
   letter-spacing: 0.06em;
 }
 
-.preset-detail-note-grid__item strong {
+.scene-detail-note-grid__item strong {
   line-height: 1.55;
 }
 
@@ -1269,7 +1269,7 @@
   font-size: 1.1rem;
 }
 
-.preset-detail-comments-toolbar {
+.scene-detail-comments-toolbar {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -1277,7 +1277,7 @@
   gap: 14px;
 }
 
-.preset-detail-comment-composer {
+.scene-detail-comment-composer {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
   gap: 14px;
@@ -1285,7 +1285,7 @@
   margin-top: 18px;
 }
 
-.preset-detail-comment-composer__avatar {
+.scene-detail-comment-composer__avatar {
   display: grid;
   place-items: center;
   width: 44px;
@@ -1297,7 +1297,7 @@
   font-weight: 700;
 }
 
-.preset-detail-comment-composer__field {
+.scene-detail-comment-composer__field {
   min-height: 44px;
   padding: 12px 0;
   border-bottom: 1px solid rgba(255, 255, 255, 0.12);
@@ -1320,18 +1320,18 @@
   min-width: 0;
 }
 
-.preset-detail-comment__header {
+.scene-detail-comment__header {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 8px;
 }
 
-.preset-detail-comment__header strong {
+.scene-detail-comment__header strong {
   font-size: 0.96rem;
 }
 
-.preset-detail-comment__header span,
+.scene-detail-comment__header span,
 .mage-comment__body p,
 .mage-watch__rail-header p {
   color: var(--muted);
@@ -1343,14 +1343,14 @@
   line-height: 1.6;
 }
 
-.preset-detail-comment__actions {
+.scene-detail-comment__actions {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
   margin-top: 10px;
 }
 
-.preset-detail-comment__action {
+.scene-detail-comment__action {
   min-height: 34px;
   padding: 8px 12px;
   font-size: 0.86rem;
@@ -1368,7 +1368,7 @@
   padding: 6px 0 2px;
 }
 
-.preset-detail-recommendation-filters {
+.scene-detail-recommendation-filters {
   padding: 0 0 2px;
 }
 
@@ -1384,7 +1384,7 @@
   gap: 10px;
 }
 
-.mage-preset-card {
+.mage-scene-card {
   display: grid;
   grid-template-columns: 108px minmax(0, 1fr);
   gap: 10px;
@@ -1397,7 +1397,7 @@
   color: inherit;
 }
 
-.mage-preset-card__thumb {
+.mage-scene-card__thumb {
   position: relative;
   width: 108px;
   aspect-ratio: 1 / 1;
@@ -1405,7 +1405,7 @@
   border-radius: 14px;
   overflow: hidden;
   background:
-    radial-gradient(circle at 20% 18%, var(--preset-accent, rgba(99, 240, 214, 0.32)), transparent 30%),
+    radial-gradient(circle at 20% 18%, var(--scene-accent, rgba(99, 240, 214, 0.32)), transparent 30%),
     radial-gradient(circle at 80% 22%, rgba(126, 200, 255, 0.24), transparent 34%),
     radial-gradient(circle at 60% 82%, rgba(255, 122, 151, 0.18), transparent 32%),
     linear-gradient(135deg, rgba(8, 18, 21, 0.98), rgba(4, 10, 12, 1));
@@ -1414,12 +1414,12 @@
   display: block;
 }
 
-.mage-preset-card__thumb-image {
+.mage-scene-card__thumb-image {
   object-fit: cover;
   background: rgba(255, 255, 255, 0.04);
 }
 
-.mage-preset-card__thumb::after {
+.mage-scene-card__thumb::after {
   content: "";
   position: absolute;
   inset: auto 0 0;
@@ -1427,7 +1427,7 @@
   background: linear-gradient(180deg, transparent, rgba(0, 0, 0, 0.4));
 }
 
-.mage-preset-card__body {
+.mage-scene-card__body {
   display: grid;
   align-content: start;
   gap: 3px;
@@ -1435,7 +1435,7 @@
   padding-top: 2px;
 }
 
-.mage-preset-card__body strong {
+.mage-scene-card__body strong {
   font-size: 0.96rem;
   line-height: 1.35;
   display: -webkit-box;
@@ -1444,7 +1444,7 @@
   -webkit-box-orient: vertical;
 }
 
-.mage-preset-card__body span {
+.mage-scene-card__body span {
   color: var(--muted);
   font-size: 0.84rem;
   line-height: 1.4;
@@ -1453,52 +1453,52 @@
   text-overflow: ellipsis;
 }
 
-.mage-preset-card:hover .mage-preset-card__body strong,
-.mage-preset-card.is-active .mage-preset-card__body strong {
+.mage-scene-card:hover .mage-scene-card__body strong,
+.mage-scene-card.is-active .mage-scene-card__body strong {
   color: var(--accent);
 }
 
-.mage-preset-card:hover .mage-preset-card__thumb,
-.mage-preset-card.is-active .mage-preset-card__thumb {
+.mage-scene-card:hover .mage-scene-card__thumb,
+.mage-scene-card.is-active .mage-scene-card__thumb {
   border-color: rgba(99, 240, 214, 0.34);
   box-shadow: 0 18px 38px rgba(0, 0, 0, 0.28);
 }
 
-.preset-detail-description-tags {
+.scene-detail-description-tags {
   margin-top: 18px;
 }
 
-.my-presets-page {
+.my-scenes-page {
   align-self: start;
   margin-top: -26px;
 }
 
-.my-presets-panel {
+.my-scenes-panel {
   display: grid;
   gap: 22px;
   overflow: visible;
 }
 
-.my-presets-panel__header {
+.my-scenes-panel__header {
   display: grid;
   gap: 14px;
   padding-bottom: 18px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-.my-presets-panel__header .eyebrow {
+.my-scenes-panel__header .eyebrow {
   justify-self: start;
   margin-bottom: 0;
 }
 
-.my-presets-panel__title {
+.my-scenes-panel__title {
   margin: 0;
   font-size: clamp(2.4rem, 6vw, 3.8rem);
   line-height: 0.96;
   letter-spacing: -0.05em;
 }
 
-.my-presets-panel__lead {
+.my-scenes-panel__lead {
   max-width: 680px;
   margin: 0;
   color: var(--muted);
@@ -1506,12 +1506,12 @@
   line-height: 1.7;
 }
 
-.my-presets-board {
+.my-scenes-board {
   display: grid;
   gap: 14px;
 }
 
-.my-presets-board__toolbar {
+.my-scenes-board__toolbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -1520,28 +1520,28 @@
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-.my-presets-board__summary {
+.my-scenes-board__summary {
   display: grid;
   gap: 4px;
 }
 
-.my-presets-board__summary strong {
+.my-scenes-board__summary strong {
   font-size: 1rem;
   letter-spacing: -0.02em;
 }
 
-.my-presets-board__summary span {
+.my-scenes-board__summary span {
   color: var(--muted);
   font-size: 0.9rem;
 }
 
-.my-presets-board__filters {
+.my-scenes-board__filters {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
 }
 
-.my-presets-board__chip {
+.my-scenes-board__chip {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1560,59 +1560,59 @@
     color 0.18s ease;
 }
 
-.my-presets-board__chip[data-active="true"] {
+.my-scenes-board__chip[data-active="true"] {
   border-color: rgba(99, 240, 214, 0.24);
   background: rgba(99, 240, 214, 0.1);
   color: #efffff;
 }
 
-.my-presets-board__chip:hover,
-.my-presets-board__chip:focus-visible {
+.my-scenes-board__chip:hover,
+.my-scenes-board__chip:focus-visible {
   border-color: rgba(99, 240, 214, 0.2);
   color: #efffff;
   outline: none;
 }
 
-.my-presets-scroll {
+.my-scenes-scroll {
   overflow-x: auto;
   padding-bottom: 8px;
   scrollbar-width: thin;
   scrollbar-color: rgba(120, 140, 135, 0.5) rgba(255, 255, 255, 0.04);
 }
 
-.my-presets-scroll::-webkit-scrollbar {
+.my-scenes-scroll::-webkit-scrollbar {
   height: 12px;
 }
 
-.my-presets-scroll::-webkit-scrollbar-track {
+.my-scenes-scroll::-webkit-scrollbar-track {
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.04);
 }
 
-.my-presets-scroll::-webkit-scrollbar-thumb {
+.my-scenes-scroll::-webkit-scrollbar-thumb {
   border-radius: 999px;
   background: rgba(120, 140, 135, 0.5);
   border: 2px solid rgba(8, 18, 21, 0.9);
 }
 
-.my-presets-table {
+.my-scenes-table {
   display: grid;
   gap: 0;
   min-width: 1080px;
 }
 
-.my-presets-table__head,
-.my-presets-row {
+.my-scenes-table__head,
+.my-scenes-row {
   display: grid;
   grid-template-columns: minmax(260px, 1.55fr) 132px 150px 90px 100px 176px;
   gap: 20px;
 }
 
-.my-presets-table__head {
+.my-scenes-table__head {
   align-items: end;
 }
 
-.my-presets-table__head {
+.my-scenes-table__head {
   padding: 0 12px 12px;
   color: rgba(171, 189, 184, 0.78);
   font-size: 0.78rem;
@@ -1621,7 +1621,7 @@
   text-transform: uppercase;
 }
 
-.my-presets-table__primary-heading {
+.my-scenes-table__primary-heading {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
   gap: 18px;
@@ -1629,19 +1629,19 @@
   justify-self: start;
 }
 
-.my-presets-table__head > span,
-.my-presets-table__sort-button {
+.my-scenes-table__head > span,
+.my-scenes-table__sort-button {
   justify-self: start;
 }
 
-.my-presets-table__status-heading {
+.my-scenes-table__status-heading {
   display: block;
   width: 100%;
   justify-self: stretch;
   text-align: center;
 }
 
-.my-presets-table__sort-button {
+.my-scenes-table__sort-button {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -1656,24 +1656,24 @@
   white-space: nowrap;
 }
 
-.my-presets-table__sort-button[data-active="true"] {
+.my-scenes-table__sort-button[data-active="true"] {
   color: #dffefa;
 }
 
-.my-presets-table__sort-button:hover,
-.my-presets-table__sort-button:focus-visible {
+.my-scenes-table__sort-button:hover,
+.my-scenes-table__sort-button:focus-visible {
   color: #efffff;
   outline: none;
 }
 
-.my-presets-table__sort-indicator {
+.my-scenes-table__sort-indicator {
   color: rgba(171, 189, 184, 0.72);
   font-size: 1rem;
   line-height: 1;
   font-weight: 800;
 }
 
-.my-presets-table__checkbox {
+.my-scenes-table__checkbox {
   width: 18px;
   height: 18px;
   margin: 0;
@@ -1682,7 +1682,7 @@
   cursor: pointer;
 }
 
-.my-presets-row {
+.my-scenes-row {
   padding: 16px 12px;
   border-top: 1px solid rgba(255, 255, 255, 0.06);
   transition: background-color 0.18s ease;
@@ -1690,11 +1690,11 @@
   align-items: center;
 }
 
-.my-presets-row:hover {
+.my-scenes-row:hover {
   background: rgba(255, 255, 255, 0.02);
 }
 
-.my-presets-row__primary {
+.my-scenes-row__primary {
   display: grid;
   grid-template-columns: auto 92px minmax(0, 1fr);
   gap: 18px;
@@ -1702,7 +1702,7 @@
   min-width: 0;
 }
 
-.my-presets-row__selection {
+.my-scenes-row__selection {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1710,19 +1710,19 @@
   height: 18px;
 }
 
-.my-presets-row__thumb-link,
-.my-presets-row__title-link {
+.my-scenes-row__thumb-link,
+.my-scenes-row__title-link {
   text-decoration: none;
   color: inherit;
 }
 
-.my-presets-row__thumb-link {
+.my-scenes-row__thumb-link {
   display: block;
   cursor: pointer;
 }
 
-.my-presets-row__thumb,
-.my-presets-row__thumb-fallback {
+.my-scenes-row__thumb,
+.my-scenes-row__thumb-fallback {
   width: 92px;
   aspect-ratio: 1 / 1;
   border-radius: 20px;
@@ -1730,13 +1730,13 @@
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.2);
 }
 
-.my-presets-row__thumb {
+.my-scenes-row__thumb {
   display: block;
   object-fit: cover;
   background: rgba(255, 255, 255, 0.04);
 }
 
-.my-presets-row__thumb-fallback {
+.my-scenes-row__thumb-fallback {
   display: grid;
   place-items: center;
   padding: 12px;
@@ -1751,17 +1751,17 @@
     linear-gradient(135deg, rgba(8, 18, 21, 0.98), rgba(4, 10, 12, 1));
 }
 
-.my-presets-row__copy {
+.my-scenes-row__copy {
   display: grid;
   gap: 6px;
   min-width: 0;
 }
 
-.my-presets-row__title-link {
+.my-scenes-row__title-link {
   min-width: 0;
 }
 
-.my-presets-row__copy strong {
+.my-scenes-row__copy strong {
   font-size: 0.98rem;
   line-height: 1.35;
   letter-spacing: -0.02em;
@@ -1772,18 +1772,18 @@
   -webkit-box-orient: vertical;
 }
 
-.my-presets-row:hover .my-presets-row__title-link strong,
-.my-presets-row__title-link:focus-visible strong {
+.my-scenes-row:hover .my-scenes-row__title-link strong,
+.my-scenes-row__title-link:focus-visible strong {
   color: var(--accent);
 }
 
-.my-presets-row__title-link:focus-visible,
-.my-presets-row__thumb-link:focus-visible,
-.my-presets-row__description:focus-visible {
+.my-scenes-row__title-link:focus-visible,
+.my-scenes-row__thumb-link:focus-visible,
+.my-scenes-row__description:focus-visible {
   outline: none;
 }
 
-.my-presets-row__description {
+.my-scenes-row__description {
   width: fit-content;
   max-width: 100%;
   padding: 0;
@@ -1800,19 +1800,19 @@
   text-overflow: ellipsis;
 }
 
-.my-presets-row__description:hover,
-.my-presets-row__description:focus-visible {
+.my-scenes-row__description:hover,
+.my-scenes-row__description:focus-visible {
   color: #d7e8e3;
   text-decoration: underline;
 }
 
-.my-presets-row__cell span {
+.my-scenes-row__cell span {
   color: var(--muted);
   font-size: 0.88rem;
   line-height: 1.45;
 }
 
-.my-presets-row__cell {
+.my-scenes-row__cell {
   display: grid;
   gap: 6px;
   min-width: 0;
@@ -1822,7 +1822,7 @@
   padding-top: 2px;
 }
 
-.my-presets-row__cell--status {
+.my-scenes-row__cell--status {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1832,7 +1832,7 @@
   padding-top: 0;
 }
 
-.my-presets-row__cell strong {
+.my-scenes-row__cell strong {
   font-size: 0.94rem;
   line-height: 1.35;
   color: var(--text);
@@ -1842,7 +1842,7 @@
   -webkit-box-orient: vertical;
 }
 
-.my-presets-row__pill {
+.my-scenes-row__pill {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1857,30 +1857,30 @@
   font-weight: 700;
 }
 
-.my-presets-row__pill[data-status="Public"] {
+.my-scenes-row__pill[data-status="Public"] {
   border-color: rgba(99, 240, 214, 0.16);
   background: rgba(99, 240, 214, 0.08);
 }
 
-.my-presets-row__pill[data-status="Private"] {
+.my-scenes-row__pill[data-status="Private"] {
   border-color: rgba(255, 184, 107, 0.18);
   background: rgba(255, 184, 107, 0.08);
   color: rgba(255, 236, 204, 0.92);
 }
 
-.my-presets-row__pill[data-status="Unlisted"] {
+.my-scenes-row__pill[data-status="Unlisted"] {
   border-color: rgba(126, 200, 255, 0.18);
   background: rgba(126, 200, 255, 0.08);
   color: rgba(229, 244, 255, 0.92);
 }
 
-.my-presets-row__pill[data-status="Draft"] {
+.my-scenes-row__pill[data-status="Draft"] {
   border-color: rgba(188, 176, 255, 0.18);
   background: rgba(188, 176, 255, 0.08);
   color: rgba(239, 234, 255, 0.92);
 }
 
-.my-presets-row__metric {
+.my-scenes-row__metric {
   display: grid;
   align-content: center;
   justify-items: start;
@@ -1889,13 +1889,13 @@
   padding-top: 2px;
 }
 
-.my-presets-row__metric strong {
+.my-scenes-row__metric strong {
   font-size: 0.94rem;
   line-height: 1.3;
   color: var(--text);
 }
 
-.my-presets-pagination {
+.my-scenes-pagination {
   display: flex;
   align-items: center;
   justify-content: flex-end;
@@ -1905,17 +1905,17 @@
   font-size: 0.88rem;
 }
 
-.my-presets-pagination__rows {
+.my-scenes-pagination__rows {
   display: inline-flex;
   align-items: center;
   gap: 10px;
 }
 
-.my-presets-pagination__menu-shell {
+.my-scenes-pagination__menu-shell {
   position: relative;
 }
 
-.my-presets-pagination__menu-button {
+.my-scenes-pagination__menu-button {
   display: inline-flex;
   align-items: center;
   justify-content: space-between;
@@ -1930,19 +1930,19 @@
   cursor: pointer;
 }
 
-.my-presets-pagination__menu-button:hover,
-.my-presets-pagination__menu-button:focus-visible {
+.my-scenes-pagination__menu-button:hover,
+.my-scenes-pagination__menu-button:focus-visible {
   border-color: rgba(99, 240, 214, 0.22);
   outline: none;
 }
 
-.my-presets-pagination__menu-caret {
+.my-scenes-pagination__menu-caret {
   font-size: 0.9rem;
   line-height: 1;
   color: rgba(220, 232, 229, 0.88);
 }
 
-.my-presets-pagination__menu {
+.my-scenes-pagination__menu {
   position: absolute;
   left: 0;
   bottom: calc(100% + 8px);
@@ -1955,7 +1955,7 @@
   box-shadow: 0 14px 32px rgba(0, 0, 0, 0.32);
 }
 
-.my-presets-pagination__menu-option {
+.my-scenes-pagination__menu-option {
   display: block;
   width: 100%;
   padding: 8px 12px;
@@ -1967,30 +1967,30 @@
   cursor: pointer;
 }
 
-.my-presets-pagination__menu-option:hover,
-.my-presets-pagination__menu-option:focus-visible {
+.my-scenes-pagination__menu-option:hover,
+.my-scenes-pagination__menu-option:focus-visible {
   background: rgba(99, 240, 214, 0.12);
   color: #efffff;
   outline: none;
 }
 
-.my-presets-pagination__menu-option[data-active="true"] {
+.my-scenes-pagination__menu-option[data-active="true"] {
   background: rgba(99, 240, 214, 0.18);
   color: #efffff;
 }
 
-.my-presets-pagination__range {
+.my-scenes-pagination__range {
   min-width: 88px;
   text-align: center;
 }
 
-.my-presets-pagination__controls {
+.my-scenes-pagination__controls {
   display: inline-flex;
   align-items: center;
   gap: 6px;
 }
 
-.my-presets-pagination__button {
+.my-scenes-pagination__button {
   width: 32px;
   height: 32px;
   border: 0;
@@ -2001,35 +2001,35 @@
   cursor: pointer;
 }
 
-.my-presets-pagination__button:hover,
-.my-presets-pagination__button:focus-visible {
+.my-scenes-pagination__button:hover,
+.my-scenes-pagination__button:focus-visible {
   color: #efffff;
   outline: none;
 }
 
-.my-presets-pagination__button:disabled {
+.my-scenes-pagination__button:disabled {
   color: rgba(171, 189, 184, 0.34);
   cursor: default;
 }
 
-.preset-status {
+.scene-status {
   margin: 0;
   color: var(--muted);
   font-size: 1rem;
   line-height: 1.7;
 }
 
-.preset-status-error {
+.scene-status-error {
   color: #ffd1d8;
 }
 
-.preset-actions {
+.scene-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 14px;
 }
 
-.preset-action {
+.scene-action {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -2047,13 +2047,13 @@
     background-color 0.18s ease;
 }
 
-.preset-action:hover {
+.scene-action:hover {
   transform: translateY(-1px);
   border-color: rgba(99, 240, 214, 0.4);
   background: rgba(99, 240, 214, 0.2);
 }
 
-.preset-action:disabled {
+.scene-action:disabled {
   cursor: wait;
   opacity: 0.72;
   transform: none;
@@ -2070,45 +2070,45 @@
   overflow: visible;
 }
 
-.surface--editor > .preset-editor-form {
+.surface--editor > .scene-editor-form {
   margin-top: 30px;
 }
 
-.preset-editor-form,
-.preset-editor-main,
-.preset-advanced-stack {
+.scene-editor-form,
+.scene-editor-main,
+.scene-advanced-stack {
   display: grid;
   gap: 22px;
 }
 
-.preset-editor-toolbar {
+.scene-editor-toolbar {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   gap: 14px;
   align-items: start;
 }
 
-.preset-editor-toolbar__name {
+.scene-editor-toolbar__name {
   margin: 0;
   max-width: none;
 }
 
-.preset-editor-toolbar__metadata {
+.scene-editor-toolbar__metadata {
   display: grid;
   gap: 18px;
 }
 
-.preset-editor-toolbar__controls {
+.scene-editor-toolbar__controls {
   display: grid;
   gap: 14px;
 }
 
-.preset-editor-toolbar__control-group {
+.scene-editor-toolbar__control-group {
   display: grid;
   gap: 8px;
 }
 
-.preset-editor-toolbar__control-group--navigation {
+.scene-editor-toolbar__control-group--navigation {
   gap: 12px;
   padding: 18px;
   border-radius: 20px;
@@ -2121,12 +2121,12 @@
     );
 }
 
-.preset-editor-toolbar__control-copy {
+.scene-editor-toolbar__control-copy {
   display: grid;
   gap: 4px;
 }
 
-.preset-editor-toolbar__eyebrow {
+.scene-editor-toolbar__eyebrow {
   font-size: 0.76rem;
   font-weight: 700;
   letter-spacing: 0.14em;
@@ -2134,18 +2134,18 @@
   color: var(--accent);
 }
 
-.preset-editor-toolbar__hint {
+.scene-editor-toolbar__hint {
   margin: 0;
   color: var(--muted);
   font-size: 0.92rem;
   line-height: 1.55;
 }
 
-.preset-editor-toolbar__navigation-shell {
+.scene-editor-toolbar__navigation-shell {
   position: relative;
 }
 
-.preset-editor-toolbar__navigation-icon {
+.scene-editor-toolbar__navigation-icon {
   position: absolute;
   top: 50%;
   left: 16px;
@@ -2156,84 +2156,84 @@
   pointer-events: none;
 }
 
-.preset-editor-toolbar__navigation-icon svg {
+.scene-editor-toolbar__navigation-icon svg {
   display: block;
   width: 100%;
   height: 100%;
 }
 
-.preset-editor-layout {
+.scene-editor-layout {
   display: grid;
   grid-template-columns: minmax(0, 1.55fr) minmax(320px, 0.95fr);
   gap: 24px;
   align-items: stretch;
 }
 
-.preset-editor-section {
+.scene-editor-section {
   padding: 24px;
 }
 
-.preset-editor-section__header {
+.scene-editor-section__header {
   display: grid;
   gap: 6px;
   margin-bottom: 18px;
 }
 
-.preset-editor-section__header h2,
-.preset-editor-preview__header h2 {
+.scene-editor-section__header h2,
+.scene-editor-preview__header h2 {
   margin: 0;
   font-size: 1.35rem;
   letter-spacing: -0.03em;
 }
 
-.preset-editor-section__header p,
-.preset-editor-preview__header p,
-.preset-effect-footnote {
+.scene-editor-section__header p,
+.scene-editor-preview__header p,
+.scene-effect-footnote {
   margin: 0;
   color: var(--muted);
   line-height: 1.7;
 }
 
-.preset-editor-grid {
+.scene-editor-grid {
   display: grid;
   gap: 18px;
 }
 
-.preset-editor-grid--2 {
+.scene-editor-grid--2 {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.preset-editor-grid--3 {
+.scene-editor-grid--3 {
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
-.preset-editor-grid__item--full {
+.scene-editor-grid__item--full {
   grid-column: 1 / -1;
 }
 
-.preset-field {
+.scene-field {
   display: grid;
   gap: 8px;
   min-width: 0;
 }
 
-.preset-field__label {
+.scene-field__label {
   display: inline-block;
   color: #f5fbf9;
   font-size: 0.92rem;
   font-weight: 700;
 }
 
-.preset-field__description {
+.scene-field__description {
   display: none;
 }
 
-.preset-thumbnail-picker {
+.scene-thumbnail-picker {
   display: grid;
   gap: 12px;
 }
 
-.preset-tag-editor__header {
+.scene-tag-editor__header {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -2241,24 +2241,24 @@
   flex-wrap: wrap;
 }
 
-.preset-tag-editor__label {
+.scene-tag-editor__label {
   font-size: 0.92rem;
   font-weight: 700;
   color: #f5fbf9;
 }
 
-.preset-tag-editor__status,
-.preset-tag-editor__picker,
-.preset-tag-editor__selected {
+.scene-tag-editor__status,
+.scene-tag-editor__picker,
+.scene-tag-editor__selected {
   display: grid;
   gap: 10px;
 }
 
-.preset-tag-dropdown {
+.scene-tag-dropdown {
   position: relative;
 }
 
-.preset-tag-dropdown__panel {
+.scene-tag-dropdown__panel {
   position: absolute;
   top: calc(100% + 8px);
   left: 0;
@@ -2273,12 +2273,12 @@
   box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
 }
 
-.preset-tag-dropdown__search {
+.scene-tag-dropdown__search {
   display: grid;
   gap: 8px;
 }
 
-.preset-tag-dropdown__search label {
+.scene-tag-dropdown__search label {
   font-size: 0.82rem;
   font-weight: 700;
   letter-spacing: 0.06em;
@@ -2286,14 +2286,14 @@
   color: rgba(155, 177, 171, 0.88);
 }
 
-.preset-tag-dropdown__options {
+.scene-tag-dropdown__options {
   display: grid;
   gap: 8px;
   max-height: 220px;
   overflow-y: auto;
 }
 
-.preset-tag-dropdown__option {
+.scene-tag-dropdown__option {
   width: 100%;
   min-height: 42px;
   padding: 10px 14px;
@@ -2310,31 +2310,31 @@
     border-color 0.2s ease;
 }
 
-.preset-tag-dropdown__option:hover {
+.scene-tag-dropdown__option:hover {
   background: rgba(26, 63, 67, 0.96);
   border-color: rgba(99, 240, 214, 0.34);
   color: #e8fffb;
 }
 
-.preset-tag-dropdown__option:disabled {
+.scene-tag-dropdown__option:disabled {
   cursor: wait;
   opacity: 0.72;
 }
 
-.preset-tag-dropdown__option--create {
+.scene-tag-dropdown__option--create {
   border-color: rgba(99, 240, 214, 0.28);
   background:
     linear-gradient(135deg, rgba(17, 58, 53, 0.74), rgba(12, 25, 29, 0.96));
   color: #e8fffb;
 }
 
-.preset-tag-dropdown__option--create:hover {
+.scene-tag-dropdown__option--create:hover {
   border-color: rgba(99, 240, 214, 0.46);
   background:
     linear-gradient(135deg, rgba(24, 79, 73, 0.84), rgba(14, 32, 36, 0.98));
 }
 
-.preset-tag-editor__selected-label {
+.scene-tag-editor__selected-label {
   font-size: 0.8rem;
   font-weight: 700;
   letter-spacing: 0.08em;
@@ -2342,23 +2342,23 @@
   color: rgba(155, 177, 171, 0.88);
 }
 
-.preset-tag-editor__selected-list {
+.scene-tag-editor__selected-list {
   display: flex;
   gap: 10px;
   flex-wrap: wrap;
 }
 
-.preset-thumbnail-input {
+.scene-thumbnail-input {
   display: none;
 }
 
-.preset-thumbnail-picker__grid {
+.scene-thumbnail-picker__grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 12px;
 }
 
-.preset-thumbnail-choice {
+.scene-thumbnail-choice {
   appearance: none;
   display: grid;
   gap: 10px;
@@ -2378,20 +2378,20 @@
     box-shadow 0.18s ease;
 }
 
-.preset-thumbnail-choice:hover {
+.scene-thumbnail-choice:hover {
   transform: translateY(-1px);
   border-color: rgba(99, 240, 214, 0.34);
   background: rgba(255, 255, 255, 0.05);
 }
 
-.preset-thumbnail-choice.is-selected {
+.scene-thumbnail-choice.is-selected {
   border-style: solid;
   border-color: rgba(99, 240, 214, 0.42);
   background: rgba(17, 58, 53, 0.42);
   box-shadow: 0 0 0 4px rgba(99, 240, 214, 0.08);
 }
 
-.preset-thumbnail-choice__eyebrow {
+.scene-thumbnail-choice__eyebrow {
   color: var(--accent);
   font-size: 0.74rem;
   font-weight: 700;
@@ -2399,18 +2399,18 @@
   text-transform: uppercase;
 }
 
-.preset-thumbnail-choice__title {
+.scene-thumbnail-choice__title {
   font-size: 1rem;
   letter-spacing: -0.02em;
 }
 
-.preset-thumbnail-choice__description {
+.scene-thumbnail-choice__description {
   color: var(--muted);
   font-size: 0.92rem;
   line-height: 1.55;
 }
 
-.preset-select {
+.scene-select {
   appearance: none;
   background-image:
     linear-gradient(45deg, transparent 50%, rgba(99, 240, 214, 0.86) 50%),
@@ -2424,36 +2424,36 @@
   background-repeat: no-repeat;
 }
 
-.preset-select--navigation {
+.scene-select--navigation {
   min-height: 56px;
   padding-left: 46px;
   border-color: rgba(99, 240, 214, 0.22);
   background-color: rgba(4, 12, 14, 0.56);
 }
 
-.preset-slider {
+.scene-slider {
   display: grid;
   gap: 10px;
 }
 
-.preset-slider__header {
+.scene-slider__header {
   display: flex;
   justify-content: flex-end;
 }
 
-.preset-slider__header strong {
+.scene-slider__header strong {
   font-size: 0.88rem;
   color: var(--accent);
 }
 
-.preset-slider__controls {
+.scene-slider__controls {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 112px;
   gap: 12px;
   align-items: center;
 }
 
-.preset-slider__range {
+.scene-slider__range {
   width: 100%;
   height: 10px;
   margin: 0;
@@ -2467,7 +2467,7 @@
   outline: none;
 }
 
-.preset-slider__range::-webkit-slider-thumb {
+.scene-slider__range::-webkit-slider-thumb {
   appearance: none;
   width: 18px;
   height: 18px;
@@ -2477,7 +2477,7 @@
   box-shadow: 0 0 0 4px rgba(99, 240, 214, 0.16);
 }
 
-.preset-slider__range::-moz-range-thumb {
+.scene-slider__range::-moz-range-thumb {
   width: 18px;
   height: 18px;
   border-radius: 50%;
@@ -2486,25 +2486,25 @@
   box-shadow: 0 0 0 4px rgba(99, 240, 214, 0.16);
 }
 
-.preset-vector-field {
+.scene-vector-field {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 12px;
 }
 
-.preset-vector-field__axis {
+.scene-vector-field__axis {
   display: grid;
   gap: 8px;
 }
 
-.preset-vector-field__axis span {
+.scene-vector-field__axis span {
   color: var(--muted);
   font-size: 0.8rem;
   font-weight: 700;
   letter-spacing: 0.08em;
 }
 
-.preset-toggle {
+.scene-toggle {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -2516,34 +2516,34 @@
   cursor: pointer;
 }
 
-.preset-toggle__copy {
+.scene-toggle__copy {
   display: grid;
   gap: 4px;
 }
 
-.preset-toggle__copy span {
+.scene-toggle__copy span {
   color: #f5fbf9;
   font-size: 0.94rem;
   font-weight: 700;
 }
 
-.preset-toggle__copy small {
+.scene-toggle__copy small {
   color: var(--muted);
   line-height: 1.5;
 }
 
-.preset-toggle__control {
+.scene-toggle__control {
   display: inline-flex;
   align-items: center;
 }
 
-.preset-toggle__input {
+.scene-toggle__input {
   position: absolute;
   opacity: 0;
   pointer-events: none;
 }
 
-.preset-toggle__track {
+.scene-toggle__track {
   position: relative;
   width: 48px;
   height: 28px;
@@ -2552,7 +2552,7 @@
   transition: background-color 0.18s ease;
 }
 
-.preset-toggle__track::after {
+.scene-toggle__track::after {
   content: "";
   position: absolute;
   top: 4px;
@@ -2564,25 +2564,25 @@
   transition: transform 0.18s ease;
 }
 
-.preset-toggle__input:checked + .preset-toggle__track {
+.scene-toggle__input:checked + .scene-toggle__track {
   background: rgba(99, 240, 214, 0.34);
 }
 
-.preset-toggle__input:checked + .preset-toggle__track::after {
+.scene-toggle__input:checked + .scene-toggle__track::after {
   transform: translateX(20px);
 }
 
-.preset-effects-grid {
+.scene-effects-grid {
   display: grid;
   gap: 24px;
 }
 
-.preset-effects-category {
+.scene-effects-category {
   display: grid;
   gap: 14px;
 }
 
-.preset-effects-category__title {
+.scene-effects-category__title {
   margin: 0;
   color: var(--muted);
   font-size: 0.78rem;
@@ -2591,7 +2591,7 @@
   text-transform: uppercase;
 }
 
-.preset-effects-category__grid {
+.scene-effects-category__grid {
   display: grid;
   gap: 18px;
 }
@@ -2631,7 +2631,7 @@
   gap: 16px;
 }
 
-.preset-color-field {
+.scene-color-field {
   display: inline-flex;
   align-items: center;
   gap: 14px;
@@ -2642,13 +2642,13 @@
   background: rgba(4, 12, 14, 0.72);
 }
 
-.preset-color-field span {
+.scene-color-field span {
   color: #f5fbf9;
   font-weight: 700;
   letter-spacing: 0.08em;
 }
 
-.preset-color-field__picker {
+.scene-color-field__picker {
   width: 52px;
   height: 32px;
   padding: 0;
@@ -2656,7 +2656,7 @@
   background: transparent;
 }
 
-.preset-pass-order {
+.scene-pass-order {
   display: grid;
   gap: 10px;
   margin: 0;
@@ -2664,7 +2664,7 @@
   list-style: none;
 }
 
-.preset-pass-order__item {
+.scene-pass-order__item {
   display: flex;
   justify-content: space-between;
   gap: 16px;
@@ -2675,23 +2675,23 @@
   background: rgba(255, 255, 255, 0.03);
 }
 
-.preset-pass-order__copy {
+.scene-pass-order__copy {
   display: grid;
   gap: 4px;
 }
 
-.preset-pass-order__copy span {
+.scene-pass-order__copy span {
   color: var(--muted);
   font-size: 0.88rem;
 }
 
-.preset-pass-order__actions {
+.scene-pass-order__actions {
   display: flex;
   gap: 8px;
 }
 
-.preset-order-button,
-.preset-secondary-button {
+.scene-order-button,
+.scene-secondary-button {
   min-height: 40px;
   padding: 0 14px;
   border-radius: 999px;
@@ -2707,35 +2707,35 @@
     color 0.18s ease;
 }
 
-.preset-order-button:hover,
-.preset-secondary-button:hover {
+.scene-order-button:hover,
+.scene-secondary-button:hover {
   border-color: rgba(99, 240, 214, 0.3);
   background: rgba(99, 240, 214, 0.16);
 }
 
-.preset-order-button:disabled {
+.scene-order-button:disabled {
   cursor: not-allowed;
   opacity: 0.52;
   transform: none;
 }
 
-.preset-advanced-header {
+.scene-advanced-header {
   display: flex;
   justify-content: space-between;
   gap: 14px;
   align-items: start;
 }
 
-.preset-textarea {
+.scene-textarea {
   font-family: "IBM Plex Mono", "Fira Code", monospace;
   line-height: 1.6;
 }
 
-.preset-textarea--code {
+.scene-textarea--code {
   min-height: 320px;
 }
 
-.preset-editor-submit {
+.scene-editor-submit {
   width: auto;
   min-width: 220px;
   justify-self: start;
@@ -2743,18 +2743,18 @@
   white-space: nowrap;
 }
 
-.preset-editor-submit:hover {
+.scene-editor-submit:hover {
   transform: none;
   background: #7bf4e1;
   box-shadow: 0 10px 30px rgba(99, 240, 214, 0.18);
 }
 
-.preset-editor-preview {
+.scene-editor-preview {
   position: relative;
   min-height: 100%;
 }
 
-.preset-editor-preview__card {
+.scene-editor-preview__card {
   position: sticky;
   top: 92px;
   display: grid;
@@ -2764,17 +2764,17 @@
   overflow: auto;
 }
 
-.preset-editor-preview__header {
+.scene-editor-preview__header {
   display: grid;
   gap: 6px;
 }
 
-.preset-editor-preview__player,
-.preset-editor-preview__player.mage-player {
+.scene-editor-preview__player,
+.scene-editor-preview__player.mage-player {
   width: 100%;
 }
 
-.preset-editor-preview__player .mage-player__viewport {
+.scene-editor-preview__player .mage-player__viewport {
   min-height: 360px;
 }
 
@@ -2791,44 +2791,44 @@
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   }
 
-  .preset-editor-layout,
-  .preset-editor-toolbar {
+  .scene-editor-layout,
+  .scene-editor-toolbar {
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .preset-thumbnail-picker__grid {
+  .scene-thumbnail-picker__grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .preset-editor-preview__card {
+  .scene-editor-preview__card {
     position: static;
   }
 }
 
 @media (max-width: 980px) {
-  .preset-detail-social-row {
+  .scene-detail-social-row {
     flex-direction: column;
     align-items: flex-start;
   }
 
-  .preset-detail-action-row {
+  .scene-detail-action-row {
     justify-content: flex-start;
   }
 
-  .mage-preset-card {
+  .mage-scene-card {
     grid-template-columns: 104px minmax(0, 1fr);
   }
 
-  .mage-preset-card__thumb {
+  .mage-scene-card__thumb {
     width: 104px;
   }
 
-  .my-presets-table {
+  .my-scenes-table {
     min-width: 1060px;
   }
 
-  .my-presets-table__head,
-  .my-presets-row {
+  .my-scenes-table__head,
+  .my-scenes-row {
     grid-template-columns: minmax(240px, 1.45fr) 110px 136px 90px 90px 130px;
   }
 }
@@ -2838,34 +2838,34 @@
     padding: 30px 24px;
   }
 
-  .preset-editor-grid--2,
-  .preset-editor-grid--3 {
+  .scene-editor-grid--2,
+  .scene-editor-grid--3 {
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .preset-thumbnail-picker__grid {
+  .scene-thumbnail-picker__grid {
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .preset-slider__controls,
-  .preset-vector-field,
-  .preset-advanced-header,
+  .scene-slider__controls,
+  .scene-vector-field,
+  .scene-advanced-header,
   .effect-card__header,
-  .preset-pass-order__item {
+  .scene-pass-order__item {
     grid-template-columns: minmax(0, 1fr);
     flex-direction: column;
     align-items: stretch;
   }
 
-  .preset-editor-submit {
+  .scene-editor-submit {
     width: 100%;
   }
 
-  .preset-pass-order__actions {
+  .scene-pass-order__actions {
     width: 100%;
   }
 
-  .preset-order-button {
+  .scene-order-button {
     flex: 1;
   }
 }
@@ -2916,7 +2916,7 @@
     padding: 20px;
   }
 
-  .preset-detail-watch .mage-player-shell {
+  .scene-detail-watch .mage-player-shell {
     width: 100%;
   }
 
@@ -2930,7 +2930,7 @@
     border-radius: 22px;
   }
 
-  .preset-detail-stage .mage-player__overlay {
+  .scene-detail-stage .mage-player__overlay {
     border-radius: 22px;
   }
 
@@ -2943,13 +2943,13 @@
     padding: 22px;
   }
 
-  .preset-detail-description-card,
-  .preset-detail-comments-panel {
+  .scene-detail-description-card,
+  .scene-detail-comments-panel {
     padding: 16px;
     border-radius: 18px;
   }
 
-  .preset-detail-note-grid {
+  .scene-detail-note-grid {
     grid-template-columns: 1fr;
   }
 
@@ -2957,53 +2957,53 @@
     grid-template-columns: 1fr;
   }
 
-  .mage-preset-card {
+  .mage-scene-card {
     grid-template-columns: 104px minmax(0, 1fr);
   }
 
-  .mage-preset-card__thumb {
+  .mage-scene-card__thumb {
     width: 104px;
   }
 
-  .my-presets-board__toolbar {
+  .my-scenes-board__toolbar {
     flex-direction: column;
     align-items: flex-start;
   }
 
-  .my-presets-row__selection {
+  .my-scenes-row__selection {
     display: none;
   }
 
-  .my-presets-table {
+  .my-scenes-table {
     min-width: 980px;
   }
 
-  .my-presets-table__head,
-  .my-presets-row {
+  .my-scenes-table__head,
+  .my-scenes-row {
     grid-template-columns: minmax(220px, 1.35fr) 100px 124px 80px 90px 120px;
   }
 
-  .my-presets-row__primary {
+  .my-scenes-row__primary {
     grid-template-columns: 92px minmax(0, 1fr);
   }
 
-  .preset-detail-social-row__creator,
-  .preset-detail-action-row {
+  .scene-detail-social-row__creator,
+  .scene-detail-action-row {
     flex-direction: column;
     align-items: stretch;
   }
 
-  .preset-detail-follow-button,
-  .preset-detail-action-chip,
-  .preset-detail-sort-chip {
+  .scene-detail-follow-button,
+  .scene-detail-action-chip,
+  .scene-detail-sort-chip {
     width: 100%;
   }
 
-  .preset-detail-comment-composer {
+  .scene-detail-comment-composer {
     grid-template-columns: 1fr;
   }
 
-  .preset-detail-comment-composer__field {
+  .scene-detail-comment-composer__field {
     padding-top: 0;
   }
 
@@ -3013,9 +3013,9 @@
   }
 }
 
-/* ─── Presets Page ────────────────────────────────────────────────────── */
+/* â”€â”€â”€ Scenes Page â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
-.presets-page {
+.scenes-page {
   width: min(1380px, 100%);
   display: grid;
   align-self: start;
@@ -3024,7 +3024,7 @@
   margin-top: -26px;
 }
 
-.presets-filter-rail {
+.scenes-filter-rail {
   position: sticky;
   top: 84px;
   z-index: 4;
@@ -3035,7 +3035,7 @@
   backdrop-filter: none;
 }
 
-/* ─── Tag Filter Bar ─────────────────────────────────────────────────── */
+/* â”€â”€â”€ Tag Filter Bar â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .tag-filter-scroller {
   position: relative;
@@ -3172,24 +3172,24 @@
   }
 }
 
-/* ─── Preset Grid ────────────────────────────────────────────────────── */
+/* â”€â”€â”€ Scene Grid â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
-.preset-grid {
+.scene-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
   gap: 24px 16px;
 }
 
-/* ─── Preset Card ────────────────────────────────────────────────────── */
+/* â”€â”€â”€ Scene Card â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
-.preset-card-link {
+.scene-card-link {
   display: block;
   text-decoration: none;
   color: inherit;
   cursor: pointer;
 }
 
-.preset-card {
+.scene-card {
   display: grid;
   gap: 12px;
   background: transparent;
@@ -3205,16 +3205,16 @@
   cursor: pointer;
 }
 
-.preset-card-link:hover .preset-card,
-.preset-card-link:focus-visible .preset-card {
+.scene-card-link:hover .scene-card,
+.scene-card-link:focus-visible .scene-card {
   background: rgba(255, 255, 255, 0.03);
 }
 
-.preset-card-link:focus-visible {
+.scene-card-link:focus-visible {
   outline: none;
 }
 
-.preset-card__thumbnail {
+.scene-card__thumbnail {
   width: 100%;
   aspect-ratio: 1 / 1;
   overflow: hidden;
@@ -3231,14 +3231,14 @@
     box-shadow 0.18s ease;
 }
 
-.preset-card__thumbnail-img {
+.scene-card__thumbnail-img {
   width: 100%;
   height: 100%;
   object-fit: cover;
   display: block;
 }
 
-.preset-card__thumbnail-placeholder {
+.scene-card__thumbnail-placeholder {
   width: 100%;
   height: 100%;
   background:
@@ -3248,7 +3248,7 @@
     linear-gradient(135deg, rgba(8, 18, 21, 0.98), rgba(4, 10, 12, 1));
 }
 
-.preset-card__thumbnail::after {
+.scene-card__thumbnail::after {
   content: "";
   position: absolute;
   inset: 0;
@@ -3256,14 +3256,14 @@
   pointer-events: none;
 }
 
-.preset-card__body {
+.scene-card__body {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
   gap: 12px;
   align-items: start;
 }
 
-.preset-card__avatar {
+.scene-card__avatar {
   width: 40px;
   height: 40px;
   border-radius: 50%;
@@ -3281,7 +3281,7 @@
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
 }
 
-.preset-card__avatar--skeleton {
+.scene-card__avatar--skeleton {
   border: 0;
   background: linear-gradient(
     90deg,
@@ -3293,14 +3293,14 @@
   animation: skeleton-shimmer 1.5s ease-in-out infinite;
 }
 
-.preset-card__meta {
+.scene-card__meta {
   display: grid;
   gap: 4px;
   min-width: 0;
   transition: color 0.18s ease;
 }
 
-.preset-card__name {
+.scene-card__name {
   margin: 0;
   font-size: 1rem;
   line-height: 1.35;
@@ -3313,8 +3313,8 @@
   -webkit-box-orient: vertical;
 }
 
-.preset-card__creator,
-.preset-card__stats {
+.scene-card__creator,
+.scene-card__stats {
   margin: 0;
   color: rgba(187, 201, 196, 0.84);
   font-size: 0.88rem;
@@ -3322,41 +3322,41 @@
   transition: color 0.18s ease;
 }
 
-.preset-card__creator {
+.scene-card__creator {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.preset-card__stats {
+.scene-card__stats {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
   gap: 6px;
 }
 
-.preset-card__stats-separator {
+.scene-card__stats-separator {
   color: rgba(155, 177, 171, 0.72);
 }
 
-.preset-card__time {
+.scene-card__time {
   color: inherit;
 }
 
-.preset-card-link:hover .preset-card__creator,
-.preset-card-link:hover .preset-card__stats,
-.preset-card-link:focus-visible .preset-card__creator,
-.preset-card-link:focus-visible .preset-card__stats {
+.scene-card-link:hover .scene-card__creator,
+.scene-card-link:hover .scene-card__stats,
+.scene-card-link:focus-visible .scene-card__creator,
+.scene-card-link:focus-visible .scene-card__stats {
   color: rgba(213, 228, 223, 0.94);
 }
 
-/* ─── Skeleton Card ──────────────────────────────────────────────────── */
+/* â”€â”€â”€ Skeleton Card â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
-.preset-card--skeleton {
+.scene-card--skeleton {
   pointer-events: none;
 }
 
-.preset-card__thumbnail--skeleton {
+.scene-card__thumbnail--skeleton {
   background: linear-gradient(
     90deg,
     rgba(255, 255, 255, 0.02) 25%,
@@ -3395,10 +3395,10 @@
   height: 12px;
 }
 
-/* ─── Empty & Error States ───────────────────────────────────────────── */
+/* â”€â”€â”€ Empty & Error States â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
-.presets-empty,
-.presets-error {
+.scenes-empty,
+.scenes-error {
   text-align: center;
   padding: 56px 24px;
   border-radius: 22px;
@@ -3410,31 +3410,31 @@
   box-shadow: 0 18px 42px rgba(0, 0, 0, 0.22);
 }
 
-.presets-empty p,
-.presets-error p {
+.scenes-empty p,
+.scenes-error p {
   margin: 0;
   font-size: 1.1rem;
   color: var(--text);
 }
 
-.presets-empty__hint {
+.scenes-empty__hint {
   margin-top: 8px !important;
   font-size: 0.95rem !important;
   color: var(--muted) !important;
 }
 
-.presets-error .demo-link {
+.scenes-error .demo-link {
   margin-top: 18px;
 }
 
-/* ─── Presets Page Responsive ────────────────────────────────────────── */
+/* â”€â”€â”€ Scenes Page Responsive â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 @media (max-width: 560px) {
-  .presets-page {
+  .scenes-page {
     gap: 18px;
   }
 
-  .preset-grid {
+  .scene-grid {
     grid-template-columns: 1fr;
     gap: 16px;
   }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -17,24 +17,24 @@ vi.mock('./pages/LoginPage', () => ({
   LoginPage: () => <div>Login page</div>,
 }))
 
-vi.mock('./pages/MyPresetsPage', () => ({
-  MyPresetsPage: () => <div>My presets page</div>,
+vi.mock('./pages/MyScenesPage', () => ({
+  MyScenesPage: () => <div>My scenes page</div>,
 }))
 
-vi.mock('./pages/PresetsPage', () => ({
-  PresetsPage: () => <div>Presets page</div>,
+vi.mock('./pages/ScenesPage', () => ({
+  ScenesPage: () => <div>Scenes page</div>,
 }))
 
-vi.mock('./pages/PresetDetailPage', () => ({
-  PresetDetailPage: () => <div>Preset detail page</div>,
+vi.mock('./pages/SceneDetailPage', () => ({
+  SceneDetailPage: () => <div>Scene detail page</div>,
 }))
 
 vi.mock('./pages/RegisterPage', () => ({
   RegisterPage: () => <div>Register page</div>,
 }))
 
-vi.mock('./pages/CreatePresetPage', () => ({
-  CreatePresetPage: () => <div>Create preset page</div>,
+vi.mock('./pages/CreateScenePage', () => ({
+  CreateScenePage: () => <div>Create scene page</div>,
 }))
 
 vi.mock('./pages/SettingsPage', () => ({
@@ -47,25 +47,25 @@ describe('App routing', () => {
     vi.restoreAllMocks()
   })
 
-  it('allows direct preset detail visits without redirecting to login', async () => {
+  it('allows direct scene detail visits without redirecting to login', async () => {
     render(
-      <MemoryRouter initialEntries={['/presets/12']}>
+      <MemoryRouter initialEntries={['/scenes/12']}>
         <App />
       </MemoryRouter>,
     )
 
-    expect(screen.getByText('Preset detail page')).toBeInTheDocument()
+    expect(screen.getByText('Scene detail page')).toBeInTheDocument()
     expect(screen.queryByText('Login page')).not.toBeInTheDocument()
   })
 
-  it('allows public visits to the presets discovery page', () => {
+  it('allows public visits to the scenes discovery page', () => {
     render(
-      <MemoryRouter initialEntries={['/presets']}>
+      <MemoryRouter initialEntries={['/scenes']}>
         <App />
       </MemoryRouter>,
     )
 
-    expect(screen.getByText('Presets page')).toBeInTheDocument()
+    expect(screen.getByText('Scenes page')).toBeInTheDocument()
     expect(screen.queryByText('Login page')).not.toBeInTheDocument()
   })
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,11 +5,11 @@ import { AuthProvider, useAuth } from './auth/AuthContext'
 import { Layout } from './components/Layout'
 import { HomePage } from './pages/HomePage'
 import { LoginPage } from './pages/LoginPage'
-import { MyPresetsPage } from './pages/MyPresetsPage'
-import { PresetDetailPage } from './pages/PresetDetailPage'
-import { PresetsPage } from './pages/PresetsPage'
+import { MyScenesPage } from './pages/MyScenesPage'
+import { SceneDetailPage } from './pages/SceneDetailPage'
+import { ScenesPage } from './pages/ScenesPage'
 import { RegisterPage } from './pages/RegisterPage'
-import { CreatePresetPage } from './pages/CreatePresetPage'
+import { CreateScenePage } from './pages/CreateScenePage'
 import { SettingsPage } from './pages/SettingsPage'
 
 type ProtectedRouteProps = {
@@ -60,7 +60,7 @@ function App() {
       <Layout>
         <Routes>
           <Route path="/" element={<HomePage />} />
-          <Route path="/presets" element={<PresetsPage />} />
+          <Route path="/scenes" element={<ScenesPage />} />
           <Route
             path="/login"
             element={
@@ -70,14 +70,14 @@ function App() {
             }
           />
           <Route
-            path="/my-presets"
+            path="/my-scenes"
             element={
               <ProtectedRoute>
-                <MyPresetsPage />
+                <MyScenesPage />
               </ProtectedRoute>
             }
           />
-          <Route path="/presets/:id" element={<PresetDetailPage />} />
+          <Route path="/scenes/:id" element={<SceneDetailPage />} />
           <Route
             path="/register"
             element={
@@ -86,7 +86,7 @@ function App() {
               </GuestOnlyRoute>
             }
           />
-          <Route path="/create-preset" element={<CreatePresetPage />} />
+          <Route path="/create-scene" element={<CreateScenePage />} />
           <Route
             path="/settings"
             element={

--- a/src/auth/AuthContext.test.tsx
+++ b/src/auth/AuthContext.test.tsx
@@ -41,7 +41,7 @@ function AuthHarness() {
       <button
         type="button"
         onClick={() => {
-          void authenticatedFetch('/presets')
+          void authenticatedFetch('/scenes')
         }}
       >
         Request protected data
@@ -176,7 +176,7 @@ describe('AuthProvider', () => {
     await waitFor(() =>
       expect(fetchSpy).toHaveBeenNthCalledWith(
         2,
-        buildApiUrl('/presets'),
+        buildApiUrl('/scenes'),
         expect.objectContaining({
           headers: expect.any(Headers),
         }),

--- a/src/components/Layout.test.tsx
+++ b/src/components/Layout.test.tsx
@@ -63,7 +63,7 @@ describe('Layout', () => {
       isAuthenticated: true,
       user: {
         authProvider: 'LOCAL',
-        displayName: 'Preset Artist',
+        displayName: 'Scene Artist',
         email: 'artist@example.com',
         userId: 8,
       },
@@ -73,19 +73,19 @@ describe('Layout', () => {
 
     renderLayout()
 
-    expect(screen.getByRole('link', { name: /create/i })).toHaveAttribute('href', '/create-preset')
+    expect(screen.getByRole('link', { name: /create/i })).toHaveAttribute('href', '/create-scene')
 
-    await user.click(screen.getByRole('button', { name: /open account menu for preset artist/i }))
+    await user.click(screen.getByRole('button', { name: /open account menu for scene artist/i }))
 
-    expect(screen.getByRole('menuitem', { name: /preset artist/i })).toHaveAttribute(
+    expect(screen.getByRole('menuitem', { name: /scene artist/i })).toHaveAttribute(
       'href',
       '/settings',
     )
     expect(screen.getByRole('button', { name: /view your channel/i })).toBeInTheDocument()
     expect(screen.getByRole('menuitem', { name: /browse/i })).toHaveAttribute('href', '/')
-    expect(screen.getByRole('menuitem', { name: /my presets/i })).toHaveAttribute(
+    expect(screen.getByRole('menuitem', { name: /my scenes/i })).toHaveAttribute(
       'href',
-      '/my-presets',
+      '/my-scenes',
     )
     expect(screen.getByRole('menuitem', { name: /sign out/i })).toBeInTheDocument()
 

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -35,7 +35,7 @@ function ChevronDownIcon() {
   )
 }
 
-function PresetsIcon() {
+function ScenesIcon() {
   return (
     <svg aria-hidden="true" fill="none" viewBox="0 0 24 24">
       <path
@@ -164,7 +164,7 @@ export function Layout({ children }: PropsWithChildren) {
           </Link>
           {isAuthenticated && user ? (
             <div className="nav-actions" ref={accountMenuRef}>
-              <Link className="nav-create" to="/create-preset">
+              <Link className="nav-create" to="/create-scene">
                 <span className="nav-create__icon" aria-hidden="true">
                   <CreateIcon />
                 </span>
@@ -235,12 +235,12 @@ export function Layout({ children }: PropsWithChildren) {
                     className="nav-menu__item"
                     onClick={() => setIsAccountMenuOpen(false)}
                     role="menuitem"
-                    to="/my-presets"
+                    to="/my-scenes"
                   >
                     <span className="nav-menu__icon">
-                      <PresetsIcon />
+                      <ScenesIcon />
                     </span>
-                    <span>My Presets</span>
+                    <span>My Scenes</span>
                   </Link>
 
                   <button

--- a/src/components/MagePlayer.test.tsx
+++ b/src/components/MagePlayer.test.tsx
@@ -16,7 +16,7 @@ function createController(overrides: Partial<MagePlayerController> = {}): MagePl
 }
 
 describe('MagePlayer', () => {
-  it('loads a preset scene blob and disposes the engine on unmount', async () => {
+  it('loads a scene blob and disposes the engine on unmount', async () => {
     const controller = createController()
     vi.mocked(createMagePlayer).mockResolvedValue(controller)
 
@@ -28,21 +28,21 @@ describe('MagePlayer', () => {
 
     const { unmount } = render(<MagePlayer sceneBlob={sceneBlob} />)
 
-    expect(screen.getByText('Loading preset preview.')).toBeInTheDocument()
+    expect(screen.getByText('Loading scene preview.')).toBeInTheDocument()
 
     await waitFor(() => {
       expect(createMagePlayer).toHaveBeenCalledTimes(1)
       expect(controller.loadSceneBlob).toHaveBeenCalledWith(sceneBlob)
     })
 
-    expect(screen.queryByText('Loading preset preview.')).not.toBeInTheDocument()
+    expect(screen.queryByText('Loading scene preview.')).not.toBeInTheDocument()
 
     unmount()
 
     expect(controller.dispose).toHaveBeenCalledTimes(1)
   })
 
-  it('reuses the same engine instance when the preset scene blob changes', async () => {
+  it('reuses the same engine instance when the scene blob changes', async () => {
     const controller = createController()
     vi.mocked(createMagePlayer).mockResolvedValue(controller)
 
@@ -73,7 +73,7 @@ describe('MagePlayer', () => {
     })
   })
 
-  it('shows a recoverable error state when the preset is invalid', async () => {
+  it('shows a recoverable error state when the scene is invalid', async () => {
     const controller = createController({
       loadSceneBlob: vi.fn((sceneBlob: unknown) => {
         if (
@@ -81,7 +81,7 @@ describe('MagePlayer', () => {
           sceneBlob !== null &&
           'invalid' in sceneBlob
         ) {
-          throw new Error('Preset scene data is missing required MAGE fields.')
+          throw new Error('Scene data is missing required MAGE fields.')
         }
       }),
     })
@@ -97,7 +97,7 @@ describe('MagePlayer', () => {
     )
 
     expect(await screen.findByRole('alert')).toHaveTextContent(
-      'Preset scene data is missing required MAGE fields.',
+      'Scene data is missing required MAGE fields.',
     )
     expect(controller.dispose).not.toHaveBeenCalled()
 

--- a/src/components/MagePlayer.tsx
+++ b/src/components/MagePlayer.tsx
@@ -19,11 +19,11 @@ function readErrorMessage(error: unknown) {
     return error.message
   }
 
-  return 'MAGE could not render this preset.'
+  return 'MAGE could not render this scene.'
 }
 
 export function MagePlayer({
-  ariaLabel = 'MAGE preset preview',
+  ariaLabel = 'MAGE scene preview',
   className,
   log = false,
   sceneBlob,
@@ -141,16 +141,16 @@ export function MagePlayer({
           ? 'ready'
           : 'loading'
 
-  let title = 'No preset selected.'
+  let title = 'No scene selected.'
   let message = 'Pass a scene blob into this player to render it in the browser.'
   let role: 'alert' | 'status' = 'status'
 
   if (status === 'loading') {
-    title = 'Loading preset preview.'
-    message = 'Initializing the MAGE engine and applying the preset scene blob.'
+    title = 'Loading scene preview.'
+    message = 'Initializing the MAGE engine and applying the scene blob.'
   } else if (status === 'error') {
-    title = 'Unable to render this preset.'
-    message = loadError?.message ?? 'MAGE could not render this preset.'
+    title = 'Unable to render this scene.'
+    message = loadError?.message ?? 'MAGE could not render this scene.'
     role = 'alert'
   }
 

--- a/src/components/SceneCard.tsx
+++ b/src/components/SceneCard.tsx
@@ -1,8 +1,8 @@
 import { Link } from 'react-router-dom'
-import type { PresetListResponse } from '../lib/api'
+import type { SceneListResponse } from '../lib/api'
 
-type PresetCardProps = {
-  preset: PresetListResponse
+type SceneCardProps = {
+  scene: SceneListResponse
 }
 
 function formatRelativeTime(isoDate: string): string {
@@ -26,8 +26,8 @@ function formatRelativeTime(isoDate: string): string {
   return 'Just now'
 }
 
-function formatViewLabel(presetId: number) {
-  const syntheticViews = 1200 + presetId * 183
+function formatViewLabel(sceneId: number) {
+  const syntheticViews = 1200 + sceneId * 183
 
   if (syntheticViews >= 1000000) {
     return `${(syntheticViews / 1000000).toFixed(1)}M renders`
@@ -42,43 +42,47 @@ function formatViewLabel(presetId: number) {
 
 function buildCreatorInitials(name: string) {
   const words = name.split(/\s+/).filter(Boolean)
-  const initials = words.slice(0, 2).map((word) => word[0]?.toUpperCase()).join('')
+  const initials = words
+    .slice(0, 2)
+    .map((word) => word[0]?.toUpperCase())
+    .join('')
+
   return initials || 'MG'
 }
 
-export function PresetCard({ preset }: PresetCardProps) {
-  const creatorName = preset.creatorDisplayName
+export function SceneCard({ scene }: SceneCardProps) {
+  const creatorName = scene.creatorDisplayName
   const creatorInitials = buildCreatorInitials(creatorName)
-  const relativeTime = formatRelativeTime(preset.createdAt)
-  const viewLabel = formatViewLabel(preset.presetId)
+  const relativeTime = formatRelativeTime(scene.createdAt)
+  const viewLabel = formatViewLabel(scene.sceneId)
 
   return (
-    <Link className="preset-card-link" to={`/presets/${preset.presetId}`}>
-      <article className="preset-card" id={`preset-${preset.presetId}`}>
-        <div className="preset-card__thumbnail">
-          {preset.thumbnailRef ? (
+    <Link className="scene-card-link" to={`/scenes/${scene.sceneId}`}>
+      <article className="scene-card" id={`scene-${scene.sceneId}`}>
+        <div className="scene-card__thumbnail">
+          {scene.thumbnailRef ? (
             <img
-              src={preset.thumbnailRef}
-              alt={`Thumbnail for ${preset.name}`}
-              className="preset-card__thumbnail-img"
+              src={scene.thumbnailRef}
+              alt={`Thumbnail for ${scene.name}`}
+              className="scene-card__thumbnail-img"
             />
           ) : (
-            <div className="preset-card__thumbnail-placeholder" aria-hidden="true" />
+            <div className="scene-card__thumbnail-placeholder" aria-hidden="true" />
           )}
         </div>
-        <div className="preset-card__body">
-          <div className="preset-card__avatar" aria-hidden="true">
+        <div className="scene-card__body">
+          <div className="scene-card__avatar" aria-hidden="true">
             {creatorInitials}
           </div>
-          <div className="preset-card__meta">
-            <h3 className="preset-card__name">{preset.name}</h3>
-            <p className="preset-card__creator">{creatorName}</p>
-            <div className="preset-card__stats">
+          <div className="scene-card__meta">
+            <h3 className="scene-card__name">{scene.name}</h3>
+            <p className="scene-card__creator">{creatorName}</p>
+            <div className="scene-card__stats">
               <span>{viewLabel}</span>
-              <span className="preset-card__stats-separator" aria-hidden="true">
-                •
+              <span className="scene-card__stats-separator" aria-hidden="true">
+                &bull;
               </span>
-              <time className="preset-card__time" dateTime={preset.createdAt}>
+              <time className="scene-card__time" dateTime={scene.createdAt}>
                 {relativeTime}
               </time>
             </div>

--- a/src/components/SceneEditorControls.tsx
+++ b/src/components/SceneEditorControls.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent, PropsWithChildren, ReactNode } from 'react'
-import type { Vector3Value } from '../lib/presetEditor'
+import type { Vector3Value } from '../lib/sceneEditor'
 
 type SectionProps = PropsWithChildren<{
   className?: string
@@ -75,13 +75,13 @@ function FieldShell({
   label: string
 }>) {
   return (
-    <div className="preset-field">
-      <div className="preset-field__label-row">
-        <label className="preset-field__label" htmlFor={htmlFor}>
+    <div className="scene-field">
+      <div className="scene-field__label-row">
+        <label className="scene-field__label" htmlFor={htmlFor}>
           {label}
         </label>
       </div>
-      {description ? <p className="preset-field__description">{description}</p> : null}
+      {description ? <p className="scene-field__description">{description}</p> : null}
       {children}
     </div>
   )
@@ -107,14 +107,14 @@ function formatSliderValue(value: number, formatValue?: (value: number) => strin
   return Number.isInteger(value) ? String(value) : value.toFixed(2).replace(/0+$/, '').replace(/\.$/, '')
 }
 
-export function PresetSection({ children, className, description, title }: SectionProps) {
+export function SceneSection({ children, className, description, title }: SectionProps) {
   return (
-    <section className={buildClassName('surface surface--soft preset-editor-section', className)}>
-      <div className="preset-editor-section__header">
+    <section className={buildClassName('surface surface--soft scene-editor-section', className)}>
+      <div className="scene-editor-section__header">
         <h2>{title}</h2>
         <p>{description}</p>
       </div>
-      <div className="preset-editor-section__content">{children}</div>
+      <div className="scene-editor-section__content">{children}</div>
     </section>
   )
 }
@@ -130,7 +130,7 @@ export function SelectField({
   return (
     <FieldShell description={description} htmlFor={id} label={label}>
       <select
-        className="preset-select"
+        className="scene-select"
         id={id}
         value={value}
         onChange={(event) => onChange(event.currentTarget.value)}
@@ -159,7 +159,7 @@ export function NumberField({
   return (
     <FieldShell description={description} htmlFor={id} label={label}>
       <input
-        className="preset-number-input"
+        className="scene-number-input"
         id={id}
         max={max}
         min={min}
@@ -186,13 +186,13 @@ export function SliderField({
 }: SliderFieldProps) {
   return (
     <FieldShell description={description} htmlFor={id} label={label}>
-      <div className="preset-slider">
-        <div className="preset-slider__header">
+      <div className="scene-slider">
+        <div className="scene-slider__header">
           <strong>{formatSliderValue(value, formatValue)}</strong>
         </div>
-        <div className="preset-slider__controls">
+        <div className="scene-slider__controls">
           <input
-            className="preset-slider__range"
+            className="scene-slider__range"
             id={id}
             max={max}
             min={min}
@@ -202,7 +202,7 @@ export function SliderField({
             value={value}
           />
           <input
-            className="preset-slider__number"
+            className="scene-slider__number"
             max={max}
             min={min}
             onChange={(event) => forwardNumericValue(event, onChange)}
@@ -224,20 +224,20 @@ export function ToggleField({
   onChange,
 }: ToggleFieldProps) {
   return (
-    <label className="preset-toggle" htmlFor={id}>
-      <div className="preset-toggle__copy">
+    <label className="scene-toggle" htmlFor={id}>
+      <div className="scene-toggle__copy">
         <span>{label}</span>
         {description ? <small>{description}</small> : null}
       </div>
-      <span className="preset-toggle__control">
+      <span className="scene-toggle__control">
         <input
           checked={checked}
-          className="preset-toggle__input"
+          className="scene-toggle__input"
           id={id}
           onChange={(event) => onChange(event.currentTarget.checked)}
           type="checkbox"
         />
-        <span className="preset-toggle__track" aria-hidden="true" />
+        <span className="scene-toggle__track" aria-hidden="true" />
       </span>
     </label>
   )
@@ -260,12 +260,12 @@ export function Vector3Field({
 
   return (
     <FieldShell description={description} htmlFor={id} label={label}>
-      <div className="preset-vector-field" id={id}>
+      <div className="scene-vector-field" id={id}>
         {(['x', 'y', 'z'] as Array<keyof Vector3Value>).map((axis) => (
-          <label className="preset-vector-field__axis" key={axis}>
+          <label className="scene-vector-field__axis" key={axis}>
             <span>{axis.toUpperCase()}</span>
             <input
-              className="preset-number-input"
+              className="scene-number-input"
               onChange={(event) => forwardNumericValue(event, (nextValue) => handleAxisChange(axis, nextValue))}
               step={step}
               type="number"

--- a/src/components/TagFilterBar.tsx
+++ b/src/components/TagFilterBar.tsx
@@ -22,7 +22,7 @@ export function TagFilterBar({ tags, activeTag, onTagSelect, isLoading }: TagFil
   }
 
   return (
-    <ScrollableTagBar ariaLabel="Filter presets by tag" role="toolbar">
+    <ScrollableTagBar ariaLabel="Filter scenes by tag" role="toolbar">
       <button
         className={`tag-pill${activeTag === null ? ' tag-pill--active' : ''}`}
         aria-pressed={activeTag === null}

--- a/src/components/my-scenes/MyScenesPagination.tsx
+++ b/src/components/my-scenes/MyScenesPagination.tsx
@@ -1,7 +1,7 @@
 import type { RefObject } from 'react'
-import { MY_PRESETS_ROWS_PER_PAGE_OPTIONS } from '../../lib/myPresets'
+import { MY_SCENES_ROWS_PER_PAGE_OPTIONS } from '../../lib/myScenes'
 
-type MyPresetsPaginationProps = {
+type MyScenesPaginationProps = {
   currentPageIndex: number
   isRowsPerPageMenuOpen: boolean
   pageCount: number
@@ -9,7 +9,7 @@ type MyPresetsPaginationProps = {
   pageStart: number
   rowsPerPage: number
   rowsPerPageMenuRef: RefObject<HTMLDivElement | null>
-  totalPresets: number
+  totalScenes: number
   onGoToFirstPage: () => void
   onGoToLastPage: () => void
   onGoToNextPage: () => void
@@ -18,7 +18,7 @@ type MyPresetsPaginationProps = {
   onToggleRowsPerPageMenu: () => void
 }
 
-export function MyPresetsPagination({
+export function MyScenesPagination({
   currentPageIndex,
   isRowsPerPageMenuOpen,
   pageCount,
@@ -26,28 +26,28 @@ export function MyPresetsPagination({
   pageStart,
   rowsPerPage,
   rowsPerPageMenuRef,
-  totalPresets,
+  totalScenes,
   onGoToFirstPage,
   onGoToLastPage,
   onGoToNextPage,
   onGoToPreviousPage,
   onSelectRowsPerPage,
   onToggleRowsPerPageMenu,
-}: MyPresetsPaginationProps) {
+}: MyScenesPaginationProps) {
   return (
-    <div className="my-presets-pagination" aria-label="Preset pagination">
-      <div className="my-presets-pagination__rows" ref={rowsPerPageMenuRef}>
+    <div className="my-scenes-pagination" aria-label="Scene pagination">
+      <div className="my-scenes-pagination__rows" ref={rowsPerPageMenuRef}>
         <span>Rows per page:</span>
-        <div className="my-presets-pagination__menu-shell">
+        <div className="my-scenes-pagination__menu-shell">
           <button
             aria-expanded={isRowsPerPageMenuOpen}
             aria-haspopup="listbox"
-            className="my-presets-pagination__menu-button"
+            className="my-scenes-pagination__menu-button"
             onClick={onToggleRowsPerPageMenu}
             type="button"
           >
             <span>{rowsPerPage}</span>
-            <span className="my-presets-pagination__menu-caret" aria-hidden="true">
+            <span className="my-scenes-pagination__menu-caret" aria-hidden="true">
               <svg viewBox="0 0 16 16" fill="none">
                 <path
                   d="M4 6.5 8 10.5l4-4"
@@ -61,12 +61,12 @@ export function MyPresetsPagination({
           </button>
 
           {isRowsPerPageMenuOpen ? (
-            <div className="my-presets-pagination__menu" role="listbox" aria-label="Rows per page">
-              {MY_PRESETS_ROWS_PER_PAGE_OPTIONS.map((option) => (
+            <div className="my-scenes-pagination__menu" role="listbox" aria-label="Rows per page">
+              {MY_SCENES_ROWS_PER_PAGE_OPTIONS.map((option) => (
                 <button
                   key={option}
                   aria-selected={rowsPerPage === option}
-                  className="my-presets-pagination__menu-option"
+                  className="my-scenes-pagination__menu-option"
                   data-active={rowsPerPage === option}
                   onClick={() => {
                     onSelectRowsPerPage(option)
@@ -82,14 +82,14 @@ export function MyPresetsPagination({
         </div>
       </div>
 
-      <span className="my-presets-pagination__range">
-        {totalPresets === 0 ? '0-0 of 0' : `${pageStart + 1}-${pageEnd} of ${totalPresets}`}
+      <span className="my-scenes-pagination__range">
+        {totalScenes === 0 ? '0-0 of 0' : `${pageStart + 1}-${pageEnd} of ${totalScenes}`}
       </span>
 
-      <div className="my-presets-pagination__controls">
+      <div className="my-scenes-pagination__controls">
         <button
           aria-label="Go to first page"
-          className="my-presets-pagination__button"
+          className="my-scenes-pagination__button"
           disabled={currentPageIndex === 0}
           onClick={onGoToFirstPage}
           type="button"
@@ -98,7 +98,7 @@ export function MyPresetsPagination({
         </button>
         <button
           aria-label="Go to previous page"
-          className="my-presets-pagination__button"
+          className="my-scenes-pagination__button"
           disabled={currentPageIndex === 0}
           onClick={onGoToPreviousPage}
           type="button"
@@ -107,7 +107,7 @@ export function MyPresetsPagination({
         </button>
         <button
           aria-label="Go to next page"
-          className="my-presets-pagination__button"
+          className="my-scenes-pagination__button"
           disabled={currentPageIndex >= pageCount - 1}
           onClick={onGoToNextPage}
           type="button"
@@ -116,7 +116,7 @@ export function MyPresetsPagination({
         </button>
         <button
           aria-label="Go to last page"
-          className="my-presets-pagination__button"
+          className="my-scenes-pagination__button"
           disabled={currentPageIndex >= pageCount - 1}
           onClick={onGoToLastPage}
           type="button"

--- a/src/components/my-scenes/MyScenesTable.tsx
+++ b/src/components/my-scenes/MyScenesTable.tsx
@@ -3,21 +3,21 @@ import { Link } from 'react-router-dom'
 import {
   buildSortAriaLabel,
   formatCompactCount,
-  formatPresetDate,
+  formatSceneDate,
   type SortDirection,
   type SortKey,
-  type UserPreset,
-} from '../../lib/myPresets'
+  type UserScene,
+} from '../../lib/myScenes'
 
-type MyPresetsTableProps = {
-  allPagePresetsSelected: boolean
-  pagedPresets: UserPreset[]
+type MyScenesTableProps = {
+  allPageScenesSelected: boolean
+  pagedScenes: UserScene[]
   selectAllCheckboxRef: RefObject<HTMLInputElement | null>
-  selectedPresetIdSet: Set<number>
+  selectedSceneIdSet: Set<number>
   sortDirection: SortDirection
   sortKey: SortKey
   onSort: (sortKey: SortKey) => void
-  onTogglePresetSelection: (presetId: number) => void
+  onToggleSceneSelection: (sceneId: number) => void
   onToggleSelectAll: () => void
 }
 
@@ -29,7 +29,7 @@ function SortIndicator({
   direction: SortDirection
 }) {
   return (
-    <span className="my-presets-table__sort-indicator" aria-hidden="true">
+    <span className="my-scenes-table__sort-indicator" aria-hidden="true">
       <svg viewBox="0 0 16 16" fill="none">
         <path
           d="M8 3.5 5.25 6.25h5.5L8 3.5Z"
@@ -61,7 +61,7 @@ function SortButton({
 }) {
   return (
     <button
-      className="my-presets-table__sort-button"
+      className="my-scenes-table__sort-button"
       aria-label={buildSortAriaLabel(label, sortKey, activeSortKey, sortDirection)}
       data-active={activeSortKey === sortKey}
       onClick={() => {
@@ -75,33 +75,33 @@ function SortButton({
   )
 }
 
-export function MyPresetsTable({
-  allPagePresetsSelected,
-  pagedPresets,
+export function MyScenesTable({
+  allPageScenesSelected,
+  pagedScenes,
   selectAllCheckboxRef,
-  selectedPresetIdSet,
+  selectedSceneIdSet,
   sortDirection,
   sortKey,
   onSort,
-  onTogglePresetSelection,
+  onToggleSceneSelection,
   onToggleSelectAll,
-}: MyPresetsTableProps) {
+}: MyScenesTableProps) {
   return (
-    <div className="my-presets-scroll">
-      <div className="my-presets-table" aria-label="My presets" role="list">
-        <div className="my-presets-table__head">
-          <div className="my-presets-table__primary-heading">
+    <div className="my-scenes-scroll">
+      <div className="my-scenes-table" aria-label="My scenes" role="list">
+        <div className="my-scenes-table__head">
+          <div className="my-scenes-table__primary-heading">
             <input
               ref={selectAllCheckboxRef}
-              checked={allPagePresetsSelected}
-              className="my-presets-table__checkbox"
+              checked={allPageScenesSelected}
+              className="my-scenes-table__checkbox"
               onChange={onToggleSelectAll}
               type="checkbox"
-              aria-label="Select all presets on this page"
+              aria-label="Select all scenes on this page"
             />
-            <span>Preset</span>
+            <span>Scene</span>
           </div>
-          <span className="my-presets-table__status-heading">Status</span>
+          <span className="my-scenes-table__status-heading">Status</span>
           <SortButton
             activeSortKey={sortKey}
             label="Updated"
@@ -126,70 +126,70 @@ export function MyPresetsTable({
           />
         </div>
 
-        {pagedPresets.map((preset) => (
-          <article key={preset.id} className="my-presets-row" role="listitem">
-            <div className="my-presets-row__primary">
-              <label className="my-presets-row__selection">
+        {pagedScenes.map((scene) => (
+          <article key={scene.id} className="my-scenes-row" role="listitem">
+            <div className="my-scenes-row__primary">
+              <label className="my-scenes-row__selection">
                 <input
-                  checked={selectedPresetIdSet.has(preset.id)}
-                  className="my-presets-table__checkbox"
+                  checked={selectedSceneIdSet.has(scene.id)}
+                  className="my-scenes-table__checkbox"
                   onChange={() => {
-                    onTogglePresetSelection(preset.id)
+                    onToggleSceneSelection(scene.id)
                   }}
                   type="checkbox"
-                  aria-label={`Select ${preset.name}`}
+                  aria-label={`Select ${scene.name}`}
                 />
               </label>
               <Link
-                aria-label="Open preset preview"
-                className="my-presets-row__thumb-link"
-                to={`/presets/${preset.id}`}
+                aria-label="Open scene preview"
+                className="my-scenes-row__thumb-link"
+                to={`/scenes/${scene.id}`}
               >
-                {preset.thumbnailRef ? (
+                {scene.thumbnailRef ? (
                   <img
-                    className="my-presets-row__thumb"
-                    src={preset.thumbnailRef}
-                    alt={`${preset.name} thumbnail`}
+                    className="my-scenes-row__thumb"
+                    src={scene.thumbnailRef}
+                    alt={`${scene.name} thumbnail`}
                   />
                 ) : (
                   <div
-                    className="my-presets-row__thumb-fallback"
-                    aria-label={`${preset.name} thumbnail unavailable`}
+                    className="my-scenes-row__thumb-fallback"
+                    aria-label={`${scene.name} thumbnail unavailable`}
                   >
                     No thumbnail available
                   </div>
                 )}
               </Link>
-              <div className="my-presets-row__copy">
-                <Link className="my-presets-row__title-link" to={`/presets/${preset.id}`}>
-                  <strong>{preset.name}</strong>
+              <div className="my-scenes-row__copy">
+                <Link className="my-scenes-row__title-link" to={`/scenes/${scene.id}`}>
+                  <strong>{scene.name}</strong>
                 </Link>
-                <button className="my-presets-row__description" type="button">
-                  {preset.description ?? 'Add description'}
+                <button className="my-scenes-row__description" type="button">
+                  {scene.description ?? 'Add description'}
                 </button>
               </div>
             </div>
 
-            <div className="my-presets-row__cell my-presets-row__cell--status">
-              <span className="my-presets-row__pill" data-status={preset.statusLabel}>
-                {preset.statusLabel}
+            <div className="my-scenes-row__cell my-scenes-row__cell--status">
+              <span className="my-scenes-row__pill" data-status={scene.statusLabel}>
+                {scene.statusLabel}
               </span>
             </div>
 
-            <div className="my-presets-row__cell">
-              <strong>{formatPresetDate(preset.createdAt)}</strong>
+            <div className="my-scenes-row__cell">
+              <strong>{formatSceneDate(scene.createdAt)}</strong>
             </div>
 
-            <div className="my-presets-row__metric">
-              <strong>{formatCompactCount(preset.viewsCount)}</strong>
+            <div className="my-scenes-row__metric">
+              <strong>{formatCompactCount(scene.viewsCount)}</strong>
             </div>
 
-            <div className="my-presets-row__metric">
-              <strong>{formatCompactCount(preset.commentsCount)}</strong>
+            <div className="my-scenes-row__metric">
+              <strong>{formatCompactCount(scene.commentsCount)}</strong>
             </div>
 
-            <div className="my-presets-row__metric">
-              <strong>{preset.likesRatio}%</strong>
+            <div className="my-scenes-row__metric">
+              <strong>{scene.likesRatio}%</strong>
             </div>
           </article>
         ))}

--- a/src/components/my-scenes/MyScenesToolbar.tsx
+++ b/src/components/my-scenes/MyScenesToolbar.tsx
@@ -1,31 +1,31 @@
-import type { PresetVisibility, StatusFilter } from '../../lib/myPresets'
+import type { SceneVisibility, StatusFilter } from '../../lib/myScenes'
 
-type MyPresetsToolbarProps = {
-  availableStatuses: PresetVisibility[]
+type MyScenesToolbarProps = {
+  availableStatuses: SceneVisibility[]
   sortSummary: string
-  totalPresets: number
+  totalScenes: number
   statusFilter: StatusFilter
   onSelectStatus: (status: StatusFilter) => void
 }
 
-export function MyPresetsToolbar({
+export function MyScenesToolbar({
   availableStatuses,
   sortSummary,
-  totalPresets,
+  totalScenes,
   statusFilter,
   onSelectStatus,
-}: MyPresetsToolbarProps) {
+}: MyScenesToolbarProps) {
   return (
-    <div className="my-presets-board__toolbar">
-      <div className="my-presets-board__summary">
+    <div className="my-scenes-board__toolbar">
+      <div className="my-scenes-board__summary">
         <strong>
-          {totalPresets} preset{totalPresets === 1 ? '' : 's'}
+          {totalScenes} scene{totalScenes === 1 ? '' : 's'}
         </strong>
         <span>{sortSummary}</span>
       </div>
-      <div className="my-presets-board__filters">
+      <div className="my-scenes-board__filters">
         <button
-          className="my-presets-board__chip"
+          className="my-scenes-board__chip"
           data-active={statusFilter === 'All'}
           onClick={() => {
             onSelectStatus('All')
@@ -37,7 +37,7 @@ export function MyPresetsToolbar({
         {availableStatuses.map((status) => (
           <button
             key={status}
-            className="my-presets-board__chip"
+            className="my-scenes-board__chip"
             data-active={statusFilter === status}
             onClick={() => {
               onSelectStatus(status)

--- a/src/components/scene-detail/SceneCommentsPanel.tsx
+++ b/src/components/scene-detail/SceneCommentsPanel.tsx
@@ -1,35 +1,35 @@
-import type { PresetComment } from '../../lib/presetDetail'
-import { readInitial } from '../../lib/presetDetail'
+import type { SceneComment } from '../../lib/sceneDetail'
+import { readInitial } from '../../lib/sceneDetail'
 import { VoteButton } from './VoteButton'
 
-type PresetCommentsPanelProps = {
+type SceneCommentsPanelProps = {
   composerInitial: string
   composerPrompt: string
-  comments: PresetComment[]
+  comments: SceneComment[]
 }
 
-export function PresetCommentsPanel({
+export function SceneCommentsPanel({
   composerInitial,
   composerPrompt,
   comments,
-}: PresetCommentsPanelProps) {
+}: SceneCommentsPanelProps) {
   return (
-    <section className="preset-detail-comments-panel">
-      <div className="preset-detail-comments-toolbar">
+    <section className="scene-detail-comments-panel">
+      <div className="scene-detail-comments-toolbar">
         <div className="mage-comments__header">
           <h2>Comments</h2>
           <span>{comments.length}</span>
         </div>
-        <button className="preset-detail-sort-chip" type="button">
+        <button className="scene-detail-sort-chip" type="button">
           Top comments
         </button>
       </div>
 
-      <div className="preset-detail-comment-composer">
-        <div className="preset-detail-comment-composer__avatar" aria-hidden="true">
+      <div className="scene-detail-comment-composer">
+        <div className="scene-detail-comment-composer__avatar" aria-hidden="true">
           {composerInitial}
         </div>
-        <div className="preset-detail-comment-composer__field">
+        <div className="scene-detail-comment-composer__field">
           <span>{composerPrompt}</span>
         </div>
       </div>
@@ -41,24 +41,24 @@ export function PresetCommentsPanel({
               {readInitial(comment.author)}
             </div>
             <div className="mage-comment__body">
-              <div className="preset-detail-comment__header">
+              <div className="scene-detail-comment__header">
                 <strong>{comment.author}</strong>
                 <span>{comment.handle}</span>
                 <span>{comment.posted}</span>
               </div>
               <p>{comment.text}</p>
-              <div className="preset-detail-comment__actions">
+              <div className="scene-detail-comment__actions">
                 <VoteButton
-                  className="preset-detail-comment__action"
+                  className="scene-detail-comment__action"
                   count={comment.upvotes}
                   direction="up"
                 />
                 <VoteButton
-                  className="preset-detail-comment__action"
+                  className="scene-detail-comment__action"
                   count={comment.downvotes}
                   direction="down"
                 />
-                <button className="preset-detail-comment__action" type="button">
+                <button className="scene-detail-comment__action" type="button">
                   Reply
                 </button>
               </div>

--- a/src/components/scene-detail/SceneDescriptionCard.tsx
+++ b/src/components/scene-detail/SceneDescriptionCard.tsx
@@ -1,31 +1,31 @@
 import { Link } from 'react-router-dom'
-import type { CreatorProfile, PresetDescription, PresetEngagement } from '../../lib/presetDetail'
+import type { CreatorProfile, SceneDescription, SceneEngagement } from '../../lib/sceneDetail'
 
-type PresetDescriptionCardProps = {
+type SceneDescriptionCardProps = {
   creatorProfile: CreatorProfile
-  engagement: PresetEngagement
+  engagement: SceneEngagement
   isDescriptionExpanded: boolean
-  presetDescription: PresetDescription
+  sceneDescription: SceneDescription
   onToggleDescription: () => void
 }
 
-export function PresetDescriptionCard({
+export function SceneDescriptionCard({
   creatorProfile,
   engagement,
   isDescriptionExpanded,
-  presetDescription,
+  sceneDescription,
   onToggleDescription,
-}: PresetDescriptionCardProps) {
+}: SceneDescriptionCardProps) {
   const descriptionToggle = (
     <button
-      className="preset-detail-description-toggle"
+      className="scene-detail-description-toggle"
       type="button"
       aria-expanded={isDescriptionExpanded}
       onClick={onToggleDescription}
     >
       <span>{isDescriptionExpanded ? 'Hide' : 'Show'}</span>
       <span
-        className={`preset-detail-description-toggle__chevron${
+        className={`scene-detail-description-toggle__chevron${
           isDescriptionExpanded ? ' is-expanded' : ''
         }`}
         aria-hidden="true"
@@ -44,42 +44,42 @@ export function PresetDescriptionCard({
   )
 
   return (
-    <section className="preset-detail-description-card">
-      <div className="preset-detail-description-card__meta">
+    <section className="scene-detail-description-card">
+      <div className="scene-detail-description-card__meta">
         <strong>{engagement.playsLabel}</strong>
         <span>{engagement.publishedLabel}</span>
       </div>
-      <div className="preset-detail-description-copy" data-expanded={isDescriptionExpanded}>
-        <p>{presetDescription.opening}</p>
-        <p>{presetDescription.middle}</p>
-        <p>{presetDescription.closing}</p>
+      <div className="scene-detail-description-copy" data-expanded={isDescriptionExpanded}>
+        <p>{sceneDescription.opening}</p>
+        <p>{sceneDescription.middle}</p>
+        <p>{sceneDescription.closing}</p>
       </div>
 
       {isDescriptionExpanded ? (
         <>
-          <div className="preset-detail-note-grid">
-            <div className="preset-detail-note-grid__item">
+          <div className="scene-detail-note-grid">
+            <div className="scene-detail-note-grid__item">
               <span>Studio note</span>
               <strong>{creatorProfile.studioNote}</strong>
             </div>
-            <div className="preset-detail-note-grid__item">
+            <div className="scene-detail-note-grid__item">
               <span>Best for</span>
-              <strong>{presetDescription.bestFor}</strong>
+              <strong>{sceneDescription.bestFor}</strong>
             </div>
-            <div className="preset-detail-note-grid__item">
+            <div className="scene-detail-note-grid__item">
               <span>Built with</span>
-              <strong>{presetDescription.builtWith}</strong>
+              <strong>{sceneDescription.builtWith}</strong>
             </div>
-            <div className="preset-detail-note-grid__item">
+            <div className="scene-detail-note-grid__item">
               <span>Saves</span>
               <strong>{engagement.savesLabel}</strong>
             </div>
           </div>
 
-          {presetDescription.tags.length > 0 ? (
-            <div className="tag-filter-bar preset-detail-description-tags" role="toolbar" aria-label="Preset tags">
-              {presetDescription.tags.map((tag) => (
-                <Link key={tag} className="tag-pill" to={`/presets?tag=${encodeURIComponent(tag)}`}>
+          {sceneDescription.tags.length > 0 ? (
+            <div className="tag-filter-bar scene-detail-description-tags" role="toolbar" aria-label="Scene tags">
+              {sceneDescription.tags.map((tag) => (
+                <Link key={tag} className="tag-pill" to={`/scenes?tag=${encodeURIComponent(tag)}`}>
                   {tag}
                 </Link>
               ))}

--- a/src/components/scene-detail/SceneDetailState.tsx
+++ b/src/components/scene-detail/SceneDetailState.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 
-export function PresetDetailState({
+export function SceneDetailState({
   title,
   description,
   actions,
@@ -11,7 +11,7 @@ export function PresetDetailState({
 }) {
   return (
     <main className="surface surface--hero">
-      <div className="eyebrow">Preset Detail</div>
+      <div className="eyebrow">Scene Detail</div>
       <h1>{title}</h1>
       <p className="page-lead">{description}</p>
       {actions ? (
@@ -20,7 +20,7 @@ export function PresetDetailState({
           {actions}
         </>
       ) : null}
-      <p className="page-footnote">Preset detail routes now resolve through the live player flow.</p>
+      <p className="page-footnote">Scene detail routes now resolve through the live player flow.</p>
       <div className="page-mark">MAGE</div>
     </main>
   )

--- a/src/components/scene-detail/SceneRecommendationRail.tsx
+++ b/src/components/scene-detail/SceneRecommendationRail.tsx
@@ -3,49 +3,49 @@ import { Link } from 'react-router-dom'
 import {
   buildTagRecommendationFilter,
   readRecommendationFilterTag,
-  type RecommendedPresetCard,
+  type RecommendedSceneCard,
   type RecommendationFilter,
-} from '../../lib/presetDetail'
+} from '../../lib/sceneDetail'
 import { ScrollableTagBar } from '../ScrollableTagBar'
 
-type PresetRecommendationRailProps = {
+type SceneRecommendationRailProps = {
   creatorDisplayName: string
-  currentPresetTags: string[]
+  currentSceneTags: string[]
   isLoading: boolean
-  recommendedPresets: RecommendedPresetCard[]
+  recommendedScenes: RecommendedSceneCard[]
   recommendationFilter: RecommendationFilter
   onSelectFilter: (filter: RecommendationFilter) => void
 }
 
-export function PresetRecommendationRail({
+export function SceneRecommendationRail({
   creatorDisplayName,
-  currentPresetTags,
+  currentSceneTags,
   isLoading,
-  recommendedPresets,
+  recommendedScenes,
   recommendationFilter,
   onSelectFilter,
-}: PresetRecommendationRailProps) {
+}: SceneRecommendationRailProps) {
   const activeRecommendationTag = readRecommendationFilterTag(recommendationFilter)
 
   const loadingCopy =
     activeRecommendationTag !== null
-      ? `Loading presets tagged "${activeRecommendationTag}"...`
+      ? `Loading scenes tagged "${activeRecommendationTag}"...`
       : recommendationFilter === 'creator'
-        ? `Loading presets from ${creatorDisplayName}...`
-        : 'Loading related presets...'
+        ? `Loading scenes from ${creatorDisplayName}...`
+        : 'Loading related scenes...'
 
   const emptyCopy =
     activeRecommendationTag !== null
-      ? `No other presets tagged "${activeRecommendationTag}" yet.`
+      ? `No other scenes tagged "${activeRecommendationTag}" yet.`
       : recommendationFilter === 'creator'
-        ? `No other presets from ${creatorDisplayName} yet.`
-        : `No related presets from ${creatorDisplayName} or this preset's tags yet.`
+        ? `No other scenes from ${creatorDisplayName} yet.`
+        : `No related scenes from ${creatorDisplayName} or this scene's tags yet.`
 
   return (
     <aside className="mage-watch__rail">
       <ScrollableTagBar
-        ariaLabel="Filter recommended presets"
-        barClassName="preset-detail-recommendation-filters"
+        ariaLabel="Filter recommended scenes"
+        barClassName="scene-detail-recommendation-filters"
         role="toolbar"
       >
         <button
@@ -68,7 +68,7 @@ export function PresetRecommendationRail({
         >
           From {creatorDisplayName}
         </button>
-        {currentPresetTags.map((tag) => {
+        {currentSceneTags.map((tag) => {
           const tagFilter = buildTagRecommendationFilter(tag)
 
           return (
@@ -89,33 +89,33 @@ export function PresetRecommendationRail({
 
       {isLoading ? (
         <p className="mage-watch__rail-empty">{loadingCopy}</p>
-      ) : recommendedPresets.length === 0 ? (
+      ) : recommendedScenes.length === 0 ? (
         <p className="mage-watch__rail-empty">{emptyCopy}</p>
       ) : (
         <div className="mage-watch__rail-list">
-          {recommendedPresets.map((recommendedPreset) => (
+          {recommendedScenes.map((recommendedScene) => (
             <Link
-              key={recommendedPreset.id}
-              className="mage-preset-card"
-              to={`/presets/${recommendedPreset.id}`}
+              key={recommendedScene.id}
+              className="mage-scene-card"
+              to={`/scenes/${recommendedScene.id}`}
             >
-              {recommendedPreset.thumbnailRef ? (
+              {recommendedScene.thumbnailRef ? (
                 <img
-                  className="mage-preset-card__thumb mage-preset-card__thumb-image"
-                  src={recommendedPreset.thumbnailRef}
-                  alt={`${recommendedPreset.title} thumbnail`}
+                  className="mage-scene-card__thumb mage-scene-card__thumb-image"
+                  src={recommendedScene.thumbnailRef}
+                  alt={`${recommendedScene.title} thumbnail`}
                 />
               ) : (
                 <div
-                  className="mage-preset-card__thumb"
-                  style={{ '--preset-accent': recommendedPreset.accent } as CSSProperties}
+                  className="mage-scene-card__thumb"
+                  style={{ '--scene-accent': recommendedScene.accent } as CSSProperties}
                   aria-hidden="true"
                 />
               )}
-              <div className="mage-preset-card__body">
-                <strong>{recommendedPreset.title}</strong>
-                <span>{recommendedPreset.creator}</span>
-                <span>{recommendedPreset.meta}</span>
+              <div className="mage-scene-card__body">
+                <strong>{recommendedScene.title}</strong>
+                <span>{recommendedScene.creator}</span>
+                <span>{recommendedScene.meta}</span>
               </div>
             </Link>
           ))}

--- a/src/components/scene-detail/VoteButton.tsx
+++ b/src/components/scene-detail/VoteButton.tsx
@@ -34,7 +34,7 @@ export function VoteButton({
 
   return (
     <button aria-label={`${label} ${count}`} className={className} type="button">
-      <span className="preset-detail-vote-button__icon" aria-hidden="true">
+      <span className="scene-detail-vote-button__icon" aria-hidden="true">
         <Icon />
       </span>
       <span>{count}</span>

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -12,7 +12,7 @@ describe('buildApiUrl', () => {
   })
 
   it('does not duplicate an existing /api prefix', () => {
-    expect(buildApiUrl('/api/presets/12')).toBe('/api/presets/12')
+    expect(buildApiUrl('/api/scenes/12')).toBe('/api/scenes/12')
   })
 
   it('supports same-origin production routing when the base url is set to /api', () => {
@@ -24,12 +24,12 @@ describe('buildApiUrl', () => {
   it('joins the configured base url with the normalized api path', () => {
     vi.stubEnv('VITE_API_BASE_URL', 'https://mage.example.com/')
 
-    expect(buildApiUrl('/presets/12')).toBe('https://mage.example.com/api/presets/12')
+    expect(buildApiUrl('/scenes/12')).toBe('https://mage.example.com/api/scenes/12')
   })
 
   it('does not double-prefix /api when the configured base url already includes it', () => {
     vi.stubEnv('VITE_API_BASE_URL', 'https://mage.example.com/api')
 
-    expect(buildApiUrl('/presets/12')).toBe('https://mage.example.com/api/presets/12')
+    expect(buildApiUrl('/scenes/12')).toBe('https://mage.example.com/api/scenes/12')
   })
 })

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -26,8 +26,8 @@ export function buildApiUrl(path: string) {
   return `${normalizedBaseUrl}${apiPath}`
 }
 
-export type PresetListResponse = {
-  presetId: number
+export type SceneListResponse = {
+  sceneId: number
   ownerUserId: number
   creatorDisplayName: string
   name: string
@@ -56,15 +56,15 @@ export async function fetchAvailableTags(options?: FetchTagsOptions): Promise<Ta
   return response.json() as Promise<TagResponse[]>
 }
 
-export async function fetchPresets(tag?: string | null): Promise<PresetListResponse[]> {
+export async function fetchScenes(tag?: string | null): Promise<SceneListResponse[]> {
   const query = tag ? `?tag=${encodeURIComponent(tag)}` : ''
-  const response = await fetch(buildApiUrl(`/presets${query}`))
+  const response = await fetch(buildApiUrl(`/scenes${query}`))
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch presets (${response.status})`)
+    throw new Error(`Failed to fetch scenes (${response.status})`)
   }
 
-  return response.json() as Promise<PresetListResponse[]>
+  return response.json() as Promise<SceneListResponse[]>
 }
 
 export async function fetchTags(options?: FetchTagsOptions): Promise<TagResponse[]> {

--- a/src/lib/embeddedShaderScenes.ts
+++ b/src/lib/embeddedShaderScenes.ts
@@ -1,10 +1,10 @@
-import type { ShaderPresetOption } from './presetEditor'
+import type { ShaderSceneOption } from './sceneEditor'
 
-export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
+export const EMBEDDED_SHADER_SCENES: ShaderSceneOption[] = [
   {
-    id: 'embedded-preset-0',
+    id: 'embedded-scene-0',
     label: 'Prism Core',
-    description: 'Bundled engine preset with layered box frames and a reflective core sphere.',
+    description: 'Bundled engine scene with layered box frames and a reflective core sphere.',
     shader: `
       let size = input()
       let pointerDown = input()
@@ -29,9 +29,9 @@ export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
     `,
   },
   {
-    id: 'embedded-preset-1',
+    id: 'embedded-scene-1',
     label: 'Steel Lattice',
-    description: 'Bundled engine preset built from stacked grids and box frames.',
+    description: 'Bundled engine scene built from stacked grids and box frames.',
     shader: `
       setMaxIterations(101);
       setStepSize(0.7260629659452175);
@@ -71,9 +71,9 @@ export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
     `,
   },
   {
-    id: 'embedded-preset-2',
+    id: 'embedded-scene-2',
     label: 'Aqua Static',
-    description: 'Bundled engine preset with noisy box frames and layered grid distortion.',
+    description: 'Bundled engine scene with noisy box frames and layered grid distortion.',
     shader: `
       setMaxIterations(133);
       setStepSize(0.8632297724861512);
@@ -118,9 +118,9 @@ export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
     `,
   },
   {
-    id: 'embedded-preset-3',
+    id: 'embedded-scene-3',
     label: 'Verdant Frames',
-    description: 'Bundled engine preset with twin box frames and green edge-lit motion.',
+    description: 'Bundled engine scene with twin box frames and green edge-lit motion.',
     shader: `
       setMaxIterations(71);
       setStepSize(0.4414923770441956);
@@ -155,9 +155,9 @@ export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
     `,
   },
   {
-    id: 'embedded-preset-4',
+    id: 'embedded-scene-4',
     label: 'Crimson Reactor',
-    description: 'Bundled engine preset with framed cylinders, a noisy core sphere, and a grid floor.',
+    description: 'Bundled engine scene with framed cylinders, a noisy core sphere, and a grid floor.',
     shader: `
       setMaxIterations(161);
       setStepSize(0.7431197197400152);
@@ -200,9 +200,9 @@ export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
     `,
   },
   {
-    id: 'embedded-preset-5',
+    id: 'embedded-scene-5',
     label: 'Alloy Capsule',
-    description: 'Bundled engine preset combining a metallic cylinder shell with a central sphere.',
+    description: 'Bundled engine scene combining a metallic cylinder shell with a central sphere.',
     shader: `
       setMaxIterations(56);
       setStepSize(0.04586632133333666);
@@ -234,9 +234,9 @@ export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
     `,
   },
   {
-    id: 'embedded-preset-6',
+    id: 'embedded-scene-6',
     label: 'Redline Core',
-    description: 'Bundled engine preset with a dominant sphere, cylinder, and dense grid accent.',
+    description: 'Bundled engine scene with a dominant sphere, cylinder, and dense grid accent.',
     shader: `
       setMaxIterations(198);
       setStepSize(0.8838993805155669);
@@ -273,9 +273,9 @@ export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
     `,
   },
   {
-    id: 'embedded-preset-7',
+    id: 'embedded-scene-7',
     label: 'Violet Matrix',
-    description: 'Bundled engine preset with layered grids and a saturated violet sphere.',
+    description: 'Bundled engine scene with layered grids and a saturated violet sphere.',
     shader: `
       setMaxIterations(193);
       setStepSize(0.7999169963821687);
@@ -313,9 +313,9 @@ export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
     `,
   },
   {
-    id: 'embedded-preset-8',
+    id: 'embedded-scene-8',
     label: 'Mint Halo',
-    description: 'Bundled engine preset with a torus frame, noisy grids, and a bright center sphere.',
+    description: 'Bundled engine scene with a torus frame, noisy grids, and a bright center sphere.',
     shader: `
       setMaxIterations(186);
       setStepSize(0.8615043142034936);
@@ -361,9 +361,9 @@ export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
     `,
   },
   {
-    id: 'embedded-preset-9',
+    id: 'embedded-scene-9',
     label: 'Ember Grid',
-    description: 'Bundled engine preset with orange framing and a tight supporting grid.',
+    description: 'Bundled engine scene with orange framing and a tight supporting grid.',
     shader: `
       setMaxIterations(56);
       setStepSize(0.7549446257595138);
@@ -399,9 +399,9 @@ export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
     `,
   },
   {
-    id: 'embedded-preset-10',
+    id: 'embedded-scene-10',
     label: 'Emerald Ring',
-    description: 'Bundled engine preset with a torus and box frame at maximum scale.',
+    description: 'Bundled engine scene with a torus and box frame at maximum scale.',
     shader: `
       setMaxIterations(151);
       setStepSize(0.26597607104610804);
@@ -436,9 +436,9 @@ export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
     `,
   },
   {
-    id: 'embedded-preset-11',
+    id: 'embedded-scene-11',
     label: 'Spectrum Relay',
-    description: 'Bundled engine preset with color-from-ray direction and sparse mixed primitives.',
+    description: 'Bundled engine scene with color-from-ray direction and sparse mixed primitives.',
     shader: `
       setMaxIterations(96);
       setStepSize(0.8497186712056144);
@@ -470,9 +470,9 @@ export const EMBEDDED_SHADER_PRESETS: ShaderPresetOption[] = [
     `,
   },
   {
-    id: 'embedded-preset-12',
+    id: 'embedded-scene-12',
     label: 'Chroma Storm',
-    description: 'Bundled engine preset with heavy noise expansion, mixed primitives, and rainbow ray coloring.',
+    description: 'Bundled engine scene with heavy noise expansion, mixed primitives, and rainbow ray coloring.',
     shader: `
       setMaxIterations(78);
       setStepSize(0.7369359368566446);

--- a/src/lib/magePlayerAdapter.ts
+++ b/src/lib/magePlayerAdapter.ts
@@ -11,7 +11,7 @@ const SCENE_BLOB_KEYS = [
 
 type MageEngineBridge = {
   dispose: () => void
-  loadPreset: (preset: unknown) => unknown
+  loadPreset: (scene: unknown) => unknown
   start: () => void
 }
 
@@ -75,15 +75,15 @@ export async function createMagePlayer(
   return {
     loadSceneBlob(sceneBlob) {
       if (!isMageSceneBlob(sceneBlob)) {
-        throw new MagePlayerAdapterError('Preset scene data is missing required MAGE fields.')
+        throw new MagePlayerAdapterError('Scene data is missing required MAGE fields.')
       }
 
       try {
-        const loadedPreset = engine.loadPreset(sceneBlob)
+        const loadedScene = engine.loadPreset(sceneBlob)
 
-        if (!loadedPreset) {
+        if (!loadedScene) {
           throw new MagePlayerAdapterError(
-            'Preset scene data could not be rendered by the MAGE engine.',
+            'Scene data could not be rendered by the MAGE engine.',
           )
         }
       } catch (error) {
@@ -91,7 +91,7 @@ export async function createMagePlayer(
           throw error
         }
 
-        throw new MagePlayerAdapterError('Preset scene data could not be rendered by the MAGE engine.')
+        throw new MagePlayerAdapterError('Scene data could not be rendered by the MAGE engine.')
       }
     },
     dispose() {

--- a/src/lib/myScenes.ts
+++ b/src/lib/myScenes.ts
@@ -1,48 +1,48 @@
 export type AuthenticatedFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
 
-export type PresetVisibility = 'Public' | 'Private' | 'Unlisted' | 'Draft'
+export type SceneVisibility = 'Public' | 'Private' | 'Unlisted' | 'Draft'
 export type SortKey = 'updated' | 'views' | 'likes'
 export type SortDirection = 'asc' | 'desc'
-export type StatusFilter = 'All' | PresetVisibility
+export type StatusFilter = 'All' | SceneVisibility
 
-export type UserPreset = {
+export type UserScene = {
   id: number
   name: string
   thumbnailRef: string | null
   createdAt: string | null
   description: string | null
-  statusLabel: PresetVisibility
+  statusLabel: SceneVisibility
   viewsCount: number
   commentsCount: number
   likesRatio: number
 }
 
-type UserPresetResponse = {
+type UserSceneResponse = {
   id?: number
-  presetId?: number
+  sceneId?: number
   name?: string
   thumbnailRef?: string | null
   createdAt?: string
   description?: string | null
 }
 
-type DemoPresetThumbnail = {
+type DemoSceneThumbnail = {
   background: string
   primary: string
   secondary: string
 }
 
-type DemoPresetRequest = {
+type DemoSceneRequest = {
   name: string
   sceneData: Record<string, unknown>
   thumbnailRef?: string
 }
 
-type DemoPresetBlueprint = Omit<DemoPresetRequest, 'thumbnailRef'> & {
-  thumbnail?: DemoPresetThumbnail
+type DemoSceneBlueprint = Omit<DemoSceneRequest, 'thumbnailRef'> & {
+  thumbnail?: DemoSceneThumbnail
 }
 
-const demoPresetBlueprints: DemoPresetBlueprint[] = [
+const demoSceneBlueprints: DemoSceneBlueprint[] = [
   {
     name: 'Aurora Drift',
     sceneData: {
@@ -110,34 +110,34 @@ const demoPresetBlueprints: DemoPresetBlueprint[] = [
 
 const rowsPerPageOptions = [10, 20, 30] as const
 
-function buildDemoThumbnail({ background, primary, secondary }: DemoPresetThumbnail) {
+function buildDemoThumbnail({ background, primary, secondary }: DemoSceneThumbnail) {
   const svg = `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 320 180'><rect width='320' height='180' fill='${background}'/><circle cx='86' cy='94' r='52' fill='${primary}'/><circle cx='244' cy='66' r='34' fill='${secondary}' fill-opacity='.88'/></svg>`
 
   return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`
 }
 
-const demoPresetRequests: DemoPresetRequest[] = demoPresetBlueprints.map(({ thumbnail, ...preset }) => ({
-  ...preset,
+const demoSceneRequests: DemoSceneRequest[] = demoSceneBlueprints.map(({ thumbnail, ...scene }) => ({
+  ...scene,
   ...(thumbnail ? { thumbnailRef: buildDemoThumbnail(thumbnail) } : {}),
 }))
 
-function isUserPresetResponse(value: unknown): value is UserPresetResponse {
+function isUserSceneResponse(value: unknown): value is UserSceneResponse {
   return typeof value === 'object' && value !== null
 }
 
-function buildViewsCount(presetId: number) {
-  return 18 + presetId * 37
+function buildViewsCount(sceneId: number) {
+  return 18 + sceneId * 37
 }
 
-function buildCommentsCount(presetId: number) {
-  return (presetId * 3) % 17
+function buildCommentsCount(sceneId: number) {
+  return (sceneId * 3) % 17
 }
 
-function buildLikesRatio(presetId: number) {
-  return 92 + (presetId % 7)
+function buildLikesRatio(sceneId: number) {
+  return 92 + (sceneId % 7)
 }
 
-function buildStatusLabel(): PresetVisibility {
+function buildStatusLabel(): SceneVisibility {
   return 'Public'
 }
 
@@ -151,7 +151,7 @@ function parseCreatedAtValue(createdAt: string | null) {
   return Number.isNaN(parsedDate.getTime()) ? 0 : parsedDate.getTime()
 }
 
-export function formatPresetDate(createdAt: string | null) {
+export function formatSceneDate(createdAt: string | null) {
   if (!createdAt) {
     return 'Recently'
   }
@@ -193,26 +193,26 @@ export function buildSortSummary(sortKey: SortKey, sortDirection: SortDirection)
   return sortDirection === 'desc' ? 'Highest likes ratio first' : 'Lowest likes ratio first'
 }
 
-export function sortPresets(presets: UserPreset[], sortKey: SortKey, sortDirection: SortDirection) {
+export function sortScenes(scenes: UserScene[], sortKey: SortKey, sortDirection: SortDirection) {
   const direction = sortDirection === 'asc' ? 1 : -1
 
-  return [...presets].sort((leftPreset, rightPreset) => {
+  return [...scenes].sort((leftScene, rightScene) => {
     let leftValue = 0
     let rightValue = 0
 
     if (sortKey === 'updated') {
-      leftValue = parseCreatedAtValue(leftPreset.createdAt)
-      rightValue = parseCreatedAtValue(rightPreset.createdAt)
+      leftValue = parseCreatedAtValue(leftScene.createdAt)
+      rightValue = parseCreatedAtValue(rightScene.createdAt)
     } else if (sortKey === 'views') {
-      leftValue = leftPreset.viewsCount
-      rightValue = rightPreset.viewsCount
+      leftValue = leftScene.viewsCount
+      rightValue = rightScene.viewsCount
     } else {
-      leftValue = leftPreset.likesRatio
-      rightValue = rightPreset.likesRatio
+      leftValue = leftScene.likesRatio
+      rightValue = rightScene.likesRatio
     }
 
     if (leftValue === rightValue) {
-      return leftPreset.name.localeCompare(rightPreset.name)
+      return leftScene.name.localeCompare(rightScene.name)
     }
 
     return (leftValue - rightValue) * direction
@@ -234,27 +234,27 @@ export function buildSortAriaLabel(
     : `Sort by ${label.toLowerCase()} descending`
 }
 
-export function normalizePresets(payload: unknown) {
+export function normalizeScenes(payload: unknown) {
   if (!Array.isArray(payload)) {
     return []
   }
 
-  return payload.reduce<UserPreset[]>((presets, item) => {
-    const presetId =
-      isUserPresetResponse(item) && typeof item.id === 'number'
+  return payload.reduce<UserScene[]>((scenes, item) => {
+    const sceneId =
+      isUserSceneResponse(item) && typeof item.id === 'number'
         ? item.id
-        : isUserPresetResponse(item) && typeof item.presetId === 'number'
-          ? item.presetId
+        : isUserSceneResponse(item) && typeof item.sceneId === 'number'
+          ? item.sceneId
           : null
 
-    if (!isUserPresetResponse(item) || presetId === null) {
-      return presets
+    if (!isUserSceneResponse(item) || sceneId === null) {
+      return scenes
     }
 
-    presets.push({
-      id: presetId,
+    scenes.push({
+      id: sceneId,
       name:
-        typeof item.name === 'string' && item.name.trim() ? item.name.trim() : `Preset ${presetId}`,
+        typeof item.name === 'string' && item.name.trim() ? item.name.trim() : `Scene ${sceneId}`,
       thumbnailRef:
         typeof item.thumbnailRef === 'string' && item.thumbnailRef.trim() ? item.thumbnailRef : null,
       createdAt:
@@ -262,41 +262,41 @@ export function normalizePresets(payload: unknown) {
       description:
         typeof item.description === 'string' && item.description.trim() ? item.description.trim() : null,
       statusLabel: buildStatusLabel(),
-      viewsCount: buildViewsCount(presetId),
-      commentsCount: buildCommentsCount(presetId),
-      likesRatio: buildLikesRatio(presetId),
+      viewsCount: buildViewsCount(sceneId),
+      commentsCount: buildCommentsCount(sceneId),
+      likesRatio: buildLikesRatio(sceneId),
     })
 
-    return presets
+    return scenes
   }, [])
 }
 
-export async function fetchUserPresets(authenticatedFetch: AuthenticatedFetch, userId: number) {
-  const response = await authenticatedFetch(`/users/${userId}/presets`)
+export async function fetchUserScenes(authenticatedFetch: AuthenticatedFetch, userId: number) {
+  const response = await authenticatedFetch(`/users/${userId}/scenes`)
 
   if (!response.ok) {
-    throw new Error('Unable to load presets.')
+    throw new Error('Unable to load scenes.')
   }
 
   const payload = (await response.json().catch(() => [])) as unknown
 
-  return normalizePresets(payload)
+  return normalizeScenes(payload)
 }
 
-export async function createDemoPresets(authenticatedFetch: AuthenticatedFetch) {
-  for (const preset of demoPresetRequests) {
-    const response = await authenticatedFetch('/presets', {
+export async function createDemoScenes(authenticatedFetch: AuthenticatedFetch) {
+  for (const scene of demoSceneRequests) {
+    const response = await authenticatedFetch('/scenes', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify(preset),
+      body: JSON.stringify(scene),
     })
 
     if (!response.ok) {
-      throw new Error('Unable to add sample presets right now. Please try again in a moment.')
+      throw new Error('Unable to add sample scenes right now. Please try again in a moment.')
     }
   }
 }
 
-export const MY_PRESETS_ROWS_PER_PAGE_OPTIONS = [...rowsPerPageOptions]
+export const MY_SCENES_ROWS_PER_PAGE_OPTIONS = [...rowsPerPageOptions]

--- a/src/lib/sceneDetail.ts
+++ b/src/lib/sceneDetail.ts
@@ -1,11 +1,11 @@
-import { buildApiUrl, fetchPresets, type PresetListResponse } from './api'
+import { buildApiUrl, fetchScenes, type SceneListResponse } from './api'
 import type { MageSceneBlob } from './magePlayerAdapter'
 
 export type AuthenticatedFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
 
-export type PresetDetailResponse = {
+export type SceneDetailResponse = {
   id?: number
-  presetId?: number
+  sceneId?: number
   ownerUserId?: number
   creatorDisplayName?: string
   name?: string
@@ -15,7 +15,7 @@ export type PresetDetailResponse = {
   tags?: unknown
 }
 
-export type PresetDetail = {
+export type SceneDetail = {
   id: number
   ownerUserId: number | null
   creatorDisplayName: string | null
@@ -26,14 +26,14 @@ export type PresetDetail = {
   tags: string[]
 }
 
-export type PresetDetailErrorCode =
+export type SceneDetailErrorCode =
   | 'auth-required'
   | 'invalid-id'
   | 'invalid-payload'
   | 'not-found'
   | 'unavailable'
 
-export type PresetComment = {
+export type SceneComment = {
   author: string
   handle: string
   posted: string
@@ -50,7 +50,7 @@ export type CreatorProfile = {
   primaryActionLabel?: string
 }
 
-export type PresetEngagement = {
+export type SceneEngagement = {
   playsLabel: string
   upvotesLabel: string
   downvotesLabel: string
@@ -59,7 +59,7 @@ export type PresetEngagement = {
   topicLabel: string
 }
 
-export type PresetDescription = {
+export type SceneDescription = {
   opening: string
   middle: string
   closing: string
@@ -68,7 +68,7 @@ export type PresetDescription = {
   tags: string[]
 }
 
-export type RecommendedPresetCard = {
+export type RecommendedSceneCard = {
   id: number
   title: string
   creator: string
@@ -78,10 +78,10 @@ export type RecommendedPresetCard = {
   ownerUserId: number
 }
 
-export type RecommendedPresetGroups = {
-  all: RecommendedPresetCard[]
-  creator: RecommendedPresetCard[]
-  byTag: Record<string, RecommendedPresetCard[]>
+export type RecommendedSceneGroups = {
+  all: RecommendedSceneCard[]
+  creator: RecommendedSceneCard[]
+  byTag: Record<string, RecommendedSceneCard[]>
 }
 
 export type RecommendationFilter = 'all' | 'creator' | `tag:${string}`
@@ -97,7 +97,7 @@ const creatorProfileBlueprints = [
     displayName: 'Jonah Reed',
     handle: '@jonahreedsignal',
     subscribersLabel: '1.42K subscribers',
-    studioNote: 'Most of my presets start from a music-first pass, then I add texture until the frame feels alive.',
+    studioNote: 'Most of my scenes start from a music-first pass, then I add texture until the frame feels alive.',
   },
   {
     displayName: 'Talia North',
@@ -109,14 +109,14 @@ const creatorProfileBlueprints = [
     displayName: 'Elio Mercer',
     handle: '@elio.mercer',
     subscribersLabel: '986 subscribers',
-    studioNote: 'If a preset looks loud with the volume off, I usually strip it back and start over.',
+    studioNote: 'If a scene looks loud with the volume off, I usually strip it back and start over.',
   },
 ] as const
 
-export class PresetDetailRequestError extends Error {
-  code: PresetDetailErrorCode
+export class SceneDetailRequestError extends Error {
+  code: SceneDetailErrorCode
 
-  constructor(code: PresetDetailErrorCode, message: string) {
+  constructor(code: SceneDetailErrorCode, message: string) {
     super(message)
     this.code = code
   }
@@ -126,7 +126,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
-function normalizePresetTags(tags: unknown) {
+function normalizeSceneTags(tags: unknown) {
   if (!Array.isArray(tags)) {
     return []
   }
@@ -147,24 +147,24 @@ function normalizePresetTags(tags: unknown) {
   return normalizedTags.filter((tagName, index) => normalizedTags.indexOf(tagName) === index)
 }
 
-function normalizePresetDetail(payload: unknown): PresetDetail | null {
+function normalizeSceneDetail(payload: unknown): SceneDetail | null {
   if (!isRecord(payload)) {
     return null
   }
 
-  const presetId =
-    typeof payload.presetId === 'number'
-      ? payload.presetId
+  const sceneId =
+    typeof payload.sceneId === 'number'
+      ? payload.sceneId
       : typeof payload.id === 'number'
         ? payload.id
         : null
 
-  if (presetId === null || !isRecord(payload.sceneData)) {
+  if (sceneId === null || !isRecord(payload.sceneData)) {
     return null
   }
 
   return {
-    id: presetId,
+    id: sceneId,
     ownerUserId: typeof payload.ownerUserId === 'number' ? payload.ownerUserId : null,
     creatorDisplayName:
       typeof payload.creatorDisplayName === 'string' && payload.creatorDisplayName.trim()
@@ -173,7 +173,7 @@ function normalizePresetDetail(payload: unknown): PresetDetail | null {
     name:
       typeof payload.name === 'string' && payload.name.trim()
         ? payload.name.trim()
-        : `Preset ${presetId}`,
+        : `Scene ${sceneId}`,
     sceneData: payload.sceneData,
     thumbnailRef:
       typeof payload.thumbnailRef === 'string' && payload.thumbnailRef.trim()
@@ -181,11 +181,11 @@ function normalizePresetDetail(payload: unknown): PresetDetail | null {
         : null,
     createdAt:
       typeof payload.createdAt === 'string' && payload.createdAt.trim() ? payload.createdAt : null,
-    tags: normalizePresetTags(payload.tags),
+    tags: normalizeSceneTags(payload.tags),
   }
 }
 
-function readErrorCode(status: number): PresetDetailErrorCode {
+function readErrorCode(status: number): SceneDetailErrorCode {
   if (status === 401) {
     return 'auth-required'
   }
@@ -261,33 +261,33 @@ function formatRelativeAge(createdAt: string | null) {
   return 'Just now'
 }
 
-function normalizeRecommendedPresetList(payload: unknown): PresetListResponse[] {
+function normalizeRecommendedSceneList(payload: unknown): SceneListResponse[] {
   if (!Array.isArray(payload)) {
     return []
   }
 
-  return payload.reduce<PresetListResponse[]>((presets, item) => {
+  return payload.reduce<SceneListResponse[]>((scenes, item) => {
     if (typeof item !== 'object' || item === null) {
-      return presets
+      return scenes
     }
 
-    const candidate = item as Partial<PresetListResponse>
+    const candidate = item as Partial<SceneListResponse>
 
     if (
-      typeof candidate.presetId !== 'number' ||
+      typeof candidate.sceneId !== 'number' ||
       typeof candidate.ownerUserId !== 'number' ||
       typeof candidate.creatorDisplayName !== 'string' ||
       typeof candidate.name !== 'string' ||
       typeof candidate.createdAt !== 'string'
     ) {
-      return presets
+      return scenes
     }
 
-    presets.push({
-      presetId: candidate.presetId,
+    scenes.push({
+      sceneId: candidate.sceneId,
       ownerUserId: candidate.ownerUserId,
       creatorDisplayName: candidate.creatorDisplayName.trim() || 'Unknown creator',
-      name: candidate.name.trim() || `Preset ${candidate.presetId}`,
+      name: candidate.name.trim() || `Scene ${candidate.sceneId}`,
       sceneData:
         typeof candidate.sceneData === 'object' && candidate.sceneData !== null ? candidate.sceneData : {},
       thumbnailRef:
@@ -297,59 +297,59 @@ function normalizeRecommendedPresetList(payload: unknown): PresetListResponse[] 
       createdAt: candidate.createdAt,
     })
 
-    return presets
+    return scenes
   }, [])
 }
 
-function buildRecommendedPlaysLabel(presetId: number) {
-  const plays = 1559 + presetId * 120
+function buildRecommendedPlaysLabel(sceneId: number) {
+  const plays = 1559 + sceneId * 120
   return `${plays.toLocaleString()} plays`
 }
 
-function buildRecommendationAccent(presetId: number) {
+function buildRecommendationAccent(sceneId: number) {
   const accents = ['#63f0d6', '#9fd9ff', '#ffb26b', '#7ef0c0', '#7f9bff']
-  return accents[Math.abs(presetId) % accents.length]
+  return accents[Math.abs(sceneId) % accents.length]
 }
 
-function buildRecommendedPresetsFromList(
-  presets: PresetListResponse[],
-  currentPresetId: number,
-): RecommendedPresetCard[] {
-  const presetsById = new Map<number, RecommendedPresetCard>()
+function buildRecommendedScenesFromList(
+  scenes: SceneListResponse[],
+  currentSceneId: number,
+): RecommendedSceneCard[] {
+  const scenesById = new Map<number, RecommendedSceneCard>()
 
-  presets
-    .filter((preset) => preset.presetId !== currentPresetId)
-    .forEach((preset) => {
-      if (presetsById.has(preset.presetId)) {
+  scenes
+    .filter((scene) => scene.sceneId !== currentSceneId)
+    .forEach((scene) => {
+      if (scenesById.has(scene.sceneId)) {
         return
       }
 
-      presetsById.set(preset.presetId, {
-        id: preset.presetId,
-        title: preset.name,
-        creator: preset.creatorDisplayName,
-        meta: `${buildRecommendedPlaysLabel(preset.presetId)} | ${formatRelativeAge(preset.createdAt)}`,
-        accent: buildRecommendationAccent(preset.presetId),
-        thumbnailRef: preset.thumbnailRef,
-        ownerUserId: preset.ownerUserId,
+      scenesById.set(scene.sceneId, {
+        id: scene.sceneId,
+        title: scene.name,
+        creator: scene.creatorDisplayName,
+        meta: `${buildRecommendedPlaysLabel(scene.sceneId)} | ${formatRelativeAge(scene.createdAt)}`,
+        accent: buildRecommendationAccent(scene.sceneId),
+        thumbnailRef: scene.thumbnailRef,
+        ownerUserId: scene.ownerUserId,
       })
     })
 
-  return [...presetsById.values()]
+  return [...scenesById.values()]
 }
 
-function mergeRecommendedPresetCards(
-  ...presetGroups: RecommendedPresetCard[][]
-): RecommendedPresetCard[] {
-  const presetsById = new Map<number, RecommendedPresetCard>()
+function mergeRecommendedSceneCards(
+  ...sceneGroups: RecommendedSceneCard[][]
+): RecommendedSceneCard[] {
+  const scenesById = new Map<number, RecommendedSceneCard>()
 
-  presetGroups.flat().forEach((preset) => {
-    if (!presetsById.has(preset.id)) {
-      presetsById.set(preset.id, preset)
+  sceneGroups.flat().forEach((scene) => {
+    if (!scenesById.has(scene.id)) {
+      scenesById.set(scene.id, scene)
     }
   })
 
-  return [...presetsById.values()]
+  return [...scenesById.values()]
 }
 
 function slugify(value: string) {
@@ -365,7 +365,7 @@ export function readInitial(value: string) {
   return trimmedValue ? trimmedValue[0].toUpperCase() : 'M'
 }
 
-export function readPresetId(value: string | undefined) {
+export function readSceneId(value: string | undefined) {
   if (!value) {
     return null
   }
@@ -379,36 +379,36 @@ export function readPresetId(value: string | undefined) {
   return parsedValue
 }
 
-export async function fetchPresetDetail(
+export async function fetchSceneDetail(
   authenticatedFetch: AuthenticatedFetch,
   isAuthenticated: boolean,
-  presetId: number,
+  sceneId: number,
 ) {
   const response = isAuthenticated
-    ? await authenticatedFetch(`/presets/${presetId}`)
-    : await fetch(buildApiUrl(`/presets/${presetId}`))
+    ? await authenticatedFetch(`/scenes/${sceneId}`)
+    : await fetch(buildApiUrl(`/scenes/${sceneId}`))
 
   if (!response.ok) {
-    throw new PresetDetailRequestError(
+    throw new SceneDetailRequestError(
       readErrorCode(response.status),
-      `Preset detail request failed with status ${response.status}.`,
+      `Scene detail request failed with status ${response.status}.`,
     )
   }
 
-  const payload = (await response.json().catch(() => null)) as PresetDetailResponse | null
-  const preset = normalizePresetDetail(payload)
+  const payload = (await response.json().catch(() => null)) as SceneDetailResponse | null
+  const scene = normalizeSceneDetail(payload)
 
-  if (!preset) {
-    throw new PresetDetailRequestError(
+  if (!scene) {
+    throw new SceneDetailRequestError(
       'invalid-payload',
-      'Preset detail response is missing the data required to render the player.',
+      'Scene detail response is missing the data required to render the player.',
     )
   }
 
-  return preset
+  return scene
 }
 
-export async function fetchCreatorPresetList(
+export async function fetchCreatorSceneList(
   authenticatedFetch: AuthenticatedFetch,
   isAuthenticated: boolean,
   ownerUserId: number | null,
@@ -417,15 +417,15 @@ export async function fetchCreatorPresetList(
     return []
   }
 
-  const response = await authenticatedFetch(`/users/${ownerUserId}/presets`)
+  const response = await authenticatedFetch(`/users/${ownerUserId}/scenes`)
 
   if (!response.ok) {
-    throw new Error(`Creator preset request failed with status ${response.status}.`)
+    throw new Error(`Creator scene request failed with status ${response.status}.`)
   }
 
   const payload = (await response.json().catch(() => [])) as unknown
 
-  return normalizeRecommendedPresetList(payload)
+  return normalizeRecommendedSceneList(payload)
 }
 
 export function buildTagRecommendationFilter(tag: string): RecommendationFilter {
@@ -436,7 +436,7 @@ export function readRecommendationFilterTag(filter: RecommendationFilter) {
   return filter.startsWith('tag:') ? filter.slice('tag:'.length) : null
 }
 
-export function createEmptyRecommendedPresetGroups(): RecommendedPresetGroups {
+export function createEmptyRecommendedSceneGroups(): RecommendedSceneGroups {
   return {
     all: [],
     creator: [],
@@ -444,69 +444,69 @@ export function createEmptyRecommendedPresetGroups(): RecommendedPresetGroups {
   }
 }
 
-export function buildRecommendedPresetGroups(
-  preset: PresetDetail,
-  allPresets: PresetListResponse[],
-  tagPresetsByTag: Record<string, PresetListResponse[]>,
-): RecommendedPresetGroups {
+export function buildRecommendedSceneGroups(
+  scene: SceneDetail,
+  allScenes: SceneListResponse[],
+  tagScenesByTag: Record<string, SceneListResponse[]>,
+): RecommendedSceneGroups {
   const creatorRecommendations =
-    preset.ownerUserId === null
+    scene.ownerUserId === null
       ? []
-      : buildRecommendedPresetsFromList(
-          allPresets.filter((candidatePreset) => candidatePreset.ownerUserId === preset.ownerUserId),
-          preset.id,
+      : buildRecommendedScenesFromList(
+          allScenes.filter((candidateScene) => candidateScene.ownerUserId === scene.ownerUserId),
+          scene.id,
         )
 
-  const recommendationsByTag = preset.tags.reduce<Record<string, RecommendedPresetCard[]>>(
+  const recommendationsByTag = scene.tags.reduce<Record<string, RecommendedSceneCard[]>>(
     (resolvedRecommendations, tag) => {
-      resolvedRecommendations[tag] = buildRecommendedPresetsFromList(tagPresetsByTag[tag] ?? [], preset.id)
+      resolvedRecommendations[tag] = buildRecommendedScenesFromList(tagScenesByTag[tag] ?? [], scene.id)
       return resolvedRecommendations
     },
     {},
   )
 
   return {
-    all: mergeRecommendedPresetCards(
+    all: mergeRecommendedSceneCards(
       creatorRecommendations,
-      ...preset.tags.map((tag) => recommendationsByTag[tag] ?? []),
+      ...scene.tags.map((tag) => recommendationsByTag[tag] ?? []),
     ),
     creator: creatorRecommendations,
     byTag: recommendationsByTag,
   }
 }
 
-export async function fetchRecommendedPresetGroups(
-  preset: PresetDetail,
-): Promise<RecommendedPresetGroups> {
-  const recommendationRequests = [fetchPresets(), ...preset.tags.map((tag) => fetchPresets(tag))]
-  const [allPresetsResult, ...tagPresetResults] = await Promise.allSettled(recommendationRequests)
+export async function fetchRecommendedSceneGroups(
+  scene: SceneDetail,
+): Promise<RecommendedSceneGroups> {
+  const recommendationRequests = [fetchScenes(), ...scene.tags.map((tag) => fetchScenes(tag))]
+  const [allScenesResult, ...tagSceneResults] = await Promise.allSettled(recommendationRequests)
 
-  const allPresets = allPresetsResult.status === 'fulfilled' ? allPresetsResult.value : []
-  const tagPresetsByTag = preset.tags.reduce<Record<string, PresetListResponse[]>>(
-    (resolvedTagPresets, tag, index) => {
-      const nextTagResult = tagPresetResults[index]
-      resolvedTagPresets[tag] = nextTagResult?.status === 'fulfilled' ? nextTagResult.value : []
-      return resolvedTagPresets
+  const allScenes = allScenesResult.status === 'fulfilled' ? allScenesResult.value : []
+  const tagScenesByTag = scene.tags.reduce<Record<string, SceneListResponse[]>>(
+    (resolvedTagScenes, tag, index) => {
+      const nextTagResult = tagSceneResults[index]
+      resolvedTagScenes[tag] = nextTagResult?.status === 'fulfilled' ? nextTagResult.value : []
+      return resolvedTagScenes
     },
     {},
   )
 
-  return buildRecommendedPresetGroups(preset, allPresets, tagPresetsByTag)
+  return buildRecommendedSceneGroups(scene, allScenes, tagScenesByTag)
 }
 
-export function buildPresetEngagement(preset: PresetDetail): PresetEngagement {
-  const plays = 1559 + preset.id * 120
-  const upvotes = 56 + preset.id * 30
-  const downvotes = 8 + preset.id * 2
-  const saves = 18 + preset.id * 11
+export function buildSceneEngagement(scene: SceneDetail): SceneEngagement {
+  const plays = 1559 + scene.id * 120
+  const upvotes = 56 + scene.id * 30
+  const downvotes = 8 + scene.id * 2
+  const saves = 18 + scene.id * 11
 
   return {
     playsLabel: `${plays.toLocaleString()} plays`,
     upvotesLabel: upvotes.toLocaleString(),
     downvotesLabel: downvotes.toLocaleString(),
     savesLabel: saves.toLocaleString(),
-    publishedLabel: `Published ${formatCreatedAt(preset.createdAt)}`,
-    topicLabel: 'Audio-reactive preset',
+    publishedLabel: `Published ${formatCreatedAt(scene.createdAt)}`,
+    topicLabel: 'Audio-reactive scene',
   }
 }
 
@@ -521,26 +521,26 @@ function buildSubscriberLabel(seed: number) {
 }
 
 export function buildCreatorProfile(
-  preset: PresetDetail,
+  scene: SceneDetail,
   viewerDisplayName: string | undefined,
   viewerUserId: number | null | undefined,
 ): CreatorProfile {
-  const resolvedDisplayName = preset.creatorDisplayName?.trim() || viewerDisplayName?.trim() || 'Your Studio'
+  const resolvedDisplayName = scene.creatorDisplayName?.trim() || viewerDisplayName?.trim() || 'Your Studio'
 
-  if (viewerUserId !== null && viewerUserId !== undefined && viewerUserId === preset.ownerUserId) {
+  if (viewerUserId !== null && viewerUserId !== undefined && viewerUserId === scene.ownerUserId) {
     return {
       displayName: resolvedDisplayName,
       handle: `@${slugify(resolvedDisplayName) || 'magecreator'}`,
-      subscribersLabel: buildSubscriberLabel(preset.id),
+      subscribersLabel: buildSubscriberLabel(scene.id),
       studioNote:
-        'I wanted this preset page to feel like something I would actually share, not just a lab route with a player dropped into it.',
+        'I wanted this scene page to feel like something I would actually share, not just a lab route with a player dropped into it.',
       primaryActionLabel: 'Subscribe',
     }
   }
 
   const blueprint =
     creatorProfileBlueprints[
-      Math.abs((preset.ownerUserId ?? preset.id) % creatorProfileBlueprints.length)
+      Math.abs((scene.ownerUserId ?? scene.id) % creatorProfileBlueprints.length)
     ]
 
   return {
@@ -551,28 +551,28 @@ export function buildCreatorProfile(
   }
 }
 
-export function buildPresetDescription(
-  preset: PresetDetail,
+export function buildSceneDescription(
+  scene: SceneDetail,
   creatorProfile: CreatorProfile,
-): PresetDescription {
+): SceneDescription {
   return {
-    opening: `I built ${preset.name} for tracks that need atmosphere without visual clutter. The motion holds back during the intro, then the reflections and bloom open up once the mids start pushing forward.`,
+    opening: `I built ${scene.name} for tracks that need atmosphere without visual clutter. The motion holds back during the intro, then the reflections and bloom open up once the mids start pushing forward.`,
     middle: `${creatorProfile.displayName} tends to tune scenes for patience rather than spectacle, so this one lands best behind slower house, downtempo electronica, mellow garage, and long vocal builds where the frame needs to stay supportive instead of noisy.`,
     closing:
-      'This page is still an early public pass, but the preset render above is the real scene payload. I wanted the surrounding notes, comments, and recommendations to read like a creator page someone would actually spend time on while the rest of the social features catch up.',
+      'This page is still an early public pass, but the scene render above is the real scene payload. I wanted the surrounding notes, comments, and recommendations to read like a creator page someone would actually spend time on while the rest of the social features catch up.',
     bestFor: 'late-night sets, focus mixes, ambient intros',
     builtWith: 'soft bloom, layered fog, reflective passes, restrained drift',
-    tags: preset.tags,
+    tags: scene.tags,
   }
 }
 
-export function buildPresetComments(preset: PresetDetail): PresetComment[] {
+export function buildSceneComments(scene: SceneDetail): SceneComment[] {
   return [
     {
       author: 'Nora Vale',
       handle: '@noravale',
       posted: '2 days ago',
-      text: `Ran ${preset.name} behind a Rhodes sketch last night and it sat exactly where I wanted it. The slower build is what makes it feel intentional.`,
+      text: `Ran ${scene.name} behind a Rhodes sketch last night and it sat exactly where I wanted it. The slower build is what makes it feel intentional.`,
       upvotes: '14',
       downvotes: '1',
     },
@@ -580,7 +580,7 @@ export function buildPresetComments(preset: PresetDetail): PresetComment[] {
       author: 'Cass Mercer',
       handle: '@cassmercer',
       posted: '5 days ago',
-      text: 'The restraint is the best part. Most reactive presets oversell the first beat, but this one gives the track room before the highlights start showing off.',
+      text: 'The restraint is the best part. Most reactive scenes oversell the first beat, but this one gives the track room before the highlights start showing off.',
       upvotes: '9',
       downvotes: '0',
     },
@@ -595,46 +595,46 @@ export function buildPresetComments(preset: PresetDetail): PresetComment[] {
   ]
 }
 
-export function buildRecommendedPresets(
-  preset: PresetDetail,
-  creatorPresets: PresetListResponse[],
-): RecommendedPresetCard[] {
-  return buildRecommendedPresetsFromList(creatorPresets, preset.id)
+export function buildRecommendedScenes(
+  scene: SceneDetail,
+  creatorScenes: SceneListResponse[],
+): RecommendedSceneCard[] {
+  return buildRecommendedScenesFromList(creatorScenes, scene.id)
 }
 
-export function readErrorCopy(errorCode: PresetDetailErrorCode) {
+export function readErrorCopy(errorCode: SceneDetailErrorCode) {
   if (errorCode === 'invalid-id') {
     return {
-      title: 'Invalid preset link',
-      description: 'This route is missing a valid preset id. Check the URL and try again.',
+      title: 'Invalid scene link',
+      description: 'This route is missing a valid scene id. Check the URL and try again.',
     }
   }
 
   if (errorCode === 'auth-required') {
     return {
-      title: 'Sign in to view this preset',
+      title: 'Sign in to view this scene',
       description:
-        'Preset detail requests are still authenticated in this build. Sign in, then reopen this preset route.',
+        'Scene detail requests are still authenticated in this build. Sign in, then reopen this scene route.',
     }
   }
 
   if (errorCode === 'not-found') {
     return {
-      title: 'Preset not found',
-      description: 'This preset does not exist or is no longer available.',
+      title: 'Scene not found',
+      description: 'This scene does not exist or is no longer available.',
     }
   }
 
   if (errorCode === 'invalid-payload') {
     return {
-      title: 'Unable to render this preset',
+      title: 'Unable to render this scene',
       description:
-        'The backend returned preset detail data, but the scene payload is missing fields required by the player.',
+        'The backend returned scene detail data, but the scene payload is missing fields required by the player.',
     }
   }
 
   return {
-    title: 'Unable to load this preset',
-    description: 'MAGE could not load this preset right now. Please try again in a moment.',
+    title: 'Unable to load this scene',
+    description: 'MAGE could not load this scene right now. Please try again in a moment.',
   }
 }

--- a/src/lib/sceneEditor.ts
+++ b/src/lib/sceneEditor.ts
@@ -1,6 +1,6 @@
-import { EMBEDDED_SHADER_PRESETS } from './embeddedShaderPresets'
+import { EMBEDDED_SHADER_SCENES } from './embeddedShaderScenes'
 
-export type PresetSceneData = Record<string, unknown>
+export type SceneData = Record<string, unknown>
 
 export type Vector3Value = {
   x: number
@@ -8,7 +8,7 @@ export type Vector3Value = {
   z: number
 }
 
-export type PresetPassId =
+export type ScenePassId =
   | 'glitchPass'
   | 'bloom'
   | 'RGBShift'
@@ -40,7 +40,7 @@ export type PersistedPassFlag =
   | 'kaleid'
   | 'outputPass'
 
-export type ShaderPresetOption = {
+export type ShaderSceneOption = {
   description: string
   id: string
   label: string
@@ -82,7 +82,7 @@ export type SceneEditorModel = {
         amount: number
       }
     }
-    passOrder: PresetPassId[]
+    passOrder: ScenePassId[]
     passes: Record<PersistedPassFlag, boolean>
     toneMapping: {
       exposure: number
@@ -118,7 +118,7 @@ export type SceneEditorModel = {
   }
 }
 
-const DEFAULT_PASS_ORDER: PresetPassId[] = [
+const DEFAULT_PASS_ORDER: ScenePassId[] = [
   'glitchPass',
   'bloom',
   'RGBShift',
@@ -137,7 +137,7 @@ const DEFAULT_PASS_ORDER: PresetPassId[] = [
   'outputPass',
 ]
 
-export const PASS_LABELS: Record<PresetPassId, string> = {
+export const PASS_LABELS: Record<ScenePassId, string> = {
   RGBShift: 'RGB Shift',
   afterImagePass: 'Afterimage',
   bleachBypassShader: 'Bleach Bypass',
@@ -156,7 +156,7 @@ export const PASS_LABELS: Record<PresetPassId, string> = {
   toonShader: 'Toon',
 }
 
-export const SHADER_PRESETS: ShaderPresetOption[] = [...EMBEDDED_SHADER_PRESETS]
+export const SHADER_SCENES: ShaderSceneOption[] = [...EMBEDDED_SHADER_SCENES]
 
 export const TONE_MAPPING_OPTIONS: ToneMappingOption[] = [
   {
@@ -203,7 +203,7 @@ export const SKYBOX_OPTIONS = Array.from({ length: 10 }, (_, index) => ({
 
 const DEFAULT_SCENE_DATA: SceneEditorModel = {
   visualizer: {
-    shader: SHADER_PRESETS[0].shader,
+    shader: SHADER_SCENES[0].shader,
     skyboxPreset: 6,
     scale: 10,
   },
@@ -309,27 +309,27 @@ function readVector3(value: unknown, fallback: Vector3Value): Vector3Value {
   }
 }
 
-function normalizePassOrder(value: unknown): PresetPassId[] {
+function normalizePassOrder(value: unknown): ScenePassId[] {
   if (!Array.isArray(value)) {
     return [...DEFAULT_PASS_ORDER]
   }
 
-  const nextOrder: PresetPassId[] = []
+  const nextOrder: ScenePassId[] = []
 
   for (const item of value) {
     if (typeof item !== 'string') {
       continue
     }
 
-    if (!DEFAULT_PASS_ORDER.includes(item as PresetPassId)) {
+    if (!DEFAULT_PASS_ORDER.includes(item as ScenePassId)) {
       continue
     }
 
-    if (nextOrder.includes(item as PresetPassId)) {
+    if (nextOrder.includes(item as ScenePassId)) {
       continue
     }
 
-    nextOrder.push(item as PresetPassId)
+    nextOrder.push(item as ScenePassId)
   }
 
   for (const passId of DEFAULT_PASS_ORDER) {
@@ -408,7 +408,7 @@ function createDefaultModel(): SceneEditorModel {
   }
 }
 
-export function createDefaultSceneData(): PresetSceneData {
+export function createDefaultSceneData(): SceneData {
   const defaults = createDefaultModel()
 
   return {
@@ -420,7 +420,7 @@ export function createDefaultSceneData(): PresetSceneData {
   }
 }
 
-export function getSceneEditorModel(sceneData: PresetSceneData): SceneEditorModel {
+export function getSceneEditorModel(sceneData: SceneData): SceneEditorModel {
   const defaults = createDefaultModel()
   const visualizer = readRecord(sceneData.visualizer)
   const controls = readRecord(sceneData.controls)
@@ -525,10 +525,10 @@ export function getSceneEditorModel(sceneData: PresetSceneData): SceneEditorMode
 }
 
 export function mergeSceneEditorBranch<K extends keyof SceneEditorModel>(
-  sceneData: PresetSceneData,
+  sceneData: SceneData,
   branch: K,
   value: SceneEditorModel[K],
-): PresetSceneData {
+): SceneData {
   switch (branch) {
     case 'visualizer': {
       const nextVisualizer = value as SceneEditorModel['visualizer']
@@ -634,7 +634,7 @@ export function mergeSceneEditorBranch<K extends keyof SceneEditorModel>(
   }
 }
 
-export function sanitizeSceneData(sceneData: PresetSceneData): PresetSceneData {
+export function sanitizeSceneData(sceneData: SceneData): SceneData {
   const normalizedModel = getSceneEditorModel(sceneData)
   let nextSceneData = { ...sceneData }
 
@@ -657,7 +657,7 @@ export function parseSceneDataJson(value: string) {
   return parsedValue
 }
 
-export function prettyPrintSceneData(sceneData: PresetSceneData) {
+export function prettyPrintSceneData(sceneData: SceneData) {
   return JSON.stringify(sanitizeSceneData(sceneData), null, 2)
 }
 

--- a/src/lib/sceneThumbnailUpload.ts
+++ b/src/lib/sceneThumbnailUpload.ts
@@ -12,11 +12,11 @@ type PresignedThumbnailUploadResponse = {
   headers?: Record<string, string>;
 };
 
-export async function uploadNewPresetThumbnail(
+export async function uploadNewSceneThumbnail(
   authenticatedFetch: AuthenticatedFetch,
   file: File,
 ) {
-  const presignResponse = await authenticatedFetch("/presets/thumbnail/presign", {
+  const presignResponse = await authenticatedFetch("/scenes/thumbnail/presign", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({

--- a/src/pages/CreateScenePage.test.tsx
+++ b/src/pages/CreateScenePage.test.tsx
@@ -8,7 +8,7 @@ import {
   type AuthenticatedUser,
 } from '../auth/AuthContext'
 import { buildApiUrl } from '../lib/api'
-import { CreatePresetPage } from './CreatePresetPage'
+import { CreateScenePage } from './CreateScenePage'
 
 vi.mock('../components/MagePlayer', () => ({
   MagePlayer: ({ sceneBlob }: { sceneBlob: unknown }) => (
@@ -19,7 +19,7 @@ vi.mock('../components/MagePlayer', () => ({
 const storedUser: AuthenticatedUser = {
   userId: 8,
   email: 'artist@example.com',
-  displayName: 'Preset Artist',
+  displayName: 'Scene Artist',
   authProvider: 'LOCAL',
 }
 
@@ -52,7 +52,7 @@ function storeSession() {
   )
 }
 
-function mockCreatePresetPageFetch(
+function mockCreateScenePageFetch(
   handler?: FetchHandler,
   tagsResponse: unknown[] = mockTags,
 ) {
@@ -77,13 +77,13 @@ function mockCreatePresetPageFetch(
   })
 }
 
-function renderCreatePresetPage() {
+function renderCreateScenePage() {
   return render(
-    <MemoryRouter initialEntries={['/create-preset']}>
+    <MemoryRouter initialEntries={['/create-scene']}>
       <AuthProvider>
         <Routes>
-          <Route path="/create-preset" element={<CreatePresetPage />} />
-          <Route path="/my-presets" element={<div>My Presets</div>} />
+          <Route path="/create-scene" element={<CreateScenePage />} />
+          <Route path="/my-scenes" element={<div>My Scenes</div>} />
         </Routes>
       </AuthProvider>
     </MemoryRouter>,
@@ -118,15 +118,15 @@ afterEach(() => {
   window.localStorage.clear()
 })
 
-describe('CreatePresetPage', () => {
+describe('CreateScenePage', () => {
   it('renders the expanded MAGE engine editor with the full section menu available', async () => {
     storeSession()
 
-    mockCreatePresetPageFetch()
+    mockCreateScenePageFetch()
 
-    renderCreatePresetPage()
+    renderCreateScenePage()
 
-    expect(screen.getByRole('heading', { name: /create preset/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /create scene/i })).toBeInTheDocument()
     expect(screen.queryByRole('tab', { name: /basic/i })).not.toBeInTheDocument()
     expect(screen.getByRole('heading', { name: /^scene$/i })).toBeInTheDocument()
     expect(screen.queryByRole('heading', { name: /^camera$/i })).not.toBeInTheDocument()
@@ -142,15 +142,15 @@ describe('CreatePresetPage', () => {
     expect(screen.getByTestId('mage-player')).toHaveTextContent('preview-ready')
   })
 
-  it('renders interactive metadata controls beneath the preset name field', async () => {
+  it('renders interactive metadata controls beneath the scene name field', async () => {
     storeSession()
 
-    mockCreatePresetPageFetch()
+    mockCreateScenePageFetch()
 
-    renderCreatePresetPage()
+    renderCreateScenePage()
 
     fireEvent.change(screen.getByLabelText(/description/i), {
-      target: { value: 'A soft drifting preset for night scenes.' },
+      target: { value: 'A soft drifting scene for night scenes.' },
     })
     fireEvent.change(screen.getByLabelText(/playlists/i), {
       target: { value: 'ambient-atlas' },
@@ -162,7 +162,7 @@ describe('CreatePresetPage', () => {
     })
 
     expect(screen.getByLabelText(/description/i)).toHaveValue(
-      'A soft drifting preset for night scenes.',
+      'A soft drifting scene for night scenes.',
     )
     expect(screen.getByLabelText(/playlists/i)).toHaveValue('ambient-atlas')
     expect(screen.getByText(/selected file:/i)).toBeInTheDocument()
@@ -173,11 +173,11 @@ describe('CreatePresetPage', () => {
   it('loads available tags and lets the user select more than one before saving', async () => {
     storeSession()
 
-    mockCreatePresetPageFetch()
+    mockCreateScenePageFetch()
 
     const user = userEvent.setup()
 
-    renderCreatePresetPage()
+    renderCreateScenePage()
 
     await selectExistingTag(user, 'ambient')
     await selectExistingTag(user, 'focus-friendly')
@@ -193,7 +193,7 @@ describe('CreatePresetPage', () => {
 
     let createTagBody: Record<string, unknown> | null = null
 
-    mockCreatePresetPageFetch((input, init) => {
+    mockCreateScenePageFetch((input, init) => {
       if (input === buildApiUrl('/tags')) {
         createTagBody = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
         return Promise.resolve(jsonResponse({ tagId: 7, name: 'late night' }, 201))
@@ -202,7 +202,7 @@ describe('CreatePresetPage', () => {
 
     const user = userEvent.setup()
 
-    renderCreatePresetPage()
+    renderCreateScenePage()
 
     await addTagFromSearch(user, 'Late Night')
 
@@ -264,7 +264,7 @@ describe('CreatePresetPage', () => {
 
     const user = userEvent.setup()
 
-    renderCreatePresetPage()
+    renderCreateScenePage()
 
     await addTagFromSearch(user, 'Late Night')
 
@@ -273,14 +273,14 @@ describe('CreatePresetPage', () => {
     expect(screen.queryByText(/failed to create tag/i)).not.toBeInTheDocument()
   })
 
-  it('clicking a selected tag pill removes it from the preset', async () => {
+  it('clicking a selected tag pill removes it from the scene', async () => {
     storeSession()
 
-    mockCreatePresetPageFetch()
+    mockCreateScenePageFetch()
 
     const user = userEvent.setup()
 
-    renderCreatePresetPage()
+    renderCreateScenePage()
 
     await selectExistingTag(user, 'ambient')
     await user.click(screen.getByRole('button', { name: /^ambient$/i }))
@@ -291,9 +291,9 @@ describe('CreatePresetPage', () => {
   it('keeps the Motion section focused on the persisted MAGE engine motion controls', async () => {
     storeSession()
 
-    mockCreatePresetPageFetch()
+    mockCreateScenePageFetch()
 
-    renderCreatePresetPage()
+    renderCreateScenePage()
 
     fireEvent.change(screen.getByLabelText(/jump to section/i), { target: { value: 'motion' } })
 
@@ -313,9 +313,9 @@ describe('CreatePresetPage', () => {
   it('splits pass ordering into its own section and groups effects into categorized cards', async () => {
     storeSession()
 
-    mockCreatePresetPageFetch()
+    mockCreateScenePageFetch()
 
-    renderCreatePresetPage()
+    renderCreateScenePage()
 
     fireEvent.change(screen.getByLabelText(/jump to section/i), { target: { value: 'effects' } })
 
@@ -342,27 +342,27 @@ describe('CreatePresetPage', () => {
 
     let submittedBody: Record<string, unknown> | null = null
 
-    mockCreatePresetPageFetch((input, init) => {
-      if (input === buildApiUrl('/presets')) {
+    mockCreateScenePageFetch((input, init) => {
+      if (input === buildApiUrl('/scenes')) {
         submittedBody = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
-        return Promise.resolve(jsonResponse({ presetId: 18 }, 201))
+        return Promise.resolve(jsonResponse({ sceneId: 18 }, 201))
       }
     })
 
     const user = userEvent.setup()
 
-    renderCreatePresetPage()
+    renderCreateScenePage()
 
-    await user.type(screen.getByLabelText(/preset name/i), 'Aurora Drift')
+    await user.type(screen.getByLabelText(/scene name/i), 'Aurora Drift')
     fireEvent.change(screen.getByLabelText(/jump to section/i), { target: { value: 'camera' } })
     expect(screen.getByRole('heading', { name: /^camera$/i })).toBeInTheDocument()
     fireEvent.change(screen.getByLabelText(/camera orientation/i), { target: { value: '90' } })
-    await user.click(screen.getByRole('button', { name: /create preset/i }))
+    await user.click(screen.getByRole('button', { name: /create scene/i }))
 
     await waitFor(() => expect(submittedBody).not.toBeNull())
 
     if (!submittedBody) {
-      throw new Error('Expected preset submission payload to be captured.')
+      throw new Error('Expected scene submission payload to be captured.')
     }
 
     const responseBody: { name: string; sceneData: Record<string, unknown> } = submittedBody
@@ -376,42 +376,42 @@ describe('CreatePresetPage', () => {
     })
     expect(intent.camTilt).toBeCloseTo(Math.PI / 2, 5)
     expect(passOrder.at(-1)).toBe('outputPass')
-    expect(await screen.findByText('My Presets')).toBeInTheDocument()
+    expect(await screen.findByText('My Scenes')).toBeInTheDocument()
   })
 
-  it('attaches selected tags after the preset is created', async () => {
+  it('attaches selected tags after the scene is created', async () => {
     storeSession()
 
     let createBody: Record<string, unknown> | null = null
     const attachedTagIds: number[] = []
 
-    mockCreatePresetPageFetch((input, init) => {
-      if (input === buildApiUrl('/presets')) {
+    mockCreateScenePageFetch((input, init) => {
+      if (input === buildApiUrl('/scenes')) {
         createBody = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
-        return Promise.resolve(jsonResponse({ presetId: 18 }, 201))
+        return Promise.resolve(jsonResponse({ sceneId: 18 }, 201))
       }
 
-      if (input === buildApiUrl('/presets/18/tags')) {
+      if (input === buildApiUrl('/scenes/18/tags')) {
         const payload = JSON.parse(String(init?.body ?? '{}')) as { tagId?: number }
 
         if (typeof payload.tagId === 'number') {
           attachedTagIds.push(payload.tagId)
         }
 
-        return Promise.resolve(jsonResponse({ presetId: 18, tagId: payload.tagId }, 201))
+        return Promise.resolve(jsonResponse({ sceneId: 18, tagId: payload.tagId }, 201))
       }
     })
 
     const user = userEvent.setup()
 
-    renderCreatePresetPage()
+    renderCreateScenePage()
 
-    await user.type(screen.getByLabelText(/preset name/i), 'Aurora Drift')
+    await user.type(screen.getByLabelText(/scene name/i), 'Aurora Drift')
     await selectExistingTag(user, 'ambient')
     await selectExistingTag(user, 'focus-friendly')
-    await user.click(screen.getByRole('button', { name: /create preset/i }))
+    await user.click(screen.getByRole('button', { name: /create scene/i }))
 
-    await screen.findByText('My Presets')
+    await screen.findByText('My Scenes')
 
     expect(createBody).toMatchObject({
       name: 'Aurora Drift',
@@ -419,17 +419,17 @@ describe('CreatePresetPage', () => {
     expect(attachedTagIds).toEqual([1, 2])
   })
 
-  it('keeps the created preset in retry mode when one or more tag attachments fail', async () => {
+  it('keeps the created scene in retry mode when one or more tag attachments fail', async () => {
     storeSession()
 
     const attachCalls: number[] = []
 
-    mockCreatePresetPageFetch((input, init) => {
-      if (input === buildApiUrl('/presets')) {
-        return Promise.resolve(jsonResponse({ presetId: 18 }, 201))
+    mockCreateScenePageFetch((input, init) => {
+      if (input === buildApiUrl('/scenes')) {
+        return Promise.resolve(jsonResponse({ sceneId: 18 }, 201))
       }
 
-      if (input === buildApiUrl('/presets/18/tags')) {
+      if (input === buildApiUrl('/scenes/18/tags')) {
         const payload = JSON.parse(String(init?.body ?? '{}')) as { tagId?: number }
 
         if (typeof payload.tagId === 'number') {
@@ -448,41 +448,41 @@ describe('CreatePresetPage', () => {
           )
         }
 
-        return Promise.resolve(jsonResponse({ presetId: 18, tagId: payload.tagId }, 201))
+        return Promise.resolve(jsonResponse({ sceneId: 18, tagId: payload.tagId }, 201))
       }
     })
 
     const user = userEvent.setup()
 
-    renderCreatePresetPage()
+    renderCreateScenePage()
 
-    await user.type(screen.getByLabelText(/preset name/i), 'Aurora Drift')
+    await user.type(screen.getByLabelText(/scene name/i), 'Aurora Drift')
     await selectExistingTag(user, 'ambient')
     await selectExistingTag(user, 'focus-friendly')
-    await user.click(screen.getByRole('button', { name: /create preset/i }))
+    await user.click(screen.getByRole('button', { name: /create scene/i }))
 
     expect(
-      await screen.findByText(/preset created, but we couldn't attach focus-friendly\./i),
+      await screen.findByText(/scene created, but we couldn't attach focus-friendly\./i),
     ).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /retry tag attachment/i })).toBeInTheDocument()
     expect(screen.getByText(/waiting to retry attachment for:/i)).toBeInTheDocument()
     expect(attachCalls).toEqual([1, 2])
   })
 
-  it('uploads a selected thumbnail before the preset create request is sent', async () => {
+  it('uploads a selected thumbnail before the scene create request is sent', async () => {
     storeSession()
 
     const uploadedFiles: File[] = []
     let presignBody: Record<string, unknown> | null = null
     let createBody: Record<string, unknown> | null = null
 
-    mockCreatePresetPageFetch((input, init) => {
-      if (input === buildApiUrl('/presets/thumbnail/presign')) {
+    mockCreateScenePageFetch((input, init) => {
+      if (input === buildApiUrl('/scenes/thumbnail/presign')) {
         presignBody = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
         return Promise.resolve(
           jsonResponse({
-            objectKey: 'presets/pending/8/thumbnails/abc123.png',
-            uploadUrl: 'https://upload.example.com/presets/pending/8/thumbnails/abc123.png',
+            objectKey: 'scenes/pending/8/thumbnails/abc123.png',
+            uploadUrl: 'https://upload.example.com/scenes/pending/8/thumbnails/abc123.png',
             method: 'PUT',
             headers: {
               'Content-Type': 'image/png',
@@ -491,7 +491,7 @@ describe('CreatePresetPage', () => {
         )
       }
 
-      if (input === 'https://upload.example.com/presets/pending/8/thumbnails/abc123.png') {
+      if (input === 'https://upload.example.com/scenes/pending/8/thumbnails/abc123.png') {
         if (init?.body instanceof File) {
           uploadedFiles.push(init.body)
         }
@@ -499,23 +499,23 @@ describe('CreatePresetPage', () => {
         return Promise.resolve(new Response(null, { status: 200 }))
       }
 
-      if (input === buildApiUrl('/presets')) {
+      if (input === buildApiUrl('/scenes')) {
         createBody = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
-        return Promise.resolve(jsonResponse({ presetId: 18 }, 201))
+        return Promise.resolve(jsonResponse({ sceneId: 18 }, 201))
       }
     })
 
     const user = userEvent.setup()
 
-    renderCreatePresetPage()
+    renderCreateScenePage()
 
-    await user.type(screen.getByLabelText(/preset name/i), 'Aurora Drift')
+    await user.type(screen.getByLabelText(/scene name/i), 'Aurora Drift')
     fireEvent.change(screen.getByLabelText(/upload thumbnail file/i), {
       target: {
         files: [new File(['cover'], 'cover.png', { type: 'image/png' })],
       },
     })
-    await user.click(screen.getByRole('button', { name: /create preset/i }))
+    await user.click(screen.getByRole('button', { name: /create scene/i }))
 
     await waitFor(() => expect(presignBody).not.toBeNull())
 
@@ -528,18 +528,18 @@ describe('CreatePresetPage', () => {
     expect(uploadedFiles[0].name).toBe('cover.png')
     expect(createBody).toMatchObject({
       name: 'Aurora Drift',
-      thumbnailObjectKey: 'presets/pending/8/thumbnails/abc123.png',
+      thumbnailObjectKey: 'scenes/pending/8/thumbnails/abc123.png',
     })
-    expect(await screen.findByText('My Presets')).toBeInTheDocument()
+    expect(await screen.findByText('My Scenes')).toBeInTheDocument()
   })
 
-  it('does not create the preset when thumbnail upload preparation fails', async () => {
+  it('does not create the scene when thumbnail upload preparation fails', async () => {
     storeSession()
 
     let createAttempted = false
 
-    mockCreatePresetPageFetch((input) => {
-      if (input === buildApiUrl('/presets/thumbnail/presign')) {
+    mockCreateScenePageFetch((input) => {
+      if (input === buildApiUrl('/scenes/thumbnail/presign')) {
         return Promise.resolve(
           jsonResponse(
             {
@@ -551,23 +551,23 @@ describe('CreatePresetPage', () => {
         )
       }
 
-      if (input === buildApiUrl('/presets')) {
+      if (input === buildApiUrl('/scenes')) {
         createAttempted = true
-        return Promise.resolve(jsonResponse({ presetId: 18 }, 201))
+        return Promise.resolve(jsonResponse({ sceneId: 18 }, 201))
       }
     })
 
     const user = userEvent.setup()
 
-    renderCreatePresetPage()
+    renderCreateScenePage()
 
-    await user.type(screen.getByLabelText(/preset name/i), 'Aurora Drift')
+    await user.type(screen.getByLabelText(/scene name/i), 'Aurora Drift')
     fireEvent.change(screen.getByLabelText(/upload thumbnail file/i), {
       target: {
         files: [new File(['cover'], 'cover.png', { type: 'image/png' })],
       },
     })
-    await user.click(screen.getByRole('button', { name: /create preset/i }))
+    await user.click(screen.getByRole('button', { name: /create scene/i }))
 
     expect(
       await screen.findByText(/thumbnail storage is unavailable right now\./i),
@@ -578,9 +578,9 @@ describe('CreatePresetPage', () => {
   it('surfaces advanced MAGE engine fields and the raw JSON editor in the Advanced section', async () => {
     storeSession()
 
-    mockCreatePresetPageFetch()
+    mockCreateScenePageFetch()
 
-    renderCreatePresetPage()
+    renderCreateScenePage()
 
     fireEvent.change(screen.getByLabelText(/jump to section/i), { target: { value: 'advanced' } })
 

--- a/src/pages/CreateScenePage.tsx
+++ b/src/pages/CreateScenePage.tsx
@@ -7,14 +7,14 @@ import { MagePlayer } from "../components/MagePlayer";
 import {
   EffectCard,
   NumberField,
-  PresetSection,
+  SceneSection,
   SelectField,
   SliderField,
   ToggleField,
   Vector3Field,
-} from "../components/PresetEditorControls";
+} from "../components/SceneEditorControls";
 import { parseApiError } from "../lib/authForm";
-import { uploadNewPresetThumbnail } from "../lib/presetThumbnailUpload";
+import { uploadNewSceneThumbnail } from "../lib/sceneThumbnailUpload";
 import {
   fetchAvailableTags,
   type TagResponse,
@@ -27,18 +27,18 @@ import {
   PASS_LABELS,
   prettyPrintSceneData,
   sanitizeSceneData,
-  SHADER_PRESETS,
+  SHADER_SCENES,
   SKYBOX_OPTIONS,
   TONE_MAPPING_OPTIONS,
   toDegrees,
   toRadians,
   type PersistedPassFlag,
-  type PresetPassId,
-  type PresetSceneData,
+  type ScenePassId,
+  type SceneData,
   type SceneEditorModel,
-} from "../lib/presetEditor";
+} from "../lib/sceneEditor";
 
-type CreatePresetFormErrors = Partial<
+type CreateSceneFormErrors = Partial<
   Record<"form" | "name" | "newTag" | "sceneData" | "tags" | "thumbnail", string>
 >;
 type EditorSectionId =
@@ -52,7 +52,7 @@ type EffectCategoryId = "color" | "finish" | "pattern" | "trail";
 type ThumbnailMode = "skip" | "upload";
 
 type PendingTagAttachment = {
-  presetId: number;
+  sceneId: number;
   tagIds: number[];
 };
 
@@ -65,7 +65,7 @@ type AdditionalPassConfig = {
   category: EffectCategoryId;
   description: string;
   flag: PersistedPassFlag;
-  passId: PresetPassId;
+  passId: ScenePassId;
 };
 
 type EditorSectionConfig = {
@@ -183,7 +183,7 @@ const additionalPassesByCategory: Record<
   ),
 };
 
-const passFlagsById: Partial<Record<PresetPassId, PersistedPassFlag>> = {
+const passFlagsById: Partial<Record<ScenePassId, PersistedPassFlag>> = {
   RGBShift: "rgbShift",
   afterImagePass: "afterImage",
   colorifyShader: "colorify",
@@ -225,13 +225,13 @@ function upsertTag(tags: TagResponse[], nextTag: TagResponse) {
   ]);
 }
 
-function parseCreatedPresetId(payload: unknown) {
+function parseCreatedSceneId(payload: unknown) {
   if (!payload || typeof payload !== "object") {
     return null;
   }
 
-  const presetId = (payload as { presetId?: unknown }).presetId;
-  return typeof presetId === "number" && presetId > 0 ? presetId : null;
+  const sceneId = (payload as { sceneId?: unknown }).sceneId;
+  return typeof sceneId === "number" && sceneId > 0 ? sceneId : null;
 }
 
 async function loadAvailableTagsFromBackend() {
@@ -239,15 +239,15 @@ async function loadAvailableTagsFromBackend() {
 }
 
 function buildShaderOptions(currentShader: string) {
-  const matchedPreset = SHADER_PRESETS.find(
-    (preset) => preset.shader.trim() === currentShader.trim(),
+  const matchedShaderScene = SHADER_SCENES.find(
+    (shaderScene) => shaderScene.shader.trim() === currentShader.trim(),
   );
-  const options = SHADER_PRESETS.map((preset) => ({
-    label: preset.label,
-    value: preset.id,
+  const options = SHADER_SCENES.map((shaderScene) => ({
+    label: shaderScene.label,
+    value: shaderScene.id,
   }));
 
-  if (!matchedPreset) {
+  if (!matchedShaderScene) {
     options.unshift({
       label: "Custom Shader",
       value: "custom",
@@ -255,9 +255,9 @@ function buildShaderOptions(currentShader: string) {
   }
 
   return {
-    matchedPreset,
+    matchedShaderScene,
     options,
-    value: matchedPreset?.id ?? "custom",
+    value: matchedShaderScene?.id ?? "custom",
   };
 }
 
@@ -307,7 +307,7 @@ function buildToneMappingOptions(currentMethod: number) {
   };
 }
 
-function describePassState(passId: PresetPassId, sceneModel: SceneEditorModel) {
+function describePassState(passId: ScenePassId, sceneModel: SceneEditorModel) {
   if (passId === "outputPass") {
     return sceneModel.fx.passes.outputPass ? "Enabled" : "Disabled";
   }
@@ -326,13 +326,13 @@ function describePassState(passId: PresetPassId, sceneModel: SceneEditorModel) {
 }
 
 function validateForm(name: string, sceneDataText: string) {
-  const errors: CreatePresetFormErrors = {};
-  let parsedSceneData: PresetSceneData | null = null;
+  const errors: CreateSceneFormErrors = {};
+  let parsedSceneData: SceneData | null = null;
 
   if (!name.trim()) {
-    errors.name = "Preset name is required.";
+    errors.name = "Scene name is required.";
   } else if (name.trim().length < 2) {
-    errors.name = "Preset name must be at least 2 characters.";
+    errors.name = "Scene name must be at least 2 characters.";
   }
 
   if (!sceneDataText.trim()) {
@@ -374,7 +374,7 @@ function validateThumbnailFile(file: File | null) {
   return null;
 }
 
-export function CreatePresetPage() {
+export function CreateScenePage() {
   const { authenticatedFetch } = useAuth();
   const navigate = useNavigate();
 
@@ -390,11 +390,11 @@ export function CreatePresetPage() {
   const [selectedTagIds, setSelectedTagIds] = useState<number[]>([]);
   const [tagSearchValue, setTagSearchValue] = useState("");
   const [isTagDropdownOpen, setIsTagDropdownOpen] = useState(false);
-  const [sceneData, setSceneData] = useState<PresetSceneData>(initialSceneData);
+  const [sceneData, setSceneData] = useState<SceneData>(initialSceneData);
   const [sceneDataText, setSceneDataText] = useState(() =>
     prettyPrintSceneData(initialSceneData),
   );
-  const [errors, setErrors] = useState<CreatePresetFormErrors>({});
+  const [errors, setErrors] = useState<CreateSceneFormErrors>({});
   const [tagsLoading, setTagsLoading] = useState(true);
   const [tagsError, setTagsError] = useState<string | null>(null);
   const [pendingTagAttachment, setPendingTagAttachment] =
@@ -407,7 +407,7 @@ export function CreatePresetPage() {
   const formErrorId = useId();
   const tagSearchInputId = useId();
   const thumbnailInputId = useId();
-  const titleId = "create-preset-title";
+  const titleId = "create-scene-title";
   const sceneModel = useMemo(() => getSceneEditorModel(sceneData), [sceneData]);
   const previewSceneData = useMemo(
     () => sanitizeSceneData(sceneData),
@@ -421,7 +421,7 @@ export function CreatePresetPage() {
     () => buildToneMappingOptions(sceneModel.fx.toneMapping.method),
     [sceneModel.fx.toneMapping.method],
   );
-  const selectedShaderPreset = shaderSelection.matchedPreset;
+  const selectedShaderScene = shaderSelection.matchedShaderScene;
   const selectedToneMapping =
     toneMappingSelection.matchedOption ?? TONE_MAPPING_OPTIONS[0];
   const normalizedTagSearchValue = normalizeTagName(tagSearchValue);
@@ -549,7 +549,7 @@ export function CreatePresetPage() {
     );
   }
 
-  function clearErrors(...fields: Array<keyof CreatePresetFormErrors>) {
+  function clearErrors(...fields: Array<keyof CreateSceneFormErrors>) {
     if (fields.length === 0) {
       setErrors({});
       return;
@@ -574,7 +574,7 @@ export function CreatePresetPage() {
     }
   }
 
-  function applySceneData(nextSceneData: PresetSceneData) {
+  function applySceneData(nextSceneData: SceneData) {
     const sanitizedSceneData = sanitizeSceneData(nextSceneData);
     setSceneData(sanitizedSceneData);
     setSceneDataText(prettyPrintSceneData(sanitizedSceneData));
@@ -830,7 +830,7 @@ export function CreatePresetPage() {
     }
   }
 
-  async function attachTagsToPreset(presetId: number, tagIds: number[]) {
+  async function attachTagsToScene(sceneId: number, tagIds: number[]) {
     const failures: TagAttachmentFailure[] = [];
 
     for (const tagId of tagIds) {
@@ -845,7 +845,7 @@ export function CreatePresetPage() {
       }
 
       try {
-        const response = await authenticatedFetch(`/presets/${presetId}/tags`, {
+        const response = await authenticatedFetch(`/scenes/${sceneId}/tags`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -861,7 +861,7 @@ export function CreatePresetPage() {
 
         if (
           response.status === 409 &&
-          apiError?.code === "PRESET_TAG_ALREADY_EXISTS"
+          apiError?.code === "SCENE_TAG_ALREADY_EXISTS"
         ) {
           continue;
         }
@@ -881,14 +881,14 @@ export function CreatePresetPage() {
     return failures;
   }
 
-  function movePass(passId: PresetPassId, direction: -1 | 1) {
+  function movePass(passId: ScenePassId, direction: -1 | 1) {
     if (passId === "outputPass") {
       return;
     }
 
     updateBranch("fx", (currentFx) => {
       const movablePasses = currentFx.passOrder.filter(
-        (currentPassId): currentPassId is Exclude<PresetPassId, "outputPass"> =>
+        (currentPassId): currentPassId is Exclude<ScenePassId, "outputPass"> =>
           currentPassId !== "outputPass",
       );
       const currentIndex = movablePasses.indexOf(passId);
@@ -921,26 +921,26 @@ export function CreatePresetPage() {
       setErrors({});
 
       try {
-        const attachFailures = await attachTagsToPreset(
-          pendingTagAttachment.presetId,
+        const attachFailures = await attachTagsToScene(
+          pendingTagAttachment.sceneId,
           pendingTagAttachment.tagIds,
         );
 
         if (attachFailures.length > 0) {
           setPendingTagAttachment({
-            presetId: pendingTagAttachment.presetId,
+            sceneId: pendingTagAttachment.sceneId,
             tagIds: attachFailures.map((failure) => failure.tagId),
           });
           setErrors({
-            form: `Preset created, but we still couldn't attach ${attachFailures
+            form: `Scene created, but we still couldn't attach ${attachFailures
               .map((failure) => failure.tagName)
-              .join(", ")}. Submit again to retry attachment for the existing preset. Additional editor changes will not be saved in this retry state.`,
+              .join(", ")}. Submit again to retry attachment for the existing scene. Additional editor changes will not be saved in this retry state.`,
           });
           return;
         }
 
         setPendingTagAttachment(null);
-        navigate("/my-presets");
+        navigate("/my-scenes");
       } finally {
         setIsSubmitting(false);
       }
@@ -973,10 +973,10 @@ export function CreatePresetPage() {
     try {
       const thumbnailObjectKey =
         thumbnailMode === "upload" && thumbnailFile
-          ? await uploadNewPresetThumbnail(authenticatedFetch, thumbnailFile)
+          ? await uploadNewSceneThumbnail(authenticatedFetch, thumbnailFile)
           : undefined;
 
-      const response = await authenticatedFetch("/presets", {
+      const response = await authenticatedFetch("/scenes", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -993,48 +993,48 @@ export function CreatePresetPage() {
           name: backendDetails.name,
           sceneData: backendDetails.sceneData,
           form:
-            apiError?.message ?? "Failed to create preset. Please try again.",
+            apiError?.message ?? "Failed to create scene. Please try again.",
         });
         return;
       }
 
-      const createdPresetPayload = (await response.json().catch(() => null)) as
+      const createdScenePayload = (await response.json().catch(() => null)) as
         | unknown
         | null;
-      const presetId = parseCreatedPresetId(createdPresetPayload);
+      const sceneId = parseCreatedSceneId(createdScenePayload);
 
-      if (presetId === null) {
+      if (sceneId === null) {
         setErrors({
           form:
-            "Preset was created, but the response did not include the new preset id for tag attachment.",
+            "Scene was created, but the response did not include the new scene id for tag attachment.",
         });
         return;
       }
 
       if (selectedTagIds.length > 0) {
-        const attachFailures = await attachTagsToPreset(presetId, selectedTagIds);
+        const attachFailures = await attachTagsToScene(sceneId, selectedTagIds);
 
         if (attachFailures.length > 0) {
           setPendingTagAttachment({
-            presetId,
+            sceneId,
             tagIds: attachFailures.map((failure) => failure.tagId),
           });
           setErrors({
-            form: `Preset created, but we couldn't attach ${attachFailures
+            form: `Scene created, but we couldn't attach ${attachFailures
               .map((failure) => failure.tagName)
-              .join(", ")}. Submit again to retry attachment for the existing preset. Additional editor changes will not be saved in this retry state.`,
+              .join(", ")}. Submit again to retry attachment for the existing scene. Additional editor changes will not be saved in this retry state.`,
           });
           return;
         }
       }
 
-      navigate("/my-presets");
+      navigate("/my-scenes");
     } catch (error) {
       setErrors({
         form:
           error instanceof Error && error.message.trim()
             ? error.message
-            : "Preset creation is unavailable right now. Please try again in a moment.",
+            : "Scene creation is unavailable right now. Please try again in a moment.",
       });
     } finally {
       setIsSubmitting(false);
@@ -1048,23 +1048,23 @@ export function CreatePresetPage() {
       titleId={titleId}
     >
       <AuthPageHeader
-        description="Build a preset with curated scene controls and effect shaping."
-        eyebrow="Preset Studio"
-        title="Create Preset"
+        description="Build a scene with curated controls and effect shaping."
+        eyebrow="Scene Studio"
+        title="Create Scene"
         titleId={titleId}
       />
 
       <form
         aria-describedby={errors.form ? formErrorId : undefined}
-        className="preset-editor-form"
+        className="scene-editor-form"
         noValidate
         onSubmit={handleSubmit}
       >
-        <div className="preset-editor-layout">
-          <div className="preset-editor-main">
-            <div className="preset-editor-toolbar">
-              <div className="field-group preset-editor-toolbar__name">
-                <label htmlFor="name">Preset Name</label>
+        <div className="scene-editor-layout">
+          <div className="scene-editor-main">
+            <div className="scene-editor-toolbar">
+              <div className="field-group scene-editor-toolbar__name">
+                <label htmlFor="name">Scene Name</label>
                 <input
                   id="name"
                   minLength={2}
@@ -1090,7 +1090,7 @@ export function CreatePresetPage() {
                 )}
               </div>
 
-              <div className="preset-editor-toolbar__metadata">
+              <div className="scene-editor-toolbar__metadata">
                 <div className="field-group">
                   <label htmlFor="description">Description</label>
                   <textarea
@@ -1098,18 +1098,18 @@ export function CreatePresetPage() {
                     onChange={(event) =>
                       setDescription(event.currentTarget.value)
                     }
-                    placeholder="Describe the mood, motion, or moment this preset is built for."
+                    placeholder="Describe the mood, motion, or moment this scene is built for."
                     rows={5}
                     value={description}
                   />
                 </div>
 
                 <div className="field-group">
-                  <div className="preset-tag-editor__header">
-                    <span className="preset-tag-editor__label">Tags</span>
+                  <div className="scene-tag-editor__header">
+                    <span className="scene-tag-editor__label">Tags</span>
                     {pendingTagAttachment ? (
                       <span className="field-hint">
-                        Retry mode for preset #{pendingTagAttachment.presetId}
+                        Retry mode for scene #{pendingTagAttachment.sceneId}
                       </span>
                     ) : null}
                   </div>
@@ -1120,12 +1120,12 @@ export function CreatePresetPage() {
                   </p>
 
                   {tagsError ? (
-                    <div className="preset-tag-editor__status">
+                    <div className="scene-tag-editor__status">
                       <p className="field-error" role="alert">
                         {tagsError}
                       </p>
                       <button
-                        className="preset-secondary-button"
+                        className="scene-secondary-button"
                         disabled={tagsLoading}
                         onClick={() => {
                           void reloadAvailableTags();
@@ -1138,7 +1138,7 @@ export function CreatePresetPage() {
                   ) : null}
 
                   <div
-                    className="preset-tag-editor__picker"
+                    className="scene-tag-editor__picker"
                     role="group"
                     aria-label="Available tags"
                   >
@@ -1160,15 +1160,15 @@ export function CreatePresetPage() {
                       </div>
                     ) : (
                       <div
-                        className="preset-tag-dropdown"
+                        className="scene-tag-dropdown"
                         ref={tagDropdownRef}
                       >
-                        <div className="preset-tag-dropdown__search">
+                        <div className="scene-tag-dropdown__search">
                           <label htmlFor={tagSearchInputId}>
                             Select existing tags
                           </label>
                           <input
-                            aria-controls="preset-tag-dropdown-panel"
+                            aria-controls="scene-tag-dropdown-panel"
                             aria-describedby={
                               errors.newTag ? "tag-editor-error" : undefined
                             }
@@ -1209,16 +1209,16 @@ export function CreatePresetPage() {
 
                         {isTagDropdownOpen ? (
                           <div
-                            className="preset-tag-dropdown__panel"
-                            id="preset-tag-dropdown-panel"
+                            className="scene-tag-dropdown__panel"
+                            id="scene-tag-dropdown-panel"
                           >
                             {filteredSelectableTags.length > 0 ||
                             canCreateTagFromSearch ? (
-                              <div className="preset-tag-dropdown__options">
+                              <div className="scene-tag-dropdown__options">
                                 {filteredSelectableTags.map((tag) => (
                                   <button
                                     key={tag.tagId}
-                                    className="preset-tag-dropdown__option"
+                                    className="scene-tag-dropdown__option"
                                     disabled={isCreatingTag}
                                     onClick={() => toggleTagSelection(tag.tagId)}
                                     type="button"
@@ -1228,7 +1228,7 @@ export function CreatePresetPage() {
                                 ))}
                                 {canCreateTagFromSearch ? (
                                   <button
-                                    className="preset-tag-dropdown__option preset-tag-dropdown__option--create"
+                                    className="scene-tag-dropdown__option scene-tag-dropdown__option--create"
                                     disabled={isCreatingTag}
                                     onClick={() => {
                                       void handleCreateTag();
@@ -1266,12 +1266,12 @@ export function CreatePresetPage() {
                     )}
                   </div>
 
-                  <div className="preset-tag-editor__selected">
-                    <span className="preset-tag-editor__selected-label">
+                  <div className="scene-tag-editor__selected">
+                    <span className="scene-tag-editor__selected-label">
                       Selected tags
                     </span>
                     {selectedTags.length > 0 ? (
-                      <div className="preset-tag-editor__selected-list">
+                      <div className="scene-tag-editor__selected-list">
                         {selectedTags.map((tag) => (
                           <button
                             key={tag.tagId}
@@ -1307,11 +1307,11 @@ export function CreatePresetPage() {
 
                 <div className="field-group">
                   <label htmlFor={thumbnailInputId}>Thumbnail</label>
-                  <div className="preset-thumbnail-picker">
+                  <div className="scene-thumbnail-picker">
                     <input
                       accept="image/jpeg,image/png,image/webp,image/gif"
                       aria-label="Upload thumbnail file"
-                      className="preset-thumbnail-input"
+                      className="scene-thumbnail-input"
                       id={thumbnailInputId}
                       onChange={(event) =>
                         handleThumbnailFileChange(event.currentTarget.files)
@@ -1320,40 +1320,40 @@ export function CreatePresetPage() {
                       type="file"
                     />
 
-                    <div className="preset-thumbnail-picker__grid">
+                    <div className="scene-thumbnail-picker__grid">
                       <button
-                        className={`preset-thumbnail-choice${
+                        className={`scene-thumbnail-choice${
                           thumbnailMode === "upload" ? " is-selected" : ""
                         }`}
                         onClick={handleThumbnailUploadClick}
                         type="button"
                       >
-                        <span className="preset-thumbnail-choice__eyebrow">
+                        <span className="scene-thumbnail-choice__eyebrow">
                           Upload
                         </span>
-                        <strong className="preset-thumbnail-choice__title">
+                        <strong className="scene-thumbnail-choice__title">
                           Upload File
                         </strong>
-                        <span className="preset-thumbnail-choice__description">
+                        <span className="scene-thumbnail-choice__description">
                           Use a custom image.
                         </span>
                       </button>
 
                       <button
-                        className={`preset-thumbnail-choice${
+                        className={`scene-thumbnail-choice${
                           thumbnailMode === "skip" ? " is-selected" : ""
                         }`}
                         onClick={() => handleThumbnailModeChange("skip")}
                         type="button"
                       >
-                        <span className="preset-thumbnail-choice__eyebrow">
+                        <span className="scene-thumbnail-choice__eyebrow">
                           Optional
                         </span>
-                        <strong className="preset-thumbnail-choice__title">
+                        <strong className="scene-thumbnail-choice__title">
                           Skip for Now
                         </strong>
-                        <span className="preset-thumbnail-choice__description">
-                          Create the preset without a thumbnail.
+                        <span className="scene-thumbnail-choice__description">
+                          Create the scene without a thumbnail.
                         </span>
                       </button>
                     </div>
@@ -1374,7 +1374,7 @@ export function CreatePresetPage() {
                 <div className="field-group">
                   <label htmlFor="playlists">Playlists</label>
                   <select
-                    className="preset-select"
+                    className="scene-select"
                     id="playlists"
                     onChange={(event) =>
                       setPlaylistValue(event.currentTarget.value)
@@ -1391,29 +1391,29 @@ export function CreatePresetPage() {
                 </div>
               </div>
 
-              <div className="preset-editor-toolbar__controls">
-                <div className="preset-editor-toolbar__control-group preset-editor-toolbar__control-group--navigation">
-                  <div className="preset-editor-toolbar__control-copy">
-                    <span className="preset-editor-toolbar__eyebrow">
+              <div className="scene-editor-toolbar__controls">
+                <div className="scene-editor-toolbar__control-group scene-editor-toolbar__control-group--navigation">
+                  <div className="scene-editor-toolbar__control-copy">
+                    <span className="scene-editor-toolbar__eyebrow">
                       Navigation
                     </span>
                     <label
-                      className="preset-field__label"
+                      className="scene-field__label"
                       htmlFor="section-jump"
                     >
                       Jump To Section
                     </label>
                   </div>
 
-                  <div className="preset-editor-toolbar__navigation-shell">
+                  <div className="scene-editor-toolbar__navigation-shell">
                     <span
                       aria-hidden="true"
-                      className="preset-editor-toolbar__navigation-icon"
+                      className="scene-editor-toolbar__navigation-icon"
                     >
                       <NavigationIcon />
                     </span>
                     <select
-                      className="preset-select preset-select--navigation"
+                      className="scene-select scene-select--navigation"
                       id="section-jump"
                       onChange={(event) =>
                         handleSectionJump(
@@ -1440,30 +1440,30 @@ export function CreatePresetPage() {
             ) : null}
 
             {sectionMenuValue === "scene" ? (
-              <PresetSection
+              <SceneSection
                 description="Choose the visual style, background environment, and overall size of the scene."
                 title="Scene"
               >
-                <div className="preset-editor-grid preset-editor-grid--3">
+                <div className="scene-editor-grid scene-editor-grid--3">
                   <SelectField
                     description={
-                      selectedShaderPreset?.description ??
+                      selectedShaderScene?.description ??
                       "Custom shader text is currently active."
                     }
                     id="shader"
                     label="Shader"
                     onChange={(nextValue) => {
-                      const nextShaderPreset = SHADER_PRESETS.find(
-                        (preset) => preset.id === nextValue,
+                      const nextShaderScene = SHADER_SCENES.find(
+                        (shaderScene) => shaderScene.id === nextValue,
                       );
 
-                      if (!nextShaderPreset) {
+                      if (!nextShaderScene) {
                         return;
                       }
 
                       updateBranch("visualizer", (currentVisualizer) => ({
                         ...currentVisualizer,
-                        shader: nextShaderPreset.shader,
+                        shader: nextShaderScene.shader,
                       }));
                     }}
                     options={shaderSelection.options}
@@ -1471,7 +1471,7 @@ export function CreatePresetPage() {
                   />
 
                   <SelectField
-                    description="Pick from the bundled skybox presets instead of entering loader-specific values."
+                    description="Pick from the bundled skybox options instead of entering loader-specific values."
                     id="skybox"
                     label="Skybox"
                     onChange={(nextValue) =>
@@ -1508,7 +1508,7 @@ export function CreatePresetPage() {
                 <div className="field-group">
                   <label htmlFor="shader-source">Custom Shader</label>
                   <textarea
-                    className="preset-textarea"
+                    className="scene-textarea"
                     id="shader-source"
                     onChange={(event) =>
                       updateBranch("visualizer", (currentVisualizer) => ({
@@ -1521,18 +1521,18 @@ export function CreatePresetPage() {
                   />
                   <p className="field-hint">
                     This is the actual `visualizer.shader` source that ships in
-                    the preset. Choosing a shader above swaps this text.
+                    the scene. Choosing a shader above swaps this text.
                   </p>
                 </div>
-              </PresetSection>
+              </SceneSection>
             ) : null}
 
             {sectionMenuValue === "camera" ? (
-              <PresetSection
+              <SceneSection
                 description="Set the starting view, framing, and lens settings for the scene."
                 title="Camera"
               >
-                <div className="preset-editor-grid preset-editor-grid--2">
+                <div className="scene-editor-grid scene-editor-grid--2">
                   <Vector3Field
                     description="The camera position in the scene."
                     id="camera-position"
@@ -1547,7 +1547,7 @@ export function CreatePresetPage() {
                   />
 
                   <Vector3Field
-                    description="Where the camera points while the preset loads."
+                    description="Where the camera points while the scene loads."
                     id="camera-target"
                     label="Camera Target"
                     onChange={(nextValue) =>
@@ -1607,15 +1607,15 @@ export function CreatePresetPage() {
                     value={sceneModel.controls.zoom0}
                   />
                 </div>
-              </PresetSection>
+              </SceneSection>
             ) : null}
 
             {sectionMenuValue === "motion" ? (
-              <PresetSection
+              <SceneSection
                 description="Adjust how the scene moves and how strongly it responds to audio and input."
                 title="Motion"
               >
-                <div className="preset-editor-grid preset-editor-grid--2">
+                <div className="scene-editor-grid scene-editor-grid--2">
                   <NumberField
                     description="Overall engine time multiplier."
                     id="time-multiplier"
@@ -1726,7 +1726,7 @@ export function CreatePresetPage() {
                     value={sceneModel.intent.easing_speed}
                   />
 
-                  <div className="preset-editor-grid__item--full">
+                  <div className="scene-editor-grid__item--full">
                     <ToggleField
                       checked={sceneModel.intent.autoRotate}
                       description="Keep the scene gently rotating on its own."
@@ -1741,20 +1741,20 @@ export function CreatePresetPage() {
                     />
                   </div>
                 </div>
-              </PresetSection>
+              </SceneSection>
             ) : null}
 
             {sectionMenuValue === "effects" ? (
-              <PresetSection
+              <SceneSection
                 description="Add glow, color treatment, distortion, and other finishing effects."
                 title="Effects"
               >
-                <div className="preset-effects-grid">
-                  <div className="preset-effects-category">
-                    <h3 className="preset-effects-category__title">
+                <div className="scene-effects-grid">
+                  <div className="scene-effects-category">
+                    <h3 className="scene-effects-category__title">
                       Finish &amp; Output
                     </h3>
-                    <div className="preset-effects-category__grid">
+                    <div className="scene-effects-category__grid">
                       <EffectCard
                         description="Soft glow for bright edges and highlights."
                         enabled={sceneModel.fx.bloom.enabled}
@@ -1769,7 +1769,7 @@ export function CreatePresetPage() {
                         }
                         title="Bloom"
                       >
-                        <div className="preset-editor-grid preset-editor-grid--2">
+                        <div className="scene-editor-grid scene-editor-grid--2">
                           <SliderField
                             description="Glow intensity."
                             id="bloom-strength"
@@ -1840,13 +1840,13 @@ export function CreatePresetPage() {
                           }))
                         }
                         footer={
-                          <p className="preset-effect-footnote">
+                          <p className="scene-effect-footnote">
                             {selectedToneMapping.description}
                           </p>
                         }
                         title="Output Pass"
                       >
-                        <div className="preset-editor-grid preset-editor-grid--2">
+                        <div className="scene-editor-grid scene-editor-grid--2">
                           <SelectField
                             description="Switch between the renderer tone-mapping methods used by the MAGE engine."
                             id="tone-mapping-method"
@@ -1890,11 +1890,11 @@ export function CreatePresetPage() {
                     </div>
                   </div>
 
-                  <div className="preset-effects-category">
-                    <h3 className="preset-effects-category__title">
+                  <div className="scene-effects-category">
+                    <h3 className="scene-effects-category__title">
                       Channel &amp; Motion
                     </h3>
-                    <div className="preset-effects-category__grid">
+                    <div className="scene-effects-category__grid">
                       <EffectCard
                         description="Shift the red, green, and blue channels apart for chromatic distortion."
                         enabled={sceneModel.fx.passes.rgbShift}
@@ -1909,7 +1909,7 @@ export function CreatePresetPage() {
                         }
                         title="RGB Shift"
                       >
-                        <div className="preset-editor-grid preset-editor-grid--2">
+                        <div className="scene-editor-grid scene-editor-grid--2">
                           <SliderField
                             description="Offset amount between color channels."
                             formatValue={(value) => formatFixed(value, 3)}
@@ -2002,11 +2002,11 @@ export function CreatePresetPage() {
                     </div>
                   </div>
 
-                  <div className="preset-effects-category">
-                    <h3 className="preset-effects-category__title">
+                  <div className="scene-effects-category">
+                    <h3 className="scene-effects-category__title">
                       Color &amp; Tone
                     </h3>
-                    <div className="preset-effects-category__grid">
+                    <div className="scene-effects-category__grid">
                       <EffectCard
                         description="Wash the output toward a chosen tint."
                         enabled={sceneModel.fx.passes.colorify}
@@ -2021,21 +2021,21 @@ export function CreatePresetPage() {
                         }
                         title="Colorify"
                       >
-                        <div className="preset-field">
-                          <div className="preset-field__label-row">
+                        <div className="scene-field">
+                          <div className="scene-field__label-row">
                             <label
-                              className="preset-field__label"
+                              className="scene-field__label"
                               htmlFor="colorify-color"
                             >
                               Color
                             </label>
                           </div>
-                          <p className="preset-field__description">
+                          <p className="scene-field__description">
                             Choose the tint used by the colorify pass.
                           </p>
-                          <div className="preset-color-field">
+                          <div className="scene-color-field">
                             <input
-                              className="preset-color-field__picker"
+                              className="scene-color-field__picker"
                               id="colorify-color"
                               onChange={(event) =>
                                 updateBranch("fx", (currentFx) => ({
@@ -2065,11 +2065,11 @@ export function CreatePresetPage() {
                     </div>
                   </div>
 
-                  <div className="preset-effects-category">
-                    <h3 className="preset-effects-category__title">
+                  <div className="scene-effects-category">
+                    <h3 className="scene-effects-category__title">
                       Pattern &amp; Structure
                     </h3>
-                    <div className="preset-effects-category__grid">
+                    <div className="scene-effects-category__grid">
                       <EffectCard
                         description="Mirror the frame into repeating radial segments."
                         enabled={sceneModel.fx.passes.kaleid}
@@ -2084,7 +2084,7 @@ export function CreatePresetPage() {
                         }
                         title="Kaleidoscope"
                       >
-                        <div className="preset-editor-grid preset-editor-grid--2">
+                        <div className="scene-editor-grid scene-editor-grid--2">
                           <SliderField
                             description="The number of mirrored slices in the frame."
                             formatValue={(value) => formatFixed(value, 0)}
@@ -2140,28 +2140,28 @@ export function CreatePresetPage() {
                     </div>
                   </div>
                 </div>
-              </PresetSection>
+              </SceneSection>
             ) : null}
 
             {sectionMenuValue === "pass-order" ? (
-              <PresetSection
+              <SceneSection
                 description="Change the order of effects to control how the final image is layered. Output always stays last."
                 title="Pass Order"
               >
-                <ol className="preset-pass-order">
+                <ol className="scene-pass-order">
                   {sceneModel.fx.passOrder.map((passId, index) => {
                     const isOutputPass = passId === "outputPass";
 
                     return (
-                      <li className="preset-pass-order__item" key={passId}>
-                        <div className="preset-pass-order__copy">
+                      <li className="scene-pass-order__item" key={passId}>
+                        <div className="scene-pass-order__copy">
                           <strong>{PASS_LABELS[passId]}</strong>
                           <span>{describePassState(passId, sceneModel)}</span>
                         </div>
-                        <div className="preset-pass-order__actions">
+                        <div className="scene-pass-order__actions">
                           <button
                             aria-label={`Move ${PASS_LABELS[passId]} up`}
-                            className="preset-order-button"
+                            className="scene-order-button"
                             disabled={isOutputPass || index === 0}
                             onClick={() => movePass(passId, -1)}
                             type="button"
@@ -2170,7 +2170,7 @@ export function CreatePresetPage() {
                           </button>
                           <button
                             aria-label={`Move ${PASS_LABELS[passId]} down`}
-                            className="preset-order-button"
+                            className="scene-order-button"
                             disabled={
                               isOutputPass ||
                               index >= sceneModel.fx.passOrder.length - 2
@@ -2185,18 +2185,18 @@ export function CreatePresetPage() {
                     );
                   })}
                 </ol>
-              </PresetSection>
+              </SceneSection>
             ) : null}
 
             {sectionMenuValue === "advanced" ? (
-              <PresetSection
-                description="Edit advanced settings, startup values, and raw preset JSON."
+              <SceneSection
+                description="Edit advanced settings, startup values, and raw scene JSON."
                 title="Advanced"
               >
-                <div className="preset-advanced-stack">
-                  <div className="preset-editor-grid preset-editor-grid--2">
+                <div className="scene-advanced-stack">
+                  <div className="scene-editor-grid scene-editor-grid--2">
                     <NumberField
-                      description="Experimental compact-preset field exported by the library."
+                      description="Experimental compact scene field exported by the library."
                       id="camera-orientation-mode"
                       label="Camera Orientation Mode"
                       min={0}
@@ -2214,7 +2214,7 @@ export function CreatePresetPage() {
                     />
 
                     <NumberField
-                      description="Experimental compact-preset field exported by the library."
+                      description="Experimental compact scene field exported by the library."
                       id="camera-orientation-speed"
                       label="Camera Orientation Speed"
                       min={0}
@@ -2232,11 +2232,11 @@ export function CreatePresetPage() {
                   <div className="field-group">
                     <label>Runtime State</label>
                     <p className="field-hint">
-                      Seed low-level engine values for debugging or for presets
+                      Seed low-level engine values for debugging or for scenes
                       that depend on non-default startup state.
                     </p>
                   </div>
-                  <div className="preset-editor-grid preset-editor-grid--3">
+                  <div className="scene-editor-grid scene-editor-grid--3">
                     <NumberField
                       description="Low-level runtime state."
                       id="state-size"
@@ -2318,17 +2318,17 @@ export function CreatePresetPage() {
                   </div>
 
                   <div className="field-group">
-                    <div className="preset-advanced-header">
+                    <div className="scene-advanced-header">
                       <div>
                         <label htmlFor="sceneData">Scene Data JSON</label>
                         <p className="field-hint">
                           Raw scene data stays available here. While the JSON is
-                          invalid, the preview keeps the last valid preset
+                          invalid, the preview keeps the last valid scene
                           state.
                         </p>
                       </div>
                       <button
-                        className="preset-secondary-button"
+                        className="scene-secondary-button"
                         onClick={handleFormatJson}
                         type="button"
                       >
@@ -2340,7 +2340,7 @@ export function CreatePresetPage() {
                         errors.sceneData ? "sceneData-error" : "sceneData-hint"
                       }
                       aria-invalid={Boolean(errors.sceneData)}
-                      className="preset-textarea preset-textarea--code"
+                      className="scene-textarea scene-textarea--code"
                       id="sceneData"
                       name="sceneData"
                       onChange={(event) =>
@@ -2361,34 +2361,34 @@ export function CreatePresetPage() {
                     ) : (
                       <p className="field-hint" id="sceneData-hint">
                         Structured controls above keep this JSON in sync with
-                        the current preset.
+                        the current scene.
                       </p>
                     )}
                   </div>
                 </div>
-              </PresetSection>
+              </SceneSection>
             ) : null}
 
             <button
-              className="demo-link auth-submit preset-editor-submit"
+              className="demo-link auth-submit scene-editor-submit"
               disabled={isSubmitting}
               type="submit"
             >
               {isSubmitting
                 ? pendingTagAttachment
                   ? "Retrying tag attachment..."
-                  : "Creating preset..."
+                  : "Creating scene..."
                 : pendingTagAttachment
                   ? "Retry tag attachment"
-                  : "Create preset"}
+                  : "Create scene"}
             </button>
           </div>
 
-          <aside className="preset-editor-preview">
-            <section className="surface surface--soft preset-editor-preview__card">
-              <div className="preset-editor-preview__header">
+          <aside className="scene-editor-preview">
+            <section className="surface surface--soft scene-editor-preview__card">
+              <div className="scene-editor-preview__header">
                 <div>
-                  <span className="preset-editor-toolbar__eyebrow">
+                  <span className="scene-editor-toolbar__eyebrow">
                     Preview
                   </span>
                   <h2>Live Preview</h2>
@@ -2396,7 +2396,7 @@ export function CreatePresetPage() {
               </div>
 
               <MagePlayer
-                className="preset-editor-preview__player"
+                className="scene-editor-preview__player"
                 sceneBlob={previewSceneData}
               />
             </section>

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -25,8 +25,8 @@ vi.mock('../components/MagePlayer', () => ({
   MagePlayer: () => <div>Preview player</div>,
 }))
 
-vi.mock('./PresetsPage', () => ({
-  PresetsPage: () => <div>Presets page</div>,
+vi.mock('./ScenesPage', () => ({
+  ScenesPage: () => <div>Scenes page</div>,
 }))
 
 describe('HomePage', () => {
@@ -47,11 +47,11 @@ describe('HomePage', () => {
 
     expect(screen.getByRole('heading', { name: 'MAGE' })).toBeInTheDocument()
     expect(screen.getByText('Preview player')).toBeInTheDocument()
-    expect(screen.queryByRole('link', { name: /browse presets/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /browse scenes/i })).not.toBeInTheDocument()
     expect(screen.queryByRole('link', { name: /create an account/i })).not.toBeInTheDocument()
   })
 
-  it('shows preset discovery for authenticated users', () => {
+  it('shows scene discovery for authenticated users', () => {
     authState = {
       ...authState,
       accessToken: 'token',
@@ -66,7 +66,7 @@ describe('HomePage', () => {
 
     render(<HomePage />)
 
-    expect(screen.getByText('Presets page')).toBeInTheDocument()
+    expect(screen.getByText('Scenes page')).toBeInTheDocument()
     expect(screen.queryByRole('heading', { name: 'MAGE' })).not.toBeInTheDocument()
   })
 })

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,9 +1,9 @@
 import { useAuth } from '../auth/AuthContext'
 import { MagePlayer } from '../components/MagePlayer'
 import type { MageSceneBlob } from '../lib/magePlayerAdapter'
-import { PresetsPage } from './PresetsPage'
+import { ScenesPage } from './ScenesPage'
 
-const HOME_PAGE_PRESET_SCENE = {
+const HOME_PAGE_SCENE = {
   visualizer: {
     shader: `
       let size = input()
@@ -47,15 +47,15 @@ export function HomePage() {
   const { accessToken, isAuthenticated, isRestoringSession } = useAuth()
 
   if (isAuthenticated) {
-    return <PresetsPage />
+    return <ScenesPage />
   }
 
   if (isRestoringSession && accessToken) {
     return (
       <main className="surface surface--hero home-hero">
-        <div className="eyebrow">Presets</div>
-        <h1>Loading presets...</h1>
-        <p className="page-lead">MAGE is restoring your account before opening preset discovery.</p>
+        <div className="eyebrow">Scenes</div>
+        <h1>Loading scenes...</h1>
+        <p className="page-lead">MAGE is restoring your account before opening scene discovery.</p>
       </main>
     )
   }
@@ -65,10 +65,10 @@ export function HomePage() {
       <div className="eyebrow">Preview</div>
       <h1>MAGE</h1>
       <p className="page-lead">Musical Autonomous Generated Environments</p>
-      <section className="home-preview-section" aria-label="Live preset preview">
+      <section className="home-preview-section" aria-label="Live scene preview">
         <MagePlayer
-          ariaLabel="MAGE live preset preview"
-          sceneBlob={HOME_PAGE_PRESET_SCENE}
+          ariaLabel="MAGE live scene preview"
+          sceneBlob={HOME_PAGE_SCENE}
         />
       </section>
       <p className="page-footnote">The full platform experience is currently in development.</p>

--- a/src/pages/MyScenesPage.test.tsx
+++ b/src/pages/MyScenesPage.test.tsx
@@ -9,8 +9,8 @@ import {
 } from '../auth/AuthContext'
 import { buildApiUrl } from '../lib/api'
 import { LoginPage } from './LoginPage'
-import { MyPresetsPage } from './MyPresetsPage'
-import { PresetDetailPage } from './PresetDetailPage'
+import { MyScenesPage } from './MyScenesPage'
+import { SceneDetailPage } from './SceneDetailPage'
 
 vi.mock('../components/MagePlayer', () => ({
   MagePlayer: ({
@@ -31,24 +31,24 @@ vi.mock('../components/MagePlayer', () => ({
 const storedUser: AuthenticatedUser = {
   userId: 8,
   email: 'artist@example.com',
-  displayName: 'Preset Artist',
+  displayName: 'Scene Artist',
   authProvider: 'LOCAL',
 }
 
-const mockPresets = [
+const mockScenes = [
   {
-    presetId: 1,
+    sceneId: 1,
     ownerUserId: 42,
     name: 'Aurora Drift',
     description: 'Soft teal bloom with low-end drift.',
     sceneData: {
       visualizer: { shader: 'nebula' },
     },
-    thumbnailRef: 'thumbnails/preset-1.png',
+    thumbnailRef: 'thumbnails/scene-1.png',
     createdAt: '2026-04-06T14:00:00Z',
   },
   {
-    presetId: 2,
+    sceneId: 2,
     ownerUserId: 42,
     name: 'Signal Bloom',
     sceneData: {
@@ -58,13 +58,13 @@ const mockPresets = [
     createdAt: '2026-04-06T14:10:00Z',
   },
   {
-    presetId: 3,
+    sceneId: 3,
     ownerUserId: 42,
-    name: 'Very Long Preset Name To Test Wrapping In The Card Layout',
+    name: 'Very Long Scene Name To Test Wrapping In The Card Layout',
     sceneData: {
       visualizer: { shader: 'glacier' },
     },
-    thumbnailRef: 'thumbnails/preset-3.png',
+    thumbnailRef: 'thumbnails/scene-3.png',
     createdAt: '2026-04-06T14:20:00Z',
   },
 ]
@@ -88,63 +88,63 @@ function storeSession() {
   )
 }
 
-function renderMyPresetsPage(initialEntries = ['/my-presets']) {
+function renderMyScenesPage(initialEntries = ['/my-scenes']) {
   return render(
     <MemoryRouter initialEntries={initialEntries}>
       <AuthProvider>
         <Routes>
           <Route path="/login" element={<LoginPage />} />
-          <Route path="/my-presets" element={<MyPresetsPage />} />
-          <Route path="/presets/:id" element={<PresetDetailPage />} />
+          <Route path="/my-scenes" element={<MyScenesPage />} />
+          <Route path="/scenes/:id" element={<SceneDetailPage />} />
         </Routes>
       </AuthProvider>
     </MemoryRouter>,
   )
 }
 
-describe('MyPresetsPage', () => {
+describe('MyScenesPage', () => {
   it('redirects signed-out visitors to login', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch')
 
-    renderMyPresetsPage()
+    renderMyScenesPage()
 
     expect(await screen.findByRole('heading', { name: /login/i })).toBeInTheDocument()
     expect(fetchSpy).not.toHaveBeenCalled()
   })
 
-  it('shows a loading state while presets are being fetched', async () => {
+  it('shows a loading state while scenes are being fetched', async () => {
     storeSession()
 
-    let resolvePresetsResponse: ((value: Response) => void) | undefined
+    let resolveScenesResponse: ((value: Response) => void) | undefined
 
     vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
       if (input === buildApiUrl('/users/me')) {
         return Promise.resolve(jsonResponse(storedUser))
       }
 
-      if (input === buildApiUrl('/users/8/presets')) {
+      if (input === buildApiUrl('/users/8/scenes')) {
         return new Promise<Response>((resolve) => {
-          resolvePresetsResponse = resolve
+          resolveScenesResponse = resolve
         })
       }
 
       throw new Error(`Unexpected request: ${String(input)}`)
     })
 
-    renderMyPresetsPage()
+    renderMyScenesPage()
 
-    expect(await screen.findAllByText(/loading presets/i)).not.toHaveLength(0)
-    await waitFor(() => expect(resolvePresetsResponse).toBeDefined())
+    expect(await screen.findAllByText(/loading scenes/i)).not.toHaveLength(0)
+    await waitFor(() => expect(resolveScenesResponse).toBeDefined())
 
-    resolvePresetsResponse?.(
+    resolveScenesResponse?.(
       jsonResponse([]),
     )
 
-    expect(await screen.findByText(/no presets yet/i)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /add sample presets/i })).toBeInTheDocument()
+    expect(await screen.findByText(/no scenes yet/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /add sample scenes/i })).toBeInTheDocument()
   })
 
-  it('renders the authenticated users presets and opens the preset detail route', async () => {
+  it('renders the authenticated users scenes and opens the scene detail route', async () => {
     storeSession()
 
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
@@ -152,7 +152,7 @@ describe('MyPresetsPage', () => {
         return Promise.resolve(jsonResponse(storedUser))
       }
 
-      if (input === buildApiUrl('/users/8/presets')) {
+      if (input === buildApiUrl('/users/8/scenes')) {
         return Promise.resolve(
           jsonResponse([
             {
@@ -170,16 +170,16 @@ describe('MyPresetsPage', () => {
         )
       }
 
-      if (input === buildApiUrl('/presets/12')) {
+      if (input === buildApiUrl('/scenes/12')) {
         return Promise.resolve(
           jsonResponse({
-            presetId: 12,
+            sceneId: 12,
             ownerUserId: 8,
             name: 'Aurora Drift',
             sceneData: {
               visualizer: { shader: 'nebula' },
             },
-            thumbnailRef: 'thumbnails/preset-12.png',
+            thumbnailRef: 'thumbnails/scene-12.png',
             createdAt: '2026-04-06T14:00:00Z',
           }),
         )
@@ -189,28 +189,28 @@ describe('MyPresetsPage', () => {
     })
     const user = userEvent.setup()
 
-    renderMyPresetsPage()
+    renderMyScenesPage()
 
     await waitFor(() =>
       expect(fetchSpy).toHaveBeenCalledWith(
-        buildApiUrl('/users/8/presets'),
+        buildApiUrl('/users/8/scenes'),
         expect.objectContaining({
           headers: expect.any(Headers),
         }),
       ),
     )
 
-    const presetLink = await screen.findByRole('link', { name: /aurora drift/i })
+    const sceneLink = await screen.findByRole('link', { name: /aurora drift/i })
 
     expect(screen.getByRole('link', { name: /signal bloom/i })).toBeInTheDocument()
 
-    await user.click(presetLink)
+    await user.click(sceneLink)
 
     expect(await screen.findByTestId('mage-player')).toHaveTextContent('player-ready')
     expect(screen.getByRole('heading', { name: /aurora drift/i })).toBeInTheDocument()
   })
 
-  it('renders the populated preset state with thumbnails, fallback UI, and navigation', async () => {
+  it('renders the populated scene state with thumbnails, fallback UI, and navigation', async () => {
     storeSession()
 
     vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
@@ -218,20 +218,20 @@ describe('MyPresetsPage', () => {
         return Promise.resolve(jsonResponse(storedUser))
       }
 
-      if (input === buildApiUrl('/users/8/presets')) {
-        return Promise.resolve(jsonResponse(mockPresets))
+      if (input === buildApiUrl('/users/8/scenes')) {
+        return Promise.resolve(jsonResponse(mockScenes))
       }
 
-      if (input === buildApiUrl('/presets/1')) {
+      if (input === buildApiUrl('/scenes/1')) {
         return Promise.resolve(
           jsonResponse({
-            presetId: 1,
+            sceneId: 1,
             ownerUserId: 42,
             name: 'Aurora Drift',
             sceneData: {
               visualizer: { shader: 'nebula' },
             },
-            thumbnailRef: 'thumbnails/preset-1.png',
+            thumbnailRef: 'thumbnails/scene-1.png',
             createdAt: '2026-04-06T14:00:00Z',
           }),
         )
@@ -241,14 +241,14 @@ describe('MyPresetsPage', () => {
     })
     const user = userEvent.setup()
 
-    renderMyPresetsPage()
+    renderMyScenesPage()
 
-    const auroraPreset = await screen.findByRole('link', { name: /aurora drift/i })
+    const auroraScene = await screen.findByRole('link', { name: /aurora drift/i })
 
-    expect(auroraPreset).toBeInTheDocument()
+    expect(auroraScene).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /signal bloom/i })).toBeInTheDocument()
     expect(
-      screen.getByRole('link', { name: /very long preset name to test wrapping in the card layout/i }),
+      screen.getByRole('link', { name: /very long scene name to test wrapping in the card layout/i }),
     ).toBeInTheDocument()
     expect(screen.getAllByText('Public')).toHaveLength(4)
     expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument()
@@ -257,7 +257,7 @@ describe('MyPresetsPage', () => {
     expect(screen.getAllByRole('button', { name: /add description/i })).toHaveLength(2)
     expect(screen.getByAltText('Aurora Drift thumbnail')).toBeInTheDocument()
     expect(
-      screen.getByAltText('Very Long Preset Name To Test Wrapping In The Card Layout thumbnail'),
+      screen.getByAltText('Very Long Scene Name To Test Wrapping In The Card Layout thumbnail'),
     ).toBeInTheDocument()
     expect(
       screen.getByLabelText('Signal Bloom thumbnail unavailable'),
@@ -265,7 +265,7 @@ describe('MyPresetsPage', () => {
     expect(screen.getByText('1-3 of 3')).toBeInTheDocument()
 
     const selectAllCheckbox = screen.getByRole('checkbox', {
-      name: /select all presets on this page/i,
+      name: /select all scenes on this page/i,
     })
 
     await user.click(selectAllCheckbox)
@@ -274,11 +274,11 @@ describe('MyPresetsPage', () => {
     expect(screen.getByRole('checkbox', { name: /select signal bloom/i })).toBeChecked()
     expect(
       screen.getByRole('checkbox', {
-        name: /select very long preset name to test wrapping in the card layout/i,
+        name: /select very long scene name to test wrapping in the card layout/i,
       }),
     ).toBeChecked()
 
-    await user.click(auroraPreset)
+    await user.click(auroraScene)
 
     expect(await screen.findByTestId('mage-player')).toHaveTextContent('player-ready')
     expect(screen.getByRole('heading', { name: /aurora drift/i })).toBeInTheDocument()
@@ -292,7 +292,7 @@ describe('MyPresetsPage', () => {
         return Promise.resolve(jsonResponse(storedUser))
       }
 
-      if (input === buildApiUrl('/users/8/presets')) {
+      if (input === buildApiUrl('/users/8/scenes')) {
         return Promise.resolve(
           jsonResponse(
             {
@@ -306,10 +306,10 @@ describe('MyPresetsPage', () => {
       throw new Error(`Unexpected request: ${String(input)}`)
     })
 
-    renderMyPresetsPage()
+    renderMyScenesPage()
 
     expect(
-      await screen.findByText(/unable to load presets right now\. please try again in a moment\./i),
+      await screen.findByText(/unable to load scenes right now\. please try again in a moment\./i),
     ).toBeInTheDocument()
     expect(fetchSpy).toHaveBeenCalledTimes(2)
   })
@@ -322,12 +322,12 @@ describe('MyPresetsPage', () => {
         return Promise.resolve(jsonResponse(storedUser))
       }
 
-      if (input === buildApiUrl('/users/8/presets')) {
+      if (input === buildApiUrl('/users/8/scenes')) {
         return Promise.resolve(
           jsonResponse([
             {
               id: 31,
-              name: 'Custom Shader Preset',
+              name: 'Custom Shader Scene',
               description: null,
               sceneData: {
                 visualizer: {
@@ -345,9 +345,9 @@ describe('MyPresetsPage', () => {
       throw new Error(`Unexpected request: ${String(input)}`)
     })
 
-    renderMyPresetsPage()
+    renderMyScenesPage()
 
-    expect(await screen.findByText('Custom Shader Preset')).toBeInTheDocument()
+    expect(await screen.findByText('Custom Shader Scene')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /add description/i })).toBeInTheDocument()
     expect(screen.queryByText(/let size = input/i)).not.toBeInTheDocument()
   })
@@ -360,22 +360,22 @@ describe('MyPresetsPage', () => {
         return Promise.resolve(jsonResponse(storedUser))
       }
 
-      if (input === buildApiUrl('/users/8/presets')) {
-        return Promise.resolve(jsonResponse(mockPresets))
+      if (input === buildApiUrl('/users/8/scenes')) {
+        return Promise.resolve(jsonResponse(mockScenes))
       }
 
       throw new Error(`Unexpected request: ${String(input)}`)
     })
     const user = userEvent.setup()
 
-    renderMyPresetsPage()
+    renderMyScenesPage()
 
     expect(await screen.findByRole('button', { name: 'All' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Public' })).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: 'Public' }))
 
-    expect(screen.getByText('3 presets')).toBeInTheDocument()
+    expect(screen.getByText('3 scenes')).toBeInTheDocument()
     expect(screen.getAllByText('Public')).toHaveLength(4)
   })
 
@@ -387,7 +387,7 @@ describe('MyPresetsPage', () => {
         return Promise.resolve(jsonResponse(storedUser))
       }
 
-      if (input === buildApiUrl('/users/8/presets')) {
+      if (input === buildApiUrl('/users/8/scenes')) {
         return Promise.resolve(
           jsonResponse([
             {
@@ -413,11 +413,11 @@ describe('MyPresetsPage', () => {
     })
     const user = userEvent.setup()
 
-    renderMyPresetsPage()
+    renderMyScenesPage()
 
     await screen.findByRole('link', { name: /signal bloom/i })
 
-    const titleLinks = () => screen.getAllByRole('link').filter((link) => /\/presets\/\d+$/.test(link.getAttribute('href') ?? '') && !/Open preset preview/i.test(link.getAttribute('aria-label') ?? ''))
+    const titleLinks = () => screen.getAllByRole('link').filter((link) => /\/scenes\/\d+$/.test(link.getAttribute('href') ?? '') && !/Open scene preview/i.test(link.getAttribute('aria-label') ?? ''))
 
     expect(titleLinks().map((link) => link.textContent)).toEqual([
       'Solar Thread',
@@ -467,13 +467,13 @@ describe('MyPresetsPage', () => {
   it('paginates the table and shows the footer controls', async () => {
     storeSession()
 
-    const paginatedPresets = Array.from({ length: 31 }, (_, index) => {
-      const presetNumber = index + 1
-      const day = String(presetNumber).padStart(2, '0')
+    const paginatedScenes = Array.from({ length: 31 }, (_, index) => {
+      const sceneNumber = index + 1
+      const day = String(sceneNumber).padStart(2, '0')
 
       return {
-        id: presetNumber,
-        name: `Preset ${presetNumber}`,
+        id: sceneNumber,
+        name: `Scene ${sceneNumber}`,
         createdAt: `2026-04-${day}T14:00:00Z`,
       }
     })
@@ -483,49 +483,49 @@ describe('MyPresetsPage', () => {
         return Promise.resolve(jsonResponse(storedUser))
       }
 
-      if (input === buildApiUrl('/users/8/presets')) {
-        return Promise.resolve(jsonResponse(paginatedPresets))
+      if (input === buildApiUrl('/users/8/scenes')) {
+        return Promise.resolve(jsonResponse(paginatedScenes))
       }
 
       throw new Error(`Unexpected request: ${String(input)}`)
     })
     const user = userEvent.setup()
 
-    renderMyPresetsPage()
+    renderMyScenesPage()
 
     expect(await screen.findByText('1-30 of 31')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'Preset 31' })).toBeInTheDocument()
-    expect(screen.queryByRole('link', { name: 'Preset 1' })).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Scene 31' })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Scene 1' })).not.toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: /go to next page/i }))
 
     expect(await screen.findByText('31-31 of 31')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'Preset 1' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Scene 1' })).toBeInTheDocument()
   })
 
-  it('adds sample presets from the empty state and reloads the list', async () => {
+  it('adds sample scenes from the empty state and reloads the list', async () => {
     storeSession()
 
-    const createdPresetBodies: Array<Record<string, unknown>> = []
-    let presetListRequestCount = 0
+    const createdSceneBodies: Array<Record<string, unknown>> = []
+    let sceneListRequestCount = 0
 
     vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
       if (input === buildApiUrl('/users/me')) {
         return Promise.resolve(jsonResponse(storedUser))
       }
 
-      if (input === buildApiUrl('/users/8/presets')) {
-        presetListRequestCount += 1
+      if (input === buildApiUrl('/users/8/scenes')) {
+        sceneListRequestCount += 1
 
         return Promise.resolve(
           jsonResponse(
-            presetListRequestCount === 1
+            sceneListRequestCount === 1
               ? []
               : [
                   {
                     id: 21,
                     name: 'Aurora Drift',
-                    thumbnailRef: 'thumbnails/preset-21.png',
+                    thumbnailRef: 'thumbnails/scene-21.png',
                   },
                   {
                     id: 22,
@@ -535,25 +535,25 @@ describe('MyPresetsPage', () => {
                   {
                     id: 23,
                     name: 'Glacier Echo',
-                    thumbnailRef: 'thumbnails/preset-23.png',
+                    thumbnailRef: 'thumbnails/scene-23.png',
                   },
                   {
                     id: 24,
                     name: 'Solar Thread',
-                    thumbnailRef: 'thumbnails/preset-24.png',
+                    thumbnailRef: 'thumbnails/scene-24.png',
                   },
                 ],
           ),
         )
       }
 
-      if (input === buildApiUrl('/presets')) {
-        createdPresetBodies.push(JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>)
+      if (input === buildApiUrl('/scenes')) {
+        createdSceneBodies.push(JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>)
 
         return Promise.resolve(
           jsonResponse(
             {
-              presetId: 20 + createdPresetBodies.length,
+              sceneId: 20 + createdSceneBodies.length,
             },
             201,
           ),
@@ -564,17 +564,17 @@ describe('MyPresetsPage', () => {
     })
     const user = userEvent.setup()
 
-    renderMyPresetsPage()
+    renderMyScenesPage()
 
-    expect(await screen.findByText(/no presets yet/i)).toBeInTheDocument()
+    expect(await screen.findByText(/no scenes yet/i)).toBeInTheDocument()
 
-    await user.click(screen.getByRole('button', { name: /add sample presets/i }))
+    await user.click(screen.getByRole('button', { name: /add sample scenes/i }))
 
     expect(await screen.findByRole('link', { name: /aurora drift/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /signal bloom/i })).toBeInTheDocument()
-    expect(createdPresetBodies).toHaveLength(4)
-    expect(presetListRequestCount).toBe(2)
-    expect(createdPresetBodies).toEqual(
+    expect(createdSceneBodies).toHaveLength(4)
+    expect(sceneListRequestCount).toBe(2)
+    expect(createdSceneBodies).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           name: 'Aurora Drift',

--- a/src/pages/MyScenesPage.tsx
+++ b/src/pages/MyScenesPage.tsx
@@ -1,32 +1,32 @@
 import { useEffect, useRef, useState } from 'react'
 import { Navigate } from 'react-router-dom'
 import { useAuth } from '../auth/AuthContext'
-import { MyPresetsPagination } from '../components/my-presets/MyPresetsPagination'
-import { MyPresetsTable } from '../components/my-presets/MyPresetsTable'
-import { MyPresetsToolbar } from '../components/my-presets/MyPresetsToolbar'
+import { MyScenesPagination } from '../components/my-scenes/MyScenesPagination'
+import { MyScenesTable } from '../components/my-scenes/MyScenesTable'
+import { MyScenesToolbar } from '../components/my-scenes/MyScenesToolbar'
 import {
   buildSortSummary,
-  createDemoPresets,
-  fetchUserPresets,
-  sortPresets,
+  createDemoScenes,
+  fetchUserScenes,
+  sortScenes,
   type SortDirection,
   type SortKey,
   type StatusFilter,
-  type UserPreset,
-} from '../lib/myPresets'
+  type UserScene,
+} from '../lib/myScenes'
 
-export function MyPresetsPage() {
+export function MyScenesPage() {
   const { authenticatedFetch, isAuthenticated, isRestoringSession, user } = useAuth()
-  const [presets, setPresets] = useState<UserPreset[]>([])
+  const [scenes, setScenes] = useState<UserScene[]>([])
   const [isLoading, setIsLoading] = useState(true)
-  const [isSeedingPresets, setIsSeedingPresets] = useState(false)
+  const [isSeedingScenes, setIsSeedingScenes] = useState(false)
   const [errorMessage, setErrorMessage] = useState('')
   const [seedErrorMessage, setSeedErrorMessage] = useState('')
   const [reloadKey, setReloadKey] = useState(0)
   const [sortKey, setSortKey] = useState<SortKey>('updated')
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('All')
-  const [selectedPresetIds, setSelectedPresetIds] = useState<number[]>([])
+  const [selectedSceneIds, setSelectedSceneIds] = useState<number[]>([])
   const [rowsPerPage, setRowsPerPage] = useState(30)
   const [pageIndex, setPageIndex] = useState(0)
   const [isRowsPerPageMenuOpen, setIsRowsPerPageMenuOpen] = useState(false)
@@ -41,24 +41,24 @@ export function MyPresetsPage() {
     const userId = user.userId
     let isCurrent = true
 
-    async function loadPresets() {
+    async function loadScenes() {
       setIsLoading(true)
       setErrorMessage('')
 
       try {
-        const nextPresets = await fetchUserPresets(authenticatedFetch, userId)
+        const nextScenes = await fetchUserScenes(authenticatedFetch, userId)
         if (!isCurrent) {
           return
         }
 
-        setPresets(nextPresets)
+        setScenes(nextScenes)
       } catch {
         if (!isCurrent) {
           return
         }
 
-        setPresets([])
-        setErrorMessage('Unable to load presets right now. Please try again in a moment.')
+        setScenes([])
+        setErrorMessage('Unable to load scenes right now. Please try again in a moment.')
       } finally {
         if (isCurrent) {
           setIsLoading(false)
@@ -66,7 +66,7 @@ export function MyPresetsPage() {
       }
     }
 
-    void loadPresets()
+    void loadScenes()
 
     return () => {
       isCurrent = false
@@ -74,10 +74,10 @@ export function MyPresetsPage() {
   }, [authenticatedFetch, isAuthenticated, isRestoringSession, reloadKey, user?.userId])
 
   useEffect(() => {
-    setSelectedPresetIds((currentIds) =>
-      currentIds.filter((presetId) => presets.some((preset) => preset.id === presetId)),
+    setSelectedSceneIds((currentIds) =>
+      currentIds.filter((sceneId) => scenes.some((scene) => scene.id === sceneId)),
     )
-  }, [presets])
+  }, [scenes])
 
   useEffect(() => {
     if (!isRowsPerPageMenuOpen) {
@@ -105,35 +105,35 @@ export function MyPresetsPage() {
     }
   }, [isRowsPerPageMenuOpen])
 
-  const availableStatuses = [...new Set(presets.map((preset) => preset.statusLabel))].sort()
-  const visiblePresets =
+  const availableStatuses = [...new Set(scenes.map((scene) => scene.statusLabel))].sort()
+  const visibleScenes =
     statusFilter === 'All'
-      ? presets
-      : presets.filter((preset) => preset.statusLabel === statusFilter)
-  const sortedPresets = sortPresets(visiblePresets, sortKey, sortDirection)
+      ? scenes
+      : scenes.filter((scene) => scene.statusLabel === statusFilter)
+  const sortedScenes = sortScenes(visibleScenes, sortKey, sortDirection)
   const sortSummary = buildSortSummary(sortKey, sortDirection)
-  const totalPresets = sortedPresets.length
-  const pageCount = Math.max(1, Math.ceil(Math.max(totalPresets, 1) / rowsPerPage))
+  const totalScenes = sortedScenes.length
+  const pageCount = Math.max(1, Math.ceil(Math.max(totalScenes, 1) / rowsPerPage))
   const currentPageIndex = Math.min(pageIndex, pageCount - 1)
-  const pageStart = totalPresets === 0 ? 0 : currentPageIndex * rowsPerPage
-  const pageEnd = Math.min(pageStart + rowsPerPage, totalPresets)
-  const pagedPresets = sortedPresets.slice(pageStart, pageEnd)
-  const selectedPresetIdSet = new Set(selectedPresetIds)
-  const currentPagePresetIds = pagedPresets.map((preset) => preset.id)
-  const allPagePresetsSelected =
-    currentPagePresetIds.length > 0 &&
-    currentPagePresetIds.every((presetId) => selectedPresetIdSet.has(presetId))
-  const somePagePresetsSelected =
-    !allPagePresetsSelected &&
-    currentPagePresetIds.some((presetId) => selectedPresetIdSet.has(presetId))
+  const pageStart = totalScenes === 0 ? 0 : currentPageIndex * rowsPerPage
+  const pageEnd = Math.min(pageStart + rowsPerPage, totalScenes)
+  const pagedScenes = sortedScenes.slice(pageStart, pageEnd)
+  const selectedSceneIdSet = new Set(selectedSceneIds)
+  const currentPageSceneIds = pagedScenes.map((scene) => scene.id)
+  const allPageScenesSelected =
+    currentPageSceneIds.length > 0 &&
+    currentPageSceneIds.every((sceneId) => selectedSceneIdSet.has(sceneId))
+  const somePageScenesSelected =
+    !allPageScenesSelected &&
+    currentPageSceneIds.some((sceneId) => selectedSceneIdSet.has(sceneId))
 
   useEffect(() => {
     if (!selectAllCheckboxRef.current) {
       return
     }
 
-    selectAllCheckboxRef.current.indeterminate = somePagePresetsSelected
-  }, [somePagePresetsSelected])
+    selectAllCheckboxRef.current.indeterminate = somePageScenesSelected
+  }, [somePageScenesSelected])
 
   useEffect(() => {
     setPageIndex((currentIndex) => Math.min(currentIndex, pageCount - 1))
@@ -142,9 +142,9 @@ export function MyPresetsPage() {
   if (isRestoringSession) {
     return (
       <main className="surface surface--hero">
-        <div className="eyebrow">My Presets</div>
-        <h1>Loading presets...</h1>
-        <p className="page-lead">MAGE is restoring your session and loading your saved presets.</p>
+        <div className="eyebrow">My Scenes</div>
+        <h1>Loading scenes...</h1>
+        <p className="page-lead">MAGE is restoring your session and loading your saved scenes.</p>
       </main>
     )
   }
@@ -156,28 +156,28 @@ export function MyPresetsPage() {
   if (typeof user?.userId !== 'number') {
     return (
       <main className="surface surface--hero">
-        <div className="eyebrow">My Presets</div>
-        <h1>Unable to load presets</h1>
-        <p className="page-lead">Your session is missing the user information needed to load presets.</p>
+        <div className="eyebrow">My Scenes</div>
+        <h1>Unable to load scenes</h1>
+        <p className="page-lead">Your session is missing the user information needed to load scenes.</p>
       </main>
     )
   }
 
-  async function handleSeedPresets() {
-    setIsSeedingPresets(true)
+  async function handleSeedScenes() {
+    setIsSeedingScenes(true)
     setSeedErrorMessage('')
 
     try {
-      await createDemoPresets(authenticatedFetch)
+      await createDemoScenes(authenticatedFetch)
       setReloadKey((currentKey) => currentKey + 1)
     } catch (error) {
       setSeedErrorMessage(
         error instanceof Error && error.message
           ? error.message
-          : 'Unable to add sample presets right now. Please try again in a moment.',
+          : 'Unable to add sample scenes right now. Please try again in a moment.',
       )
     } finally {
-      setIsSeedingPresets(false)
+      setIsSeedingScenes(false)
     }
   }
 
@@ -193,76 +193,76 @@ export function MyPresetsPage() {
     setPageIndex(0)
   }
 
-  function handleSelectAllVisiblePresets() {
-    if (allPagePresetsSelected) {
-      setSelectedPresetIds((currentIds) =>
-        currentIds.filter((presetId) => !currentPagePresetIds.includes(presetId)),
+  function handleSelectAllVisibleScenes() {
+    if (allPageScenesSelected) {
+      setSelectedSceneIds((currentIds) =>
+        currentIds.filter((sceneId) => !currentPageSceneIds.includes(sceneId)),
       )
       return
     }
 
-    setSelectedPresetIds((currentIds) => {
+    setSelectedSceneIds((currentIds) => {
       const nextIds = new Set(currentIds)
-      currentPagePresetIds.forEach((presetId) => {
-        nextIds.add(presetId)
+      currentPageSceneIds.forEach((sceneId) => {
+        nextIds.add(sceneId)
       })
       return [...nextIds]
     })
   }
 
-  function handleTogglePresetSelection(presetId: number) {
-    setSelectedPresetIds((currentIds) => {
-      if (currentIds.includes(presetId)) {
-        return currentIds.filter((currentId) => currentId !== presetId)
+  function handleToggleSceneSelection(sceneId: number) {
+    setSelectedSceneIds((currentIds) => {
+      if (currentIds.includes(sceneId)) {
+        return currentIds.filter((currentId) => currentId !== sceneId)
       }
 
-      return [...currentIds, presetId]
+      return [...currentIds, sceneId]
     })
   }
 
   return (
-    <main className="page-stack my-presets-page">
-      <section className="surface surface--page-panel my-presets-panel" aria-live="polite">
-        <header className="my-presets-panel__header">
-          <div className="eyebrow">My Presets</div>
-          <h1 className="my-presets-panel__title">Preset library</h1>
-          <p className="my-presets-panel__lead">
-            Review the presets created by your account and stage edits, organization, or cleanup from one place.
+    <main className="page-stack my-scenes-page">
+      <section className="surface surface--page-panel my-scenes-panel" aria-live="polite">
+        <header className="my-scenes-panel__header">
+          <div className="eyebrow">My Scenes</div>
+          <h1 className="my-scenes-panel__title">Scene library</h1>
+          <p className="my-scenes-panel__lead">
+            Review the scenes created by your account and stage edits, organization, or cleanup from one place.
           </p>
         </header>
 
         {isLoading ? (
-          <p className="preset-status">Loading presets...</p>
+          <p className="scene-status">Loading scenes...</p>
         ) : errorMessage ? (
-          <p className="preset-status preset-status-error">{errorMessage}</p>
-        ) : presets.length === 0 ? (
-          <div className="preset-empty-state">
-            <p className="preset-status">No presets yet</p>
-            <p className="preset-status">
-              Temporary helper: add sample presets to this account so you can preview the list UI.
+          <p className="scene-status scene-status-error">{errorMessage}</p>
+        ) : scenes.length === 0 ? (
+          <div className="scene-empty-state">
+            <p className="scene-status">No scenes yet</p>
+            <p className="scene-status">
+              Temporary helper: add sample scenes to this account so you can preview the list UI.
             </p>
-            <div className="preset-actions">
+            <div className="scene-actions">
               <button
                 type="button"
-                className="preset-action"
+                className="scene-action"
                 onClick={() => {
-                  void handleSeedPresets()
+                  void handleSeedScenes()
                 }}
-                disabled={isSeedingPresets}
+                disabled={isSeedingScenes}
               >
-                {isSeedingPresets ? 'Adding sample presets...' : 'Add sample presets'}
+                {isSeedingScenes ? 'Adding sample scenes...' : 'Add sample scenes'}
               </button>
             </div>
             {seedErrorMessage ? (
-              <p className="preset-status preset-status-error">{seedErrorMessage}</p>
+              <p className="scene-status scene-status-error">{seedErrorMessage}</p>
             ) : null}
           </div>
         ) : (
-          <div className="my-presets-board">
-            <MyPresetsToolbar
+          <div className="my-scenes-board">
+            <MyScenesToolbar
               availableStatuses={availableStatuses}
               sortSummary={sortSummary}
-              totalPresets={sortedPresets.length}
+              totalScenes={sortedScenes.length}
               statusFilter={statusFilter}
               onSelectStatus={(status) => {
                 setStatusFilter(status)
@@ -270,19 +270,19 @@ export function MyPresetsPage() {
               }}
             />
 
-            <MyPresetsTable
-              allPagePresetsSelected={allPagePresetsSelected}
-              pagedPresets={pagedPresets}
+            <MyScenesTable
+              allPageScenesSelected={allPageScenesSelected}
+              pagedScenes={pagedScenes}
               selectAllCheckboxRef={selectAllCheckboxRef}
-              selectedPresetIdSet={selectedPresetIdSet}
+              selectedSceneIdSet={selectedSceneIdSet}
               sortDirection={sortDirection}
               sortKey={sortKey}
               onSort={handleSort}
-              onTogglePresetSelection={handleTogglePresetSelection}
-              onToggleSelectAll={handleSelectAllVisiblePresets}
+              onToggleSceneSelection={handleToggleSceneSelection}
+              onToggleSelectAll={handleSelectAllVisibleScenes}
             />
 
-            <MyPresetsPagination
+            <MyScenesPagination
               currentPageIndex={currentPageIndex}
               isRowsPerPageMenuOpen={isRowsPerPageMenuOpen}
               pageCount={pageCount}
@@ -290,7 +290,7 @@ export function MyPresetsPage() {
               pageStart={pageStart}
               rowsPerPage={rowsPerPage}
               rowsPerPageMenuRef={rowsPerPageMenuRef}
-              totalPresets={totalPresets}
+              totalScenes={totalScenes}
               onGoToFirstPage={() => {
                 setPageIndex(0)
               }}

--- a/src/pages/SceneDetailPage.test.tsx
+++ b/src/pages/SceneDetailPage.test.tsx
@@ -9,8 +9,8 @@ import {
 } from '../auth/AuthContext'
 import { buildApiUrl } from '../lib/api'
 import { LoginPage } from './LoginPage'
-import { MyPresetsPage } from './MyPresetsPage'
-import { PresetDetailPage } from './PresetDetailPage'
+import { MyScenesPage } from './MyScenesPage'
+import { SceneDetailPage } from './SceneDetailPage'
 
 vi.mock('../components/MagePlayer', () => ({
   MagePlayer: ({
@@ -31,41 +31,41 @@ vi.mock('../components/MagePlayer', () => ({
 const storedUser: AuthenticatedUser = {
   userId: 8,
   email: 'artist@example.com',
-  displayName: 'Preset Artist',
+  displayName: 'Scene Artist',
   authProvider: 'LOCAL',
 }
 
-const presetResponse = {
-  presetId: 12,
+const sceneResponse = {
+  sceneId: 12,
   ownerUserId: 8,
-  creatorDisplayName: 'Preset Artist',
+  creatorDisplayName: 'Scene Artist',
   name: 'Aurora Drift',
   sceneData: {
     visualizer: {
       shader: 'nebula',
     },
   },
-  thumbnailRef: 'thumbnails/preset-12.png',
+  thumbnailRef: 'thumbnails/scene-12.png',
   createdAt: '2026-04-06T14:00:00Z',
   tags: ['ambient', 'focus-friendly'],
 }
 
-const creatorPresetResponse = {
-  presetId: 16,
+const creatorSceneResponse = {
+  sceneId: 16,
   ownerUserId: 8,
-  creatorDisplayName: 'Preset Artist',
+  creatorDisplayName: 'Scene Artist',
   name: 'Signal Bloom',
   sceneData: {
     visualizer: {
       shader: 'pulse',
     },
   },
-  thumbnailRef: 'thumbnails/preset-16.png',
+  thumbnailRef: 'thumbnails/scene-16.png',
   createdAt: '2026-04-08T14:00:00Z',
 }
 
-const tagPresetResponse = {
-  presetId: 21,
+const tagSceneResponse = {
+  sceneId: 21,
   ownerUserId: 42,
   creatorDisplayName: 'Night Archive',
   name: 'Afterglow Static',
@@ -74,12 +74,12 @@ const tagPresetResponse = {
       shader: 'mist',
     },
   },
-  thumbnailRef: 'thumbnails/preset-21.png',
+  thumbnailRef: 'thumbnails/scene-21.png',
   createdAt: '2026-04-09T14:00:00Z',
 }
 
-const unrelatedPresetResponse = {
-  presetId: 34,
+const unrelatedSceneResponse = {
+  sceneId: 34,
   ownerUserId: 77,
   creatorDisplayName: 'Other Creator',
   name: 'Unrelated Echo',
@@ -88,7 +88,7 @@ const unrelatedPresetResponse = {
       shader: 'echo',
     },
   },
-  thumbnailRef: 'thumbnails/preset-34.png',
+  thumbnailRef: 'thumbnails/scene-34.png',
   createdAt: '2026-04-10T14:00:00Z',
 }
 
@@ -111,11 +111,11 @@ function storeSession() {
   )
 }
 
-function renderPresetDetailPage(initialEntries = ['/presets/12']) {
-  function PresetsRouteProbe() {
+function renderSceneDetailPage(initialEntries = ['/scenes/12']) {
+  function ScenesRouteProbe() {
     const location = useLocation()
 
-    return <div data-testid="presets-route">{location.search}</div>
+    return <div data-testid="scenes-route">{location.search}</div>
   }
 
   return render(
@@ -124,17 +124,17 @@ function renderPresetDetailPage(initialEntries = ['/presets/12']) {
         <Routes>
           <Route path="/" element={<div>Home</div>} />
           <Route path="/login" element={<LoginPage />} />
-          <Route path="/my-presets" element={<MyPresetsPage />} />
-          <Route path="/presets" element={<PresetsRouteProbe />} />
-          <Route path="/presets/:id" element={<PresetDetailPage />} />
+          <Route path="/my-scenes" element={<MyScenesPage />} />
+          <Route path="/scenes" element={<ScenesRouteProbe />} />
+          <Route path="/scenes/:id" element={<SceneDetailPage />} />
         </Routes>
       </AuthProvider>
     </MemoryRouter>,
   )
 }
 
-describe('PresetDetailPage', () => {
-  it('loads preset detail on a direct route visit and renders the player', async () => {
+describe('SceneDetailPage', () => {
+  it('loads scene detail on a direct route visit and renders the player', async () => {
     storeSession()
 
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
@@ -142,32 +142,32 @@ describe('PresetDetailPage', () => {
         return Promise.resolve(jsonResponse(storedUser))
       }
 
-      if (input === buildApiUrl('/presets/12')) {
-        return Promise.resolve(jsonResponse(presetResponse))
+      if (input === buildApiUrl('/scenes/12')) {
+        return Promise.resolve(jsonResponse(sceneResponse))
       }
 
-      if (input === buildApiUrl('/presets')) {
+      if (input === buildApiUrl('/scenes')) {
         return Promise.resolve(
           jsonResponse([
-            presetResponse,
-            creatorPresetResponse,
-            unrelatedPresetResponse,
+            sceneResponse,
+            creatorSceneResponse,
+            unrelatedSceneResponse,
           ]),
         )
       }
 
-      if (input === buildApiUrl('/presets?tag=ambient')) {
-        return Promise.resolve(jsonResponse([presetResponse, tagPresetResponse]))
+      if (input === buildApiUrl('/scenes?tag=ambient')) {
+        return Promise.resolve(jsonResponse([sceneResponse, tagSceneResponse]))
       }
 
-      if (input === buildApiUrl('/presets?tag=focus-friendly')) {
-        return Promise.resolve(jsonResponse([presetResponse, creatorPresetResponse]))
+      if (input === buildApiUrl('/scenes?tag=focus-friendly')) {
+        return Promise.resolve(jsonResponse([sceneResponse, creatorSceneResponse]))
       }
 
       throw new Error(`Unexpected request: ${String(input)}`)
     })
 
-    renderPresetDetailPage()
+    renderSceneDetailPage()
 
     expect(await screen.findByRole('heading', { name: /aurora drift/i })).toBeInTheDocument()
     expect(screen.getByTestId('mage-player')).toHaveTextContent('player-ready')
@@ -175,10 +175,10 @@ describe('PresetDetailPage', () => {
     expect(screen.getByRole('button', { name: /upvote 416/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /^show$/i })).toBeInTheDocument()
     expect(screen.getAllByRole('button', { name: /downvote/i }).length).toBeGreaterThan(0)
-    expect(screen.getByText(/add a comment as preset artist/i)).toBeInTheDocument()
-    expect(screen.getAllByText('Preset Artist').length).toBeGreaterThan(0)
+    expect(screen.getByText(/add a comment as scene artist/i)).toBeInTheDocument()
+    expect(screen.getAllByText('Scene Artist').length).toBeGreaterThan(0)
     expect(screen.getAllByText(/2,999 plays/i).length).toBeGreaterThan(0)
-    expect(screen.getByRole('button', { name: /from preset artist/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /from scene artist/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /^ambient$/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /^focus-friendly$/i })).toBeInTheDocument()
     expect(await screen.findByRole('link', { name: /signal bloom/i })).toBeInTheDocument()
@@ -190,29 +190,29 @@ describe('PresetDetailPage', () => {
     await waitFor(() =>
       expect(fetchSpy).toHaveBeenNthCalledWith(
         2,
-        buildApiUrl('/presets/12'),
+        buildApiUrl('/scenes/12'),
         expect.objectContaining({
           headers: expect.any(Headers),
         }),
       ),
     )
 
-    const presetRequestHeaders = fetchSpy.mock.calls[1][1]?.headers as Headers
+    const sceneRequestHeaders = fetchSpy.mock.calls[1][1]?.headers as Headers
 
-    expect(presetRequestHeaders.get('Authorization')).toBe('Bearer stored-auth-token')
+    expect(sceneRequestHeaders.get('Authorization')).toBe('Bearer stored-auth-token')
   })
 
-  it('shows a clear error state for an invalid preset route id', async () => {
+  it('shows a clear error state for an invalid scene route id', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch')
 
-    renderPresetDetailPage(['/presets/not-a-number'])
+    renderSceneDetailPage(['/scenes/not-a-number'])
 
-    expect(await screen.findByRole('heading', { name: /invalid preset link/i })).toBeInTheDocument()
-    expect(screen.getByText(/missing a valid preset id/i)).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: /invalid scene link/i })).toBeInTheDocument()
+    expect(screen.getByText(/missing a valid scene id/i)).toBeInTheDocument()
     expect(fetchSpy).not.toHaveBeenCalled()
   })
 
-  it('shows a not-found state when the preset request returns 404', async () => {
+  it('shows a not-found state when the scene request returns 404', async () => {
     storeSession()
 
     vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
@@ -220,11 +220,11 @@ describe('PresetDetailPage', () => {
         return Promise.resolve(jsonResponse(storedUser))
       }
 
-      if (input === buildApiUrl('/presets/12')) {
+      if (input === buildApiUrl('/scenes/12')) {
         return Promise.resolve(
           jsonResponse(
             {
-              message: 'Preset not found.',
+              message: 'Scene not found.',
             },
             404,
           ),
@@ -234,15 +234,15 @@ describe('PresetDetailPage', () => {
       throw new Error(`Unexpected request: ${String(input)}`)
     })
 
-    renderPresetDetailPage()
+    renderSceneDetailPage()
 
-    expect(await screen.findByRole('heading', { name: /preset not found/i })).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: /scene not found/i })).toBeInTheDocument()
     expect(screen.getByText(/does not exist or is no longer available/i)).toBeInTheDocument()
   })
 
-  it('shows a sign-in-needed state when an unauthenticated preset request is rejected', async () => {
+  it('shows a sign-in-needed state when an unauthenticated scene request is rejected', async () => {
     vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
-      if (input === buildApiUrl('/presets/12')) {
+      if (input === buildApiUrl('/scenes/12')) {
         return Promise.resolve(
           jsonResponse(
             {
@@ -256,13 +256,13 @@ describe('PresetDetailPage', () => {
       throw new Error(`Unexpected request: ${String(input)}`)
     })
 
-    renderPresetDetailPage()
+    renderSceneDetailPage()
 
-    expect(await screen.findByRole('heading', { name: /sign in to view this preset/i })).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: /sign in to view this scene/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /go to login/i })).toBeInTheDocument()
   })
 
-  it('shows the real creator name for another users preset', async () => {
+  it('shows the real creator name for another users scene', async () => {
     storeSession()
 
     vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
@@ -270,10 +270,10 @@ describe('PresetDetailPage', () => {
         return Promise.resolve(jsonResponse(storedUser))
       }
 
-      if (input === buildApiUrl('/presets/44')) {
+      if (input === buildApiUrl('/scenes/44')) {
         return Promise.resolve(
           jsonResponse({
-            presetId: 44,
+            sceneId: 44,
             ownerUserId: 77,
             creatorDisplayName: 'Peter',
             name: 'Test 3',
@@ -282,18 +282,18 @@ describe('PresetDetailPage', () => {
                 shader: 'nebula',
               },
             },
-            thumbnailRef: 'thumbnails/preset-44.png',
+            thumbnailRef: 'thumbnails/scene-44.png',
             createdAt: '2026-04-06T14:00:00Z',
             tags: ['chill'],
           }),
         )
       }
 
-      if (input === buildApiUrl('/presets')) {
+      if (input === buildApiUrl('/scenes')) {
         return Promise.resolve(
           jsonResponse([
             {
-              presetId: 44,
+              sceneId: 44,
               ownerUserId: 77,
               creatorDisplayName: 'Peter',
               name: 'Test 3',
@@ -302,11 +302,11 @@ describe('PresetDetailPage', () => {
                   shader: 'nebula',
                 },
               },
-              thumbnailRef: 'thumbnails/preset-44.png',
+              thumbnailRef: 'thumbnails/scene-44.png',
               createdAt: '2026-04-06T14:00:00Z',
             },
             {
-              presetId: 45,
+              sceneId: 45,
               ownerUserId: 77,
               creatorDisplayName: 'Peter',
               name: 'Pulse Coast',
@@ -315,18 +315,18 @@ describe('PresetDetailPage', () => {
                   shader: 'nebula',
                 },
               },
-              thumbnailRef: 'thumbnails/preset-45.png',
+              thumbnailRef: 'thumbnails/scene-45.png',
               createdAt: '2026-04-08T14:00:00Z',
             },
           ]),
         )
       }
 
-      if (input === buildApiUrl('/presets?tag=chill')) {
+      if (input === buildApiUrl('/scenes?tag=chill')) {
         return Promise.resolve(
           jsonResponse([
             {
-              presetId: 44,
+              sceneId: 44,
               ownerUserId: 77,
               creatorDisplayName: 'Peter',
               name: 'Test 3',
@@ -335,7 +335,7 @@ describe('PresetDetailPage', () => {
                   shader: 'nebula',
                 },
               },
-              thumbnailRef: 'thumbnails/preset-44.png',
+              thumbnailRef: 'thumbnails/scene-44.png',
               createdAt: '2026-04-06T14:00:00Z',
             },
           ]),
@@ -345,14 +345,14 @@ describe('PresetDetailPage', () => {
       throw new Error(`Unexpected request: ${String(input)}`)
     })
 
-    renderPresetDetailPage(['/presets/44'])
+    renderSceneDetailPage(['/scenes/44'])
 
     expect(await screen.findAllByText('Peter')).not.toHaveLength(0)
     expect(screen.getByRole('button', { name: /from peter/i })).toBeInTheDocument()
     expect(screen.queryByText('Talia North')).not.toBeInTheDocument()
   })
 
-  it('shows attached preset tags and routes to the filtered presets grid when clicked', async () => {
+  it('shows attached scene tags and routes to the filtered scenes grid when clicked', async () => {
     storeSession()
 
     vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
@@ -360,20 +360,20 @@ describe('PresetDetailPage', () => {
         return Promise.resolve(jsonResponse(storedUser))
       }
 
-      if (input === buildApiUrl('/presets/12')) {
-        return Promise.resolve(jsonResponse(presetResponse))
+      if (input === buildApiUrl('/scenes/12')) {
+        return Promise.resolve(jsonResponse(sceneResponse))
       }
 
-      if (input === buildApiUrl('/presets')) {
-        return Promise.resolve(jsonResponse([presetResponse, creatorPresetResponse]))
+      if (input === buildApiUrl('/scenes')) {
+        return Promise.resolve(jsonResponse([sceneResponse, creatorSceneResponse]))
       }
 
-      if (input === buildApiUrl('/presets?tag=ambient')) {
-        return Promise.resolve(jsonResponse([presetResponse, tagPresetResponse]))
+      if (input === buildApiUrl('/scenes?tag=ambient')) {
+        return Promise.resolve(jsonResponse([sceneResponse, tagSceneResponse]))
       }
 
-      if (input === buildApiUrl('/presets?tag=focus-friendly')) {
-        return Promise.resolve(jsonResponse([presetResponse, creatorPresetResponse]))
+      if (input === buildApiUrl('/scenes?tag=focus-friendly')) {
+        return Promise.resolve(jsonResponse([sceneResponse, creatorSceneResponse]))
       }
 
       throw new Error(`Unexpected request: ${String(input)}`)
@@ -381,24 +381,24 @@ describe('PresetDetailPage', () => {
 
     const user = userEvent.setup()
 
-    renderPresetDetailPage()
+    renderSceneDetailPage()
 
     await screen.findByRole('heading', { name: /aurora drift/i })
     await user.click(screen.getByRole('button', { name: /^show$/i }))
 
     const ambientTagLink = screen.getByRole('link', { name: /^ambient$/i })
-    expect(ambientTagLink).toHaveAttribute('href', '/presets?tag=ambient')
+    expect(ambientTagLink).toHaveAttribute('href', '/scenes?tag=ambient')
     expect(screen.getByRole('link', { name: /^focus-friendly$/i })).toHaveAttribute(
       'href',
-      '/presets?tag=focus-friendly',
+      '/scenes?tag=focus-friendly',
     )
 
     await user.click(ambientTagLink)
 
-    expect(await screen.findByTestId('presets-route')).toHaveTextContent('?tag=ambient')
+    expect(await screen.findByTestId('scenes-route')).toHaveTextContent('?tag=ambient')
   })
 
-  it('filters sidebar recommendations by creator and the current preset tags', async () => {
+  it('filters sidebar recommendations by creator and the current scene tags', async () => {
     storeSession()
 
     vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
@@ -406,26 +406,26 @@ describe('PresetDetailPage', () => {
         return Promise.resolve(jsonResponse(storedUser))
       }
 
-      if (input === buildApiUrl('/presets/12')) {
-        return Promise.resolve(jsonResponse(presetResponse))
+      if (input === buildApiUrl('/scenes/12')) {
+        return Promise.resolve(jsonResponse(sceneResponse))
       }
 
-      if (input === buildApiUrl('/presets')) {
+      if (input === buildApiUrl('/scenes')) {
         return Promise.resolve(
           jsonResponse([
-            presetResponse,
-            creatorPresetResponse,
-            unrelatedPresetResponse,
+            sceneResponse,
+            creatorSceneResponse,
+            unrelatedSceneResponse,
           ]),
         )
       }
 
-      if (input === buildApiUrl('/presets?tag=ambient')) {
-        return Promise.resolve(jsonResponse([presetResponse, tagPresetResponse]))
+      if (input === buildApiUrl('/scenes?tag=ambient')) {
+        return Promise.resolve(jsonResponse([sceneResponse, tagSceneResponse]))
       }
 
-      if (input === buildApiUrl('/presets?tag=focus-friendly')) {
-        return Promise.resolve(jsonResponse([presetResponse, creatorPresetResponse]))
+      if (input === buildApiUrl('/scenes?tag=focus-friendly')) {
+        return Promise.resolve(jsonResponse([sceneResponse, creatorSceneResponse]))
       }
 
       throw new Error(`Unexpected request: ${String(input)}`)
@@ -433,12 +433,12 @@ describe('PresetDetailPage', () => {
 
     const user = userEvent.setup()
 
-    renderPresetDetailPage()
+    renderSceneDetailPage()
 
     expect(await screen.findByRole('link', { name: /signal bloom/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /afterglow static/i })).toBeInTheDocument()
 
-    await user.click(screen.getByRole('button', { name: /from preset artist/i }))
+    await user.click(screen.getByRole('button', { name: /from scene artist/i }))
 
     expect(screen.getByRole('link', { name: /signal bloom/i })).toBeInTheDocument()
     expect(screen.queryByRole('link', { name: /afterglow static/i })).not.toBeInTheDocument()

--- a/src/pages/SceneDetailPage.tsx
+++ b/src/pages/SceneDetailPage.tsx
@@ -2,72 +2,72 @@ import { useEffect, useState, type CSSProperties } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { useAuth } from '../auth/AuthContext'
 import { MagePlayer } from '../components/MagePlayer'
-import { PresetCommentsPanel } from '../components/preset-detail/PresetCommentsPanel'
-import { PresetDescriptionCard } from '../components/preset-detail/PresetDescriptionCard'
-import { PresetRecommendationRail } from '../components/preset-detail/PresetRecommendationRail'
-import { PresetDetailState } from '../components/preset-detail/PresetDetailState'
-import { VoteButton } from '../components/preset-detail/VoteButton'
+import { SceneCommentsPanel } from '../components/scene-detail/SceneCommentsPanel'
+import { SceneDescriptionCard } from '../components/scene-detail/SceneDescriptionCard'
+import { SceneRecommendationRail } from '../components/scene-detail/SceneRecommendationRail'
+import { SceneDetailState } from '../components/scene-detail/SceneDetailState'
+import { VoteButton } from '../components/scene-detail/VoteButton'
 import {
   buildCreatorProfile,
-  buildPresetComments,
-  buildPresetDescription,
-  buildPresetEngagement,
-  createEmptyRecommendedPresetGroups,
-  fetchRecommendedPresetGroups,
-  fetchPresetDetail,
-  PresetDetailRequestError,
+  buildSceneComments,
+  buildSceneDescription,
+  buildSceneEngagement,
+  createEmptyRecommendedSceneGroups,
+  fetchRecommendedSceneGroups,
+  fetchSceneDetail,
+  SceneDetailRequestError,
   readErrorCopy,
   readInitial,
-  readPresetId,
+  readSceneId,
   readRecommendationFilterTag,
-  type PresetDetail,
-  type PresetDetailErrorCode,
-  type RecommendedPresetGroups,
+  type SceneDetail,
+  type SceneDetailErrorCode,
+  type RecommendedSceneGroups,
   type RecommendationFilter,
-} from '../lib/presetDetail'
+} from '../lib/sceneDetail'
 
-export function PresetDetailPage() {
+export function SceneDetailPage() {
   const { id } = useParams<{ id: string }>()
   const { authenticatedFetch, isAuthenticated, isRestoringSession, user } = useAuth()
-  const [preset, setPreset] = useState<PresetDetail | null>(null)
-  const [errorCode, setErrorCode] = useState<PresetDetailErrorCode | null>(null)
+  const [scene, setScene] = useState<SceneDetail | null>(null)
+  const [errorCode, setErrorCode] = useState<SceneDetailErrorCode | null>(null)
   const [isLoading, setIsLoading] = useState(true)
-  const [recommendedPresetGroups, setRecommendedPresetGroups] = useState<RecommendedPresetGroups>(
-    createEmptyRecommendedPresetGroups(),
+  const [recommendedSceneGroups, setRecommendedSceneGroups] = useState<RecommendedSceneGroups>(
+    createEmptyRecommendedSceneGroups(),
   )
   const [isRecommendationsLoading, setIsRecommendationsLoading] = useState(false)
   const [recommendationFilter, setRecommendationFilter] = useState<RecommendationFilter>('all')
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
 
-  const presetId = readPresetId(id)
+  const sceneId = readSceneId(id)
 
   useEffect(() => {
-    if (presetId === null || isRestoringSession) {
+    if (sceneId === null || isRestoringSession) {
       return
     }
 
-    const nextPresetId = presetId
+    const nextSceneId = sceneId
     let isCurrent = true
 
-    async function loadPreset() {
+    async function loadScene() {
       setIsLoading(true)
       setErrorCode(null)
-      setPreset(null)
+      setScene(null)
 
       try {
-        const nextPreset = await fetchPresetDetail(authenticatedFetch, isAuthenticated, nextPresetId)
+        const nextScene = await fetchSceneDetail(authenticatedFetch, isAuthenticated, nextSceneId)
 
         if (!isCurrent) {
           return
         }
 
-        setPreset(nextPreset)
+        setScene(nextScene)
       } catch (error) {
         if (!isCurrent) {
           return
         }
 
-        setErrorCode(error instanceof PresetDetailRequestError ? error.code : 'unavailable')
+        setErrorCode(error instanceof SceneDetailRequestError ? error.code : 'unavailable')
       } finally {
         if (isCurrent) {
           setIsLoading(false)
@@ -75,45 +75,45 @@ export function PresetDetailPage() {
       }
     }
 
-    void loadPreset()
+    void loadScene()
 
     return () => {
       isCurrent = false
     }
-  }, [authenticatedFetch, isAuthenticated, isRestoringSession, presetId])
+  }, [authenticatedFetch, isAuthenticated, isRestoringSession, sceneId])
 
   useEffect(() => {
     setIsDescriptionExpanded(false)
     setRecommendationFilter('all')
-  }, [preset?.id])
+  }, [scene?.id])
 
   useEffect(() => {
-    if (!preset) {
-      setRecommendedPresetGroups(createEmptyRecommendedPresetGroups())
+    if (!scene) {
+      setRecommendedSceneGroups(createEmptyRecommendedSceneGroups())
       setIsRecommendationsLoading(false)
       return
     }
 
-    const currentPreset = preset
+    const currentScene = scene
     let isCurrent = true
 
-    async function loadRecommendedPresets() {
+    async function loadRecommendedScenes() {
       setIsRecommendationsLoading(true)
 
       try {
-        const nextRecommendedPresetGroups = await fetchRecommendedPresetGroups(currentPreset)
+        const nextRecommendedSceneGroups = await fetchRecommendedSceneGroups(currentScene)
 
         if (!isCurrent) {
           return
         }
 
-        setRecommendedPresetGroups(nextRecommendedPresetGroups)
+        setRecommendedSceneGroups(nextRecommendedSceneGroups)
       } catch {
         if (!isCurrent) {
           return
         }
 
-        setRecommendedPresetGroups(createEmptyRecommendedPresetGroups())
+        setRecommendedSceneGroups(createEmptyRecommendedSceneGroups())
       } finally {
         if (isCurrent) {
           setIsRecommendationsLoading(false)
@@ -121,18 +121,18 @@ export function PresetDetailPage() {
       }
     }
 
-    void loadRecommendedPresets()
+    void loadRecommendedScenes()
 
     return () => {
       isCurrent = false
     }
-  }, [preset])
+  }, [scene])
 
-  if (presetId === null) {
+  if (sceneId === null) {
     const { description, title } = readErrorCopy('invalid-id')
 
     return (
-      <PresetDetailState
+      <SceneDetailState
         title={title}
         description={description}
         actions={
@@ -141,8 +141,8 @@ export function PresetDetailPage() {
               Back to Home
             </Link>
             {isAuthenticated ? (
-              <Link className="secondary-link" to="/my-presets">
-                Back to My Presets
+              <Link className="secondary-link" to="/my-scenes">
+                Back to My Scenes
               </Link>
             ) : null}
           </div>
@@ -153,22 +153,22 @@ export function PresetDetailPage() {
 
   if (isRestoringSession || isLoading) {
     return (
-      <PresetDetailState
-        title="Loading preset..."
+      <SceneDetailState
+        title="Loading scene..."
         description={
           isRestoringSession
-            ? 'MAGE is restoring your session before loading this preset.'
-            : 'MAGE is fetching preset metadata and loading the embedded player.'
+            ? 'MAGE is restoring your session before loading this scene.'
+            : 'MAGE is fetching scene metadata and loading the embedded player.'
         }
       />
     )
   }
 
-  if (errorCode || !preset) {
+  if (errorCode || !scene) {
     const { description, title } = readErrorCopy(errorCode ?? 'unavailable')
 
     return (
-      <PresetDetailState
+      <SceneDetailState
         title={title}
         description={description}
         actions={
@@ -183,8 +183,8 @@ export function PresetDetailPage() {
               </Link>
             )}
             {isAuthenticated ? (
-              <Link className="secondary-link" to="/my-presets">
-                Back to My Presets
+              <Link className="secondary-link" to="/my-scenes">
+                Back to My Scenes
               </Link>
             ) : errorCode !== 'auth-required' ? (
               <Link className="secondary-link" to="/login">
@@ -197,45 +197,45 @@ export function PresetDetailPage() {
     )
   }
 
-  const creatorProfile = buildCreatorProfile(preset, user?.displayName, user?.userId)
-  const engagement = buildPresetEngagement(preset)
-  const presetDescription = buildPresetDescription(preset, creatorProfile)
-  const presetComments = buildPresetComments(preset)
+  const creatorProfile = buildCreatorProfile(scene, user?.displayName, user?.userId)
+  const engagement = buildSceneEngagement(scene)
+  const sceneDescription = buildSceneDescription(scene, creatorProfile)
+  const sceneComments = buildSceneComments(scene)
   const activeRecommendationTag = readRecommendationFilterTag(recommendationFilter)
-  const filteredRecommendedPresets =
+  const filteredRecommendedScenes =
     activeRecommendationTag !== null
-      ? recommendedPresetGroups.byTag[activeRecommendationTag] ?? []
+      ? recommendedSceneGroups.byTag[activeRecommendationTag] ?? []
       : recommendationFilter === 'creator'
-        ? recommendedPresetGroups.creator
-        : recommendedPresetGroups.all
+        ? recommendedSceneGroups.creator
+        : recommendedSceneGroups.all
   const composerInitial = readInitial(user?.displayName ?? 'Guest')
   const composerPrompt = user?.displayName
     ? `Add a comment as ${user.displayName}...`
     : 'Sign in to join the conversation'
 
   return (
-    <main className="preset-detail-page">
-      <section className="mage-watch preset-detail-watch">
+    <main className="scene-detail-page">
+      <section className="mage-watch scene-detail-watch">
         <div className="mage-watch__main">
           <div className="mage-player-shell">
             <div
-              className="mage-stage-frame mage-stage-frame--watch preset-detail-stage"
-              style={{ '--preset-accent': '#63f0d6' } as CSSProperties}
+              className="mage-stage-frame mage-stage-frame--watch scene-detail-stage"
+              style={{ '--scene-accent': '#63f0d6' } as CSSProperties}
             >
               <MagePlayer
-                ariaLabel={`${preset.name} live render`}
-                className="preset-detail-player"
-                sceneBlob={preset.sceneData}
+                ariaLabel={`${scene.name} live render`}
+                className="scene-detail-player"
+                sceneBlob={scene.sceneData}
               />
             </div>
           </div>
 
-          <div className="preset-detail-header">
-            <h1 className="mage-watch__title">{preset.name}</h1>
+          <div className="scene-detail-header">
+            <h1 className="mage-watch__title">{scene.name}</h1>
           </div>
 
-          <section className="preset-detail-social-row">
-            <div className="preset-detail-social-row__creator">
+          <section className="scene-detail-social-row">
+            <div className="scene-detail-social-row__creator">
               <div className="mage-channel-card">
                 <div className="mage-channel-card__avatar" aria-hidden="true">
                   {readInitial(creatorProfile.displayName)}
@@ -247,54 +247,54 @@ export function PresetDetailPage() {
               </div>
 
               {creatorProfile.primaryActionLabel ? (
-                <button className="preset-detail-follow-button" type="button">
+                <button className="scene-detail-follow-button" type="button">
                   {creatorProfile.primaryActionLabel}
                 </button>
               ) : null}
             </div>
 
-            <div className="preset-detail-action-row">
+            <div className="scene-detail-action-row">
               <VoteButton
-                className="preset-detail-action-chip"
+                className="scene-detail-action-chip"
                 count={engagement.upvotesLabel}
                 direction="up"
               />
               <VoteButton
-                className="preset-detail-action-chip"
+                className="scene-detail-action-chip"
                 count={engagement.downvotesLabel}
                 direction="down"
               />
-              <button className="preset-detail-action-chip" type="button">
+              <button className="scene-detail-action-chip" type="button">
                 Share
               </button>
-              <button className="preset-detail-action-chip" type="button">
+              <button className="scene-detail-action-chip" type="button">
                 Save
               </button>
             </div>
           </section>
 
-          <PresetDescriptionCard
+          <SceneDescriptionCard
             creatorProfile={creatorProfile}
             engagement={engagement}
             isDescriptionExpanded={isDescriptionExpanded}
-            presetDescription={presetDescription}
+            sceneDescription={sceneDescription}
             onToggleDescription={() => {
               setIsDescriptionExpanded((currentValue) => !currentValue)
             }}
           />
 
-          <PresetCommentsPanel
-            comments={presetComments}
+          <SceneCommentsPanel
+            comments={sceneComments}
             composerInitial={composerInitial}
             composerPrompt={composerPrompt}
           />
         </div>
 
-        <PresetRecommendationRail
+        <SceneRecommendationRail
           creatorDisplayName={creatorProfile.displayName}
-          currentPresetTags={preset.tags}
+          currentSceneTags={scene.tags}
           isLoading={isRecommendationsLoading}
-          recommendedPresets={filteredRecommendedPresets}
+          recommendedScenes={filteredRecommendedScenes}
           recommendationFilter={recommendationFilter}
           onSelectFilter={setRecommendationFilter}
         />

--- a/src/pages/ScenesPage.test.tsx
+++ b/src/pages/ScenesPage.test.tsx
@@ -2,16 +2,16 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { PresetsPage } from './PresetsPage'
+import { ScenesPage } from './ScenesPage'
 
 const mockTags = [
   { tagId: 1, name: 'fire' },
   { tagId: 2, name: 'water' },
 ]
 
-const mockPresets = [
+const mockScenes = [
   {
-    presetId: 1,
+    sceneId: 1,
     ownerUserId: 10,
     creatorDisplayName: 'Sunset Artist',
     name: 'Sunset Scene',
@@ -20,7 +20,7 @@ const mockPresets = [
     createdAt: new Date().toISOString(),
   },
   {
-    presetId: 2,
+    sceneId: 2,
     ownerUserId: 10,
     creatorDisplayName: 'Ocean Artist',
     name: 'Ocean Breeze',
@@ -30,17 +30,17 @@ const mockPresets = [
   },
 ]
 
-function renderPresetsPage() {
+function renderScenesPage() {
   return render(
-    <MemoryRouter initialEntries={['/presets']}>
-      <PresetsPage />
+    <MemoryRouter initialEntries={['/scenes']}>
+      <ScenesPage />
     </MemoryRouter>,
   )
 }
 
 function mockFetchResponses(
   tagsResponse: unknown[] = mockTags,
-  presetsResponse: unknown[] = mockPresets,
+  scenesResponse: unknown[] = mockScenes,
 ) {
   return vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
     const url = typeof input === 'string' ? input : (input as Request).url
@@ -55,7 +55,7 @@ function mockFetchResponses(
     }
 
     return Promise.resolve(
-      new Response(JSON.stringify(presetsResponse), {
+      new Response(JSON.stringify(scenesResponse), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       }),
@@ -63,7 +63,7 @@ function mockFetchResponses(
   })
 }
 
-describe('PresetsPage', () => {
+describe('ScenesPage', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
   })
@@ -73,15 +73,15 @@ describe('PresetsPage', () => {
       () => new Promise(() => {}),
     )
 
-    renderPresetsPage()
+    renderScenesPage()
 
-    expect(screen.getByLabelText(/loading presets/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/loading scenes/i)).toBeInTheDocument()
   })
 
-  it('renders preset cards after successful fetch', async () => {
+  it('renders scene cards after successful fetch', async () => {
     mockFetchResponses()
 
-    renderPresetsPage()
+    renderScenesPage()
 
     expect(await screen.findByText('Sunset Scene')).toBeInTheDocument()
     expect(screen.getByText('Ocean Breeze')).toBeInTheDocument()
@@ -92,7 +92,7 @@ describe('PresetsPage', () => {
   it('renders tag filter pills after loading', async () => {
     const fetchSpy = mockFetchResponses()
 
-    renderPresetsPage()
+    renderScenesPage()
 
     expect(await screen.findByRole('button', { name: 'All' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'fire' })).toBeInTheDocument()
@@ -107,31 +107,31 @@ describe('PresetsPage', () => {
     expect(tagUrl).toContain('attachedOnly=true')
   })
 
-  it('shows empty state when no presets are returned', async () => {
+  it('shows empty state when no scenes are returned', async () => {
     mockFetchResponses(mockTags, [])
 
-    renderPresetsPage()
+    renderScenesPage()
 
-    expect(await screen.findByText(/no presets found/i)).toBeInTheDocument()
+    expect(await screen.findByText(/no scenes found/i)).toBeInTheDocument()
   })
 
-  it('clicking a tag pill filters presets by that tag', async () => {
+  it('clicking a tag pill filters scenes by that tag', async () => {
     const fetchSpy = mockFetchResponses()
     const user = userEvent.setup()
 
-    renderPresetsPage()
+    renderScenesPage()
 
     const fireButton = await screen.findByRole('button', { name: 'fire' })
     await user.click(fireButton)
 
     await waitFor(() => {
-      const presetCalls = fetchSpy.mock.calls.filter(
+      const sceneCalls = fetchSpy.mock.calls.filter(
         (call) => {
           const url = typeof call[0] === 'string' ? call[0] : (call[0] as Request).url
-          return url.includes('/presets')
+          return url.includes('/scenes')
         },
       )
-      const lastCall = presetCalls[presetCalls.length - 1]
+      const lastCall = sceneCalls[sceneCalls.length - 1]
       const url = typeof lastCall[0] === 'string' ? lastCall[0] : (lastCall[0] as Request).url
       expect(url).toContain('tag=fire')
     })
@@ -141,7 +141,7 @@ describe('PresetsPage', () => {
     const fetchSpy = mockFetchResponses()
     const user = userEvent.setup()
 
-    renderPresetsPage()
+    renderScenesPage()
 
     const fireButton = await screen.findByRole('button', { name: 'fire' })
     await user.click(fireButton)
@@ -150,13 +150,13 @@ describe('PresetsPage', () => {
     await user.click(allButton)
 
     await waitFor(() => {
-      const presetCalls = fetchSpy.mock.calls.filter(
+      const sceneCalls = fetchSpy.mock.calls.filter(
         (call) => {
           const url = typeof call[0] === 'string' ? call[0] : (call[0] as Request).url
-          return url.includes('/presets')
+          return url.includes('/scenes')
         },
       )
-      const lastCall = presetCalls[presetCalls.length - 1]
+      const lastCall = sceneCalls[sceneCalls.length - 1]
       const url = typeof lastCall[0] === 'string' ? lastCall[0] : (lastCall[0] as Request).url
       expect(url).not.toContain('tag=')
     })
@@ -180,7 +180,7 @@ describe('PresetsPage', () => {
       )
     })
 
-    renderPresetsPage()
+    renderScenesPage()
 
     expect(await screen.findByText(/something went wrong/i)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument()

--- a/src/pages/ScenesPage.tsx
+++ b/src/pages/ScenesPage.tsx
@@ -1,16 +1,16 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import type { PresetListResponse, TagResponse } from '../lib/api'
-import { fetchPresets, fetchTags } from '../lib/api'
-import { PresetCard } from '../components/PresetCard'
+import type { SceneListResponse, TagResponse } from '../lib/api'
+import { fetchScenes, fetchTags } from '../lib/api'
+import { SceneCard } from '../components/SceneCard'
 import { TagFilterBar } from '../components/TagFilterBar'
 
 type PageState = 'loading' | 'ready' | 'error'
 
-export function PresetsPage() {
+export function ScenesPage() {
   const [searchParams, setSearchParams] = useSearchParams()
   const [tags, setTags] = useState<TagResponse[]>([])
-  const [presets, setPresets] = useState<PresetListResponse[]>([])
+  const [scenes, setScenes] = useState<SceneListResponse[]>([])
   const [pageState, setPageState] = useState<PageState>('loading')
   const [tagsLoading, setTagsLoading] = useState(true)
   const [reloadVersion, setReloadVersion] = useState(0)
@@ -58,15 +58,15 @@ export function PresetsPage() {
   useEffect(() => {
     let cancelled = false
 
-    async function loadPresets() {
+    async function loadScenes() {
       try {
-        const data = await fetchPresets(activeTag)
+        const data = await fetchScenes(activeTag)
 
         if (cancelled) {
           return
         }
 
-        setPresets(data)
+        setScenes(data)
         setPageState('ready')
       } catch {
         if (!cancelled) {
@@ -75,7 +75,7 @@ export function PresetsPage() {
       }
     }
 
-    void loadPresets()
+    void loadScenes()
 
     return () => {
       cancelled = true
@@ -112,8 +112,8 @@ export function PresetsPage() {
   }
 
   return (
-    <main className="presets-page">
-      <div className="presets-filter-rail">
+    <main className="scenes-page">
+      <div className="scenes-filter-rail">
         <TagFilterBar
           tags={availableTags}
           activeTag={activeTag}
@@ -123,13 +123,13 @@ export function PresetsPage() {
       </div>
 
       {pageState === 'loading' && (
-        <div className="preset-grid" aria-label="Loading presets">
+        <div className="scene-grid" aria-label="Loading scenes">
           {Array.from({ length: 6 }, (_, i) => (
-            <div key={i} className="preset-card preset-card--skeleton" aria-hidden="true">
-              <div className="preset-card__thumbnail preset-card__thumbnail--skeleton" />
-              <div className="preset-card__body">
-                <span className="preset-card__avatar preset-card__avatar--skeleton" />
-                <div className="preset-card__meta">
+            <div key={i} className="scene-card scene-card--skeleton" aria-hidden="true">
+              <div className="scene-card__thumbnail scene-card__thumbnail--skeleton" />
+              <div className="scene-card__body">
+                <span className="scene-card__avatar scene-card__avatar--skeleton" />
+                <div className="scene-card__meta">
                   <span className="skeleton-text skeleton-text--title" />
                   <span className="skeleton-text skeleton-text--sub" />
                   <span className="skeleton-text skeleton-text--meta" />
@@ -140,28 +140,28 @@ export function PresetsPage() {
         </div>
       )}
 
-      {pageState === 'ready' && presets.length === 0 && (
-        <div className="presets-empty" role="status">
-          <p>No presets found{activeTag ? ` for "${activeTag}"` : ''}.</p>
-          <p className="presets-empty__hint">
+      {pageState === 'ready' && scenes.length === 0 && (
+        <div className="scenes-empty" role="status">
+          <p>No scenes found{activeTag ? ` for "${activeTag}"` : ''}.</p>
+          <p className="scenes-empty__hint">
             {activeTag
-              ? 'Try selecting a different tag or browse all presets.'
-              : 'Presets will appear here once they are created.'}
+              ? 'Try selecting a different tag or browse all scenes.'
+              : 'Scenes will appear here once they are created.'}
           </p>
         </div>
       )}
 
-      {pageState === 'ready' && presets.length > 0 && (
-        <div className="preset-grid" aria-label="Preset list">
-          {presets.map((preset) => (
-            <PresetCard key={preset.presetId} preset={preset} />
+      {pageState === 'ready' && scenes.length > 0 && (
+        <div className="scene-grid" aria-label="Scene list">
+          {scenes.map((scene) => (
+            <SceneCard key={scene.sceneId} scene={scene} />
           ))}
         </div>
       )}
 
       {pageState === 'error' && (
-        <div className="presets-error" role="alert">
-          <p>Something went wrong loading presets.</p>
+        <div className="scenes-error" role="alert">
+          <p>Something went wrong loading scenes.</p>
           <button className="demo-link" onClick={handleRetry} type="button">
             Try again
           </button>

--- a/src/pages/SettingsPage.test.tsx
+++ b/src/pages/SettingsPage.test.tsx
@@ -41,7 +41,7 @@ describe('SettingsPage', () => {
       isAuthenticated: true,
       user: {
         authProvider: 'LOCAL',
-        displayName: 'Preset Artist',
+        displayName: 'Scene Artist',
         email: 'artist@example.com',
         userId: 8,
       },
@@ -55,7 +55,7 @@ describe('SettingsPage', () => {
       screen.getByText(/review the account details currently tied to your mage profile/i),
     ).toBeInTheDocument()
     expect(screen.getByLabelText(/email/i)).toHaveValue('artist@example.com')
-    expect(screen.getByLabelText(/first name/i)).toHaveValue('Preset')
+    expect(screen.getByLabelText(/first name/i)).toHaveValue('Scene')
     expect(screen.getByLabelText(/last name/i)).toHaveValue('Artist')
     expect(screen.queryByText('LOCAL')).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: /reset password/i })).toBeInTheDocument()

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -100,7 +100,7 @@ function ProfileDetailsForm({ displayName, email }: ProfileDetailsFormProps) {
           />
         </div>
 
-        <button className="preset-secondary-button settings-reset-button" type="button">
+        <button className="scene-secondary-button settings-reset-button" type="button">
           Reset password
         </button>
       </div>

--- a/src/types/mage-engine.d.ts
+++ b/src/types/mage-engine.d.ts
@@ -1,7 +1,7 @@
 declare module '@mage/engine' {
   export type MageEngine = {
     dispose: () => void
-    loadPreset: (preset: unknown) => unknown
+    loadPreset: (scene: unknown) => unknown
     start: () => void
   }
 


### PR DESCRIPTION
## Summary

This PR renames the frontend preset experience to scenes across routes, pages, components, helpers, tests, styles, and frontend docs.

## Changes

- Renames scene browsing, detail, and creation flows from preset terminology to scene terminology
- Updates frontend routes to:
  - `/scenes`
  - `/scenes/:id`
  - `/my-scenes`
  - `/create-scene`
- Updates API usage to call scene endpoints and consume `sceneId`
- Renames affected pages, components, and helpers, including:
  - discovery/list pages
  - scene detail views
  - my scenes views
  - scene editor/create flow
  - thumbnail upload/editor utilities
- Updates shared styling and tests to use scene naming
- Updates frontend README/docs to match the new terminology

## Testing

- `npm test -- --run`
- `npm run build`
