### PR TITLE
Fix frontend Docker build inputs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ ARG VITE_API_BASE_URL=
 ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
 
 COPY package.json package-lock.json ./
-COPY patches ./patches
-COPY vendor ./vendor
 RUN npm ci
 
 COPY . .


### PR DESCRIPTION
## Summary

Fix the frontend Docker build after switching fully to the published `@notrac/mage` package.

## What changed

- removed stale `COPY patches ./patches` from the frontend Dockerfile
- removed stale `COPY vendor ./vendor` from the frontend Dockerfile
- kept the install path aligned with the current frontend package setup:
  - copy `package.json` and `package-lock.json`
  - run `npm ci`
  - copy the rest of the app
  - run `npm run build`

## Why

The frontend no longer depends on the old local patching flow during Docker build, but the Dockerfile still expected `patches/` and `vendor/` to exist as required build inputs. In Coolify this caused the image build to fail at:

`COPY patches ./patches`

with:

`"/patches": not found`

## Verification

- `npm run build`
- `docker build -f Dockerfile -t mage-frontend-test --build-arg VITE_API_BASE_URL=/api .`

Both passed locally.

