### PR TITLE
Fix Linux native build dependencies for Docker deploys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,10 @@
         "typescript-eslint": "^8.48.0",
         "vite": "^7.3.1",
         "vitest": "^4.1.2"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@swc/core-linux-x64-gnu": "1.15.18"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -749,6 +753,19 @@
       "version": "2.0.2",
       "license": "MIT"
     },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.59.0",
       "cpu": [
@@ -820,6 +837,22 @@
         "@swc/helpers": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.18.tgz",
+      "integrity": "sha512-wG9J8vReUlpaHz4KOD/5UE1AUgirimU4UFT9oZmupUDEofxJKYb1mTA/DrMj0s78bkBiNI+7Fo2EgPuvOJfuAA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.13.1"
   },
+  "optionalDependencies": {
+    "@swc/core-linux-x64-gnu": "1.15.18",
+    "@rollup/rollup-linux-x64-gnu": "4.59.0"
+  },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
     "@testing-library/jest-dom": "^6.9.1",


### PR DESCRIPTION
## Summary

Fix Docker/Linux deployments failing during `vite build` because native Rollup and SWC binaries were missing from installs produced by `npm ci`.

## What Changed

- added `@rollup/rollup-linux-x64-gnu` as an explicit `optionalDependency`
- added `@swc/core-linux-x64-gnu` as an explicit `optionalDependency`
- regenerated `package-lock.json` so the Linux native packages are concretely present in the lockfile

## Why

The frontend lockfile had been generated on Windows and only contained the Windows native package entries in the concrete `packages` section.

In local development this was fine, but Linux container builds were failing with:

- `Cannot find module @rollup/rollup-linux-x64-gnu`
- `Error: Failed to load native binding` from `@swc/core`

This caused Docker/Coolify deployments to fail during:

- `npm run build`
- specifically inside `vite build`

## Result

Linux container installs now get the native binaries they need, and the Docker build path succeeds again.

## Verification

- `npm run build`
- `docker build --no-cache -f Dockerfile --progress plain .`
