### PR TITLE
Feat/create scene section navigation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2200,24 +2200,6 @@
   line-height: 1.7;
 }
 
-.scene-editor-section__subheader {
-  display: grid;
-  gap: 6px;
-  margin: 24px 0 18px;
-}
-
-.scene-editor-section__subheader h3 {
-  margin: 0;
-  font-size: 1rem;
-  letter-spacing: 0.02em;
-}
-
-.scene-editor-section__subheader p {
-  margin: 0;
-  color: var(--muted);
-  line-height: 1.7;
-}
-
 .scene-editor-grid {
   display: grid;
   gap: 18px;

--- a/src/App.css
+++ b/src/App.css
@@ -2081,6 +2081,12 @@
   gap: 22px;
 }
 
+.scene-editor-stack {
+  display: grid;
+  gap: 18px;
+  margin-bottom: 24px;
+}
+
 .scene-editor-toolbar {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
@@ -2189,6 +2195,24 @@
 .scene-editor-section__header p,
 .scene-editor-preview__header p,
 .scene-effect-footnote {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.scene-editor-section__subheader {
+  display: grid;
+  gap: 6px;
+  margin: 24px 0 18px;
+}
+
+.scene-editor-section__subheader h3 {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0.02em;
+}
+
+.scene-editor-section__subheader p {
   margin: 0;
   color: var(--muted);
   line-height: 1.7;
@@ -2738,7 +2762,6 @@
 .scene-editor-submit {
   width: auto;
   min-width: 220px;
-  justify-self: start;
   cursor: pointer;
   white-space: nowrap;
 }
@@ -2747,6 +2770,48 @@
   transform: none;
   background: #7bf4e1;
   box-shadow: 0 10px 30px rgba(99, 240, 214, 0.18);
+}
+
+.scene-editor-action-bar {
+  position: sticky;
+  bottom: 16px;
+  z-index: 12;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 18px;
+  padding: 16px 18px;
+  border: 1px solid rgba(99, 240, 214, 0.14);
+  border-radius: 22px;
+  background: rgba(5, 14, 16, 0.9);
+  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(18px);
+}
+
+.scene-editor-action-bar__meta {
+  display: grid;
+  gap: 2px;
+}
+
+.scene-editor-action-bar__meta strong {
+  font-size: 1rem;
+  letter-spacing: -0.02em;
+}
+
+.scene-editor-action-bar__meta span:last-child {
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.scene-editor-action-bar__buttons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.scene-editor-nav-button {
+  min-width: 108px;
 }
 
 .scene-editor-preview {
@@ -2802,6 +2867,10 @@
 
   .scene-editor-preview__card {
     position: static;
+  }
+
+  .scene-editor-action-bar {
+    bottom: 0;
   }
 }
 
@@ -2859,6 +2928,19 @@
 
   .scene-editor-submit {
     width: 100%;
+  }
+
+  .scene-editor-action-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .scene-editor-action-bar__buttons {
+    justify-content: stretch;
+  }
+
+  .scene-editor-nav-button {
+    flex: 1;
   }
 
   .scene-pass-order__actions {

--- a/src/App.css
+++ b/src/App.css
@@ -2066,7 +2066,14 @@
 }
 
 .surface--editor {
-  padding: 40px 30px;
+  --scene-editor-edge-gap: 40px;
+  --scene-editor-footer-gap: calc(var(--scene-editor-edge-gap) / 4);
+  --scene-editor-side-gap: 30px;
+  --scene-editor-panel-radius: 32px;
+  padding:
+    var(--scene-editor-edge-gap)
+    var(--scene-editor-side-gap)
+    var(--scene-editor-footer-gap);
   overflow: visible;
 }
 
@@ -2755,19 +2762,54 @@
 }
 
 .scene-editor-action-bar {
+  grid-column: 1 / -1;
   position: sticky;
-  bottom: 16px;
+  bottom: var(--scene-editor-footer-gap);
   z-index: 12;
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 18px;
-  padding: 16px 18px;
-  border: 1px solid rgba(99, 240, 214, 0.14);
-  border-radius: 22px;
-  background: rgba(5, 14, 16, 0.9);
-  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.28);
-  backdrop-filter: blur(18px);
+  width: calc(100% + (var(--scene-editor-side-gap) * 2));
+  margin-inline: calc(var(--scene-editor-side-gap) * -1);
+  padding: 16px var(--scene-editor-side-gap) 0;
+  border: 0;
+  border-top: 1px solid var(--surface-soft-border);
+  border-radius: 0;
+  background: var(--bg-soft);
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
+.scene-editor-action-bar:not(.scene-editor-action-bar--stuck) {
+  border-radius: 0 0 var(--scene-editor-panel-radius) var(--scene-editor-panel-radius);
+}
+
+.scene-editor-action-bar::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 0;
+  width: 100%;
+  height: var(--scene-editor-footer-gap);
+  background: var(--bg-soft);
+  box-sizing: border-box;
+  pointer-events: none;
+}
+
+.scene-editor-action-bar:not(.scene-editor-action-bar--stuck)::after {
+  border-right: 1px solid var(--surface-soft-border);
+  border-left: 1px solid var(--surface-soft-border);
+  border-radius: 0 0 var(--scene-editor-panel-radius) var(--scene-editor-panel-radius);
+}
+
+.scene-editor-action-bar--stuck::after {
+  border-radius: 0;
+}
+
+.scene-editor-action-bar-sentinel {
+  grid-column: 1 / -1;
+  height: 1px;
 }
 
 .scene-editor-action-bar__meta {
@@ -2886,7 +2928,14 @@
 
 @media (max-width: 780px) {
   .surface--editor {
-    padding: 30px 24px;
+    --scene-editor-edge-gap: 30px;
+    --scene-editor-footer-gap: calc(var(--scene-editor-edge-gap) / 4);
+    --scene-editor-side-gap: 24px;
+    --scene-editor-panel-radius: 28px;
+    padding:
+      var(--scene-editor-edge-gap)
+      var(--scene-editor-side-gap)
+      var(--scene-editor-footer-gap);
   }
 
   .scene-editor-grid--2,

--- a/src/App.css
+++ b/src/App.css
@@ -2067,13 +2067,9 @@
 
 .surface--editor {
   --scene-editor-edge-gap: 40px;
-  --scene-editor-footer-gap: calc(var(--scene-editor-edge-gap) / 4);
   --scene-editor-side-gap: 30px;
   --scene-editor-panel-radius: 32px;
-  padding:
-    var(--scene-editor-edge-gap)
-    var(--scene-editor-side-gap)
-    var(--scene-editor-footer-gap);
+  padding: var(--scene-editor-edge-gap) var(--scene-editor-side-gap) 0;
   overflow: visible;
 }
 
@@ -2091,7 +2087,6 @@
 .scene-editor-stack {
   display: grid;
   gap: 18px;
-  margin-bottom: 24px;
 }
 
 .scene-editor-toolbar {
@@ -2122,16 +2117,8 @@
 }
 
 .scene-editor-toolbar__control-group--navigation {
-  gap: 12px;
-  padding: 18px;
-  border-radius: 20px;
-  border: 1px solid rgba(99, 240, 214, 0.16);
-  background:
-    linear-gradient(
-      135deg,
-      rgba(15, 48, 44, 0.72),
-      rgba(8, 22, 25, 0.72)
-    );
+  gap: 16px;
+  padding: 10px 0 4px;
 }
 
 .scene-editor-toolbar__control-copy {
@@ -2154,28 +2141,112 @@
   line-height: 1.55;
 }
 
-.scene-editor-toolbar__navigation-shell {
+.scene-editor-stepper {
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.scene-editor-stepper::-webkit-scrollbar {
+  display: none;
+}
+
+.scene-editor-stepper__list {
+  list-style: none;
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(104px, 1fr);
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  min-width: max-content;
+}
+
+.scene-editor-stepper__item {
   position: relative;
 }
 
-.scene-editor-toolbar__navigation-icon {
+.scene-editor-stepper__item:not(:last-child)::after {
+  content: "";
   position: absolute;
-  top: 50%;
-  left: 16px;
-  width: 18px;
-  height: 18px;
-  color: var(--accent);
-  transform: translateY(-50%);
-  pointer-events: none;
+  top: 48px;
+  left: calc(50% + 11px);
+  width: calc(100% - 22px);
+  height: 2px;
+  background: rgba(255, 255, 255, 0.18);
 }
 
-.scene-editor-toolbar__navigation-icon svg {
-  display: block;
+.scene-editor-stepper__button {
   width: 100%;
-  height: 100%;
+  display: grid;
+  grid-template-rows: minmax(28px, auto) 22px;
+  justify-items: center;
+  gap: 12px;
+  padding: 0 12px;
+  border: 0;
+  background: none;
+  color: var(--muted);
+  cursor: pointer;
+  text-align: center;
+  position: relative;
+  z-index: 1;
+}
+
+.scene-editor-stepper__button:hover {
+  color: #d8e6e1;
+}
+
+.scene-editor-stepper__button--active {
+  color: #f2f8f6;
+}
+
+.scene-editor-stepper__button--complete {
+  color: #d8e6e1;
+}
+
+.scene-editor-stepper__button--invalid {
+  color: #ff8c83;
+}
+
+.scene-editor-stepper__label {
+  font-size: 0.98rem;
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+.scene-editor-stepper__marker {
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  border: 3px solid rgba(255, 255, 255, 0.22);
+  background: var(--bg-soft);
+  color: #061013;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.scene-editor-stepper__marker svg {
+  width: 14px;
+  height: 14px;
+}
+
+.scene-editor-stepper__button--active .scene-editor-stepper__marker {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px rgba(99, 240, 214, 0.12);
+}
+
+.scene-editor-stepper__button--complete .scene-editor-stepper__marker {
+  border-color: #eef5f3;
+  background: #eef5f3;
+}
+
+.scene-editor-stepper__button--invalid .scene-editor-stepper__marker {
+  border-color: #ff8c83;
+  color: #ff8c83;
 }
 
 .scene-editor-layout {
+  position: relative;
   display: grid;
   grid-template-columns: minmax(0, 1.55fr) minmax(320px, 0.95fr);
   gap: 24px;
@@ -2183,13 +2254,55 @@
 }
 
 .scene-editor-section {
-  padding: 24px;
+  display: grid;
+  gap: 18px;
 }
 
 .scene-editor-section__header {
   display: grid;
   gap: 6px;
-  margin-bottom: 18px;
+}
+
+.scene-editor-section__content {
+  display: grid;
+  gap: 18px;
+}
+
+.scene-editor-collapsible {
+  display: grid;
+  gap: 14px;
+  justify-items: center;
+}
+
+.scene-editor-collapsible__toggle {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  min-height: 40px;
+  padding: 0 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(99, 240, 214, 0.18);
+  background: rgba(99, 240, 214, 0.08);
+  color: #f5fbf9;
+  font: inherit;
+  font-size: 0.88rem;
+  font-weight: 700;
+  text-align: center;
+  cursor: pointer;
+  justify-self: center;
+}
+
+.scene-editor-collapsible__toggle:hover {
+  border-color: rgba(99, 240, 214, 0.3);
+  background: rgba(99, 240, 214, 0.14);
+}
+
+.scene-editor-collapsible__content {
+  display: grid;
+  gap: 16px;
+  width: 100%;
 }
 
 .scene-editor-section__header h2,
@@ -2226,7 +2339,55 @@
 
 .scene-field {
   display: grid;
-  gap: 8px;
+  gap: 0;
+  min-width: 0;
+}
+
+.scene-field__shell,
+.scene-slider,
+.scene-toggle:not(.scene-toggle--compact) {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background:
+    linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.035),
+      rgba(255, 255, 255, 0.015)
+    ),
+    rgba(6, 17, 20, 0.44);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025);
+}
+
+.scene-field__shell:focus-within,
+.scene-slider:focus-within,
+.scene-toggle:not(.scene-toggle--compact):focus-within {
+  border-color: rgba(99, 240, 214, 0.18);
+  background:
+    linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.04),
+      rgba(255, 255, 255, 0.018)
+    ),
+    rgba(6, 17, 20, 0.5);
+}
+
+.scene-field__top,
+.scene-slider__top,
+.scene-toggle__top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.scene-field__copy,
+.scene-slider__copy,
+.scene-toggle__copy {
+  display: grid;
+  gap: 6px;
   min-width: 0;
 }
 
@@ -2237,8 +2398,159 @@
   font-weight: 700;
 }
 
+.scene-field__label-row,
+.scene-toggle__label-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.scene-field__control {
+  display: grid;
+  gap: 12px;
+}
+
 .scene-field__description {
-  display: none;
+  margin: 0;
+  color: rgba(180, 201, 196, 0.86);
+  font-size: 0.84rem;
+  line-height: 1.55;
+}
+
+.surface--editor .field-group {
+  display: grid;
+  gap: 14px;
+  min-width: 0;
+  padding: 18px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background:
+    linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.035),
+      rgba(255, 255, 255, 0.015)
+    ),
+    rgba(6, 17, 20, 0.44);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025);
+}
+
+.surface--editor .field-group:focus-within {
+  border-color: rgba(99, 240, 214, 0.18);
+  background:
+    linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.04),
+      rgba(255, 255, 255, 0.018)
+    ),
+    rgba(6, 17, 20, 0.5);
+}
+
+.scene-confirm-summary {
+  display: grid;
+  gap: 20px;
+}
+
+.scene-confirm-section {
+  display: grid;
+  gap: 14px;
+}
+
+.scene-confirm-section + .scene-confirm-section {
+  padding-top: 20px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.scene-confirm-section__title {
+  margin: 0;
+  color: #f5fbf9;
+  font-size: 1rem;
+  letter-spacing: -0.02em;
+}
+
+.scene-confirm-section__list {
+  display: grid;
+  gap: 0;
+  margin: 0;
+}
+
+.scene-confirm-section__item {
+  display: grid;
+  grid-template-columns: minmax(132px, 180px) minmax(0, 1fr);
+  gap: 14px;
+  padding: 10px 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.scene-confirm-section__item:first-child {
+  padding-top: 0;
+  border-top: 0;
+}
+
+.scene-confirm-section__term {
+  color: rgba(155, 177, 171, 0.88);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.scene-confirm-section__value {
+  margin: 0;
+  color: #f5fbf9;
+  line-height: 1.6;
+  text-align: left;
+}
+
+.scene-confirm-vector {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.scene-confirm-vector__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 30px;
+  padding: 0 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.scene-confirm-vector__axis {
+  color: rgba(155, 177, 171, 0.88);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.scene-confirm-vector__value {
+  color: #f5fbf9;
+  font-feature-settings: "tnum" 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.scene-confirm-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.scene-confirm-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(99, 240, 214, 0.16);
+  background: rgba(99, 240, 214, 0.08);
+  color: #e8fffb;
+  font-size: 0.82rem;
+  line-height: 1;
 }
 
 .scene-thumbnail-picker {
@@ -2384,17 +2696,12 @@
   font: inherit;
   text-align: left;
   cursor: pointer;
-  transition:
-    transform 0.18s ease,
-    border-color 0.18s ease,
-    background-color 0.18s ease,
-    box-shadow 0.18s ease;
 }
 
 .scene-thumbnail-choice:hover {
-  transform: translateY(-1px);
   border-color: rgba(99, 240, 214, 0.34);
   background: rgba(255, 255, 255, 0.05);
+  box-shadow: 0 0 0 1px rgba(99, 240, 214, 0.12);
 }
 
 .scene-thumbnail-choice.is-selected {
@@ -2444,19 +2751,24 @@
   background-color: rgba(4, 12, 14, 0.56);
 }
 
-.scene-slider {
-  display: grid;
-  gap: 10px;
+.scene-field--slider {
+  gap: 0;
 }
 
-.scene-slider__header {
-  display: flex;
-  justify-content: flex-end;
-}
-
-.scene-slider__header strong {
-  font-size: 0.88rem;
+.scene-slider__value {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 72px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(99, 240, 214, 0.16);
+  background: rgba(99, 240, 214, 0.08);
   color: var(--accent);
+  font-size: 0.88rem;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
 }
 
 .scene-slider__controls {
@@ -2474,8 +2786,8 @@
   appearance: none;
   background: linear-gradient(
     90deg,
-    rgba(99, 240, 214, 0.3),
-    rgba(118, 196, 255, 0.3)
+    rgba(99, 240, 214, 0.38),
+    rgba(118, 196, 255, 0.34)
   );
   outline: none;
 }
@@ -2518,36 +2830,42 @@
 }
 
 .scene-toggle {
+  display: block;
+  cursor: pointer;
+}
+
+.scene-toggle--compact {
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 16px;
-  padding: 16px 18px;
-  border-radius: 18px;
+  padding: 12px 14px;
+  border-radius: 16px;
   border: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(255, 255, 255, 0.03);
-  cursor: pointer;
 }
 
 .scene-toggle__copy {
   display: grid;
-  gap: 4px;
+  gap: 0;
+  min-width: 0;
 }
 
-.scene-toggle__copy span {
+.scene-toggle__label {
   color: #f5fbf9;
   font-size: 0.94rem;
   font-weight: 700;
 }
 
-.scene-toggle__copy small {
-  color: var(--muted);
-  line-height: 1.5;
-}
-
 .scene-toggle__control {
   display: inline-flex;
   align-items: center;
+}
+
+.scene-toggle__switch {
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
 }
 
 .scene-toggle__input {
@@ -2577,11 +2895,11 @@
   transition: transform 0.18s ease;
 }
 
-.scene-toggle__input:checked + .scene-toggle__track {
+.scene-toggle__input:checked + .scene-toggle__switch .scene-toggle__track {
   background: rgba(99, 240, 214, 0.34);
 }
 
-.scene-toggle__input:checked + .scene-toggle__track::after {
+.scene-toggle__input:checked + .scene-toggle__switch .scene-toggle__track::after {
   transform: translateX(20px);
 }
 
@@ -2609,13 +2927,27 @@
   gap: 18px;
 }
 
-.effect-card {
+.effect-card-group {
   display: grid;
-  gap: 18px;
-  padding: 20px;
+  gap: 14px;
 }
 
-.effect-card.is-disabled {
+.effect-card {
+  display: grid;
+  padding: 18px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background:
+    linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.035),
+      rgba(255, 255, 255, 0.015)
+    ),
+    rgba(6, 17, 20, 0.44);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025);
+}
+
+.effect-card-group.is-disabled .effect-card {
   opacity: 0.92;
 }
 
@@ -2638,9 +2970,21 @@
   line-height: 1.6;
 }
 
+.effect-card__details {
+  display: grid;
+  gap: 16px;
+  margin-left: 18px;
+  padding-left: 18px;
+  border-left: 1px solid rgba(99, 240, 214, 0.14);
+}
+
 .effect-card__content,
 .effect-card__footer {
   display: grid;
+  gap: 16px;
+}
+
+.effect-card__content .scene-editor-grid {
   gap: 16px;
 }
 
@@ -2671,7 +3015,7 @@
 
 .scene-pass-order {
   display: grid;
-  gap: 10px;
+  gap: 18px;
   margin: 0;
   padding: 0;
   list-style: none;
@@ -2681,26 +3025,64 @@
   display: flex;
   justify-content: space-between;
   gap: 16px;
-  align-items: center;
-  padding: 14px 16px;
-  border-radius: 16px;
+  align-items: flex-start;
+  padding: 18px;
+  border-radius: 20px;
   border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.03);
+  background:
+    linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.035),
+      rgba(255, 255, 255, 0.015)
+    ),
+    rgba(6, 17, 20, 0.44);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025);
 }
 
 .scene-pass-order__copy {
   display: grid;
-  gap: 4px;
+  gap: 10px;
+  min-width: 0;
+}
+
+.scene-pass-order__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.scene-pass-order__copy strong {
+  font-size: 1rem;
+  letter-spacing: -0.02em;
+}
+
+.scene-pass-order__index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  padding: 0 12px;
+  min-height: 30px;
+  border-radius: 999px;
+  border: 1px solid rgba(99, 240, 214, 0.18);
+  background: rgba(99, 240, 214, 0.08);
+  color: var(--accent);
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
 }
 
 .scene-pass-order__copy span {
   color: var(--muted);
-  font-size: 0.88rem;
+  font-size: 0.9rem;
+  line-height: 1.55;
 }
 
 .scene-pass-order__actions {
   display: flex;
   gap: 8px;
+  justify-content: flex-end;
 }
 
 .scene-order-button,
@@ -2753,18 +3135,19 @@
   min-width: 220px;
   cursor: pointer;
   white-space: nowrap;
+  box-shadow: none;
 }
 
 .scene-editor-submit:hover {
   transform: none;
   background: #7bf4e1;
-  box-shadow: 0 10px 30px rgba(99, 240, 214, 0.18);
+  box-shadow: none;
 }
 
 .scene-editor-action-bar {
   grid-column: 1 / -1;
   position: sticky;
-  bottom: var(--scene-editor-footer-gap);
+  bottom: 0;
   z-index: 12;
   display: flex;
   justify-content: space-between;
@@ -2772,7 +3155,7 @@
   gap: 18px;
   width: calc(100% + (var(--scene-editor-side-gap) * 2));
   margin-inline: calc(var(--scene-editor-side-gap) * -1);
-  padding: 16px var(--scene-editor-side-gap) 0;
+  padding: 16px var(--scene-editor-side-gap);
   border: 0;
   border-top: 1px solid var(--surface-soft-border);
   border-radius: 0;
@@ -2785,31 +3168,13 @@
   border-radius: 0 0 var(--scene-editor-panel-radius) var(--scene-editor-panel-radius);
 }
 
-.scene-editor-action-bar::after {
-  content: "";
-  position: absolute;
-  top: 100%;
-  left: 0;
-  width: 100%;
-  height: var(--scene-editor-footer-gap);
-  background: var(--bg-soft);
-  box-sizing: border-box;
-  pointer-events: none;
-}
-
-.scene-editor-action-bar:not(.scene-editor-action-bar--stuck)::after {
-  border-right: 1px solid var(--surface-soft-border);
-  border-left: 1px solid var(--surface-soft-border);
-  border-radius: 0 0 var(--scene-editor-panel-radius) var(--scene-editor-panel-radius);
-}
-
-.scene-editor-action-bar--stuck::after {
-  border-radius: 0;
-}
-
 .scene-editor-action-bar-sentinel {
-  grid-column: 1 / -1;
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
   height: 1px;
+  pointer-events: none;
 }
 
 .scene-editor-action-bar__meta {
@@ -2929,13 +3294,9 @@
 @media (max-width: 780px) {
   .surface--editor {
     --scene-editor-edge-gap: 30px;
-    --scene-editor-footer-gap: calc(var(--scene-editor-edge-gap) / 4);
     --scene-editor-side-gap: 24px;
     --scene-editor-panel-radius: 28px;
-    padding:
-      var(--scene-editor-edge-gap)
-      var(--scene-editor-side-gap)
-      var(--scene-editor-footer-gap);
+    padding: var(--scene-editor-edge-gap) var(--scene-editor-side-gap) 0;
   }
 
   .scene-editor-grid--2,
@@ -2950,7 +3311,10 @@
   .scene-slider__controls,
   .scene-vector-field,
   .scene-advanced-header,
+  .scene-editor-collapsible__toggle,
+  .scene-confirm-section__item,
   .effect-card__header,
+  .scene-pass-order__header,
   .scene-pass-order__item {
     grid-template-columns: minmax(0, 1fr);
     flex-direction: column;

--- a/src/components/SceneEditorControls.tsx
+++ b/src/components/SceneEditorControls.tsx
@@ -36,6 +36,7 @@ type SliderFieldProps = NumberFieldProps & {
 }
 
 type ToggleFieldProps = {
+  compact?: boolean
   description?: string
   id: string
   label: string
@@ -76,13 +77,19 @@ function FieldShell({
 }>) {
   return (
     <div className="scene-field">
-      <div className="scene-field__label-row">
-        <label className="scene-field__label" htmlFor={htmlFor}>
-          {label}
-        </label>
+      <div className="scene-field__shell">
+        <div className="scene-field__top">
+          <div className="scene-field__copy">
+            <div className="scene-field__label-row">
+              <label className="scene-field__label" htmlFor={htmlFor}>
+                {label}
+              </label>
+            </div>
+            {description ? <p className="scene-field__description">{description}</p> : null}
+          </div>
+        </div>
+        <div className="scene-field__control">{children}</div>
       </div>
-      {description ? <p className="scene-field__description">{description}</p> : null}
-      {children}
     </div>
   )
 }
@@ -109,7 +116,7 @@ function formatSliderValue(value: number, formatValue?: (value: number) => strin
 
 export function SceneSection({ children, className, description, title }: SectionProps) {
   return (
-    <section className={buildClassName('surface surface--soft scene-editor-section', className)}>
+    <section className={buildClassName('scene-editor-section', className)}>
       <div className="scene-editor-section__header">
         <h2>{title}</h2>
         <p>{description}</p>
@@ -185,10 +192,20 @@ export function SliderField({
   value,
 }: SliderFieldProps) {
   return (
-    <FieldShell description={description} htmlFor={id} label={label}>
+    <div className="scene-field scene-field--slider">
       <div className="scene-slider">
-        <div className="scene-slider__header">
-          <strong>{formatSliderValue(value, formatValue)}</strong>
+        <div className="scene-slider__top">
+          <div className="scene-slider__copy">
+            <div className="scene-field__label-row">
+              <label className="scene-field__label" htmlFor={id}>
+                {label}
+              </label>
+            </div>
+            {description ? <p className="scene-field__description">{description}</p> : null}
+          </div>
+          <output className="scene-slider__value" htmlFor={id}>
+            {formatSliderValue(value, formatValue)}
+          </output>
         </div>
         <div className="scene-slider__controls">
           <input
@@ -202,6 +219,7 @@ export function SliderField({
             value={value}
           />
           <input
+            aria-label="Numeric value"
             className="scene-slider__number"
             max={max}
             min={min}
@@ -212,34 +230,45 @@ export function SliderField({
           />
         </div>
       </div>
-    </FieldShell>
+    </div>
   )
 }
 
 export function ToggleField({
   checked,
+  compact = false,
   description,
   id,
   label,
   onChange,
 }: ToggleFieldProps) {
   return (
-    <label className="scene-toggle" htmlFor={id}>
-      <div className="scene-toggle__copy">
-        <span>{label}</span>
-        {description ? <small>{description}</small> : null}
+    <div className={buildClassName('scene-toggle-field', compact && 'scene-toggle-field--compact')}>
+      <div className={buildClassName('scene-toggle', compact && 'scene-toggle--compact')}>
+        <div className="scene-toggle__top">
+          <div className="scene-toggle__copy">
+            <div className="scene-toggle__label-row">
+              <label className="scene-toggle__label" htmlFor={id}>
+                {label}
+              </label>
+            </div>
+            {description ? <p className="scene-field__description">{description}</p> : null}
+          </div>
+          <span className="scene-toggle__control">
+            <input
+              checked={checked}
+              className="scene-toggle__input"
+              id={id}
+              onChange={(event) => onChange(event.currentTarget.checked)}
+              type="checkbox"
+            />
+            <label className="scene-toggle__switch" htmlFor={id}>
+              <span className="scene-toggle__track" aria-hidden="true" />
+            </label>
+          </span>
+        </div>
       </div>
-      <span className="scene-toggle__control">
-        <input
-          checked={checked}
-          className="scene-toggle__input"
-          id={id}
-          onChange={(event) => onChange(event.currentTarget.checked)}
-          type="checkbox"
-        />
-        <span className="scene-toggle__track" aria-hidden="true" />
-      </span>
-    </label>
+    </div>
   )
 }
 
@@ -291,25 +320,30 @@ export function EffectCard({
   const toggleId = `${title.toLowerCase().replace(/\s+/g, '-')}-toggle`
 
   return (
-    <section
-      className={buildClassName('surface surface--nested effect-card', !isEnabled && 'is-disabled')}
-    >
-      <div className="effect-card__header">
-        <div>
-          <h3>{title}</h3>
-          <p>{description}</p>
+    <section className={buildClassName('effect-card-group', !isEnabled && 'is-disabled')}>
+      <div className="surface surface--nested effect-card">
+        <div className="effect-card__header">
+          <div>
+            <h3>{title}</h3>
+            <p>{description}</p>
+          </div>
+          {onToggle ? (
+            <ToggleField
+              checked={isEnabled}
+              compact
+              id={toggleId}
+              label={isEnabled ? 'On' : 'Off'}
+              onChange={onToggle}
+            />
+          ) : null}
         </div>
-        {onToggle ? (
-          <ToggleField
-            checked={isEnabled}
-            id={toggleId}
-            label={isEnabled ? 'On' : 'Off'}
-            onChange={onToggle}
-          />
-        ) : null}
       </div>
-      {isEnabled && hasContent ? <div className="effect-card__content">{children}</div> : null}
-      {footer ? <div className="effect-card__footer">{footer}</div> : null}
+      {isEnabled && (hasContent || footer) ? (
+        <div className="effect-card__details">
+          {hasContent ? <div className="effect-card__content">{children}</div> : null}
+          {footer ? <div className="effect-card__footer">{footer}</div> : null}
+        </div>
+      ) : null}
     </section>
   )
 }

--- a/src/pages/CreateScenePage.test.tsx
+++ b/src/pages/CreateScenePage.test.tsx
@@ -170,6 +170,41 @@ describe('CreateScenePage', () => {
     expect(screen.queryByRole('button', { name: /a\/b testing/i })).not.toBeInTheDocument()
   })
 
+  it('keeps the first section ordered around scene metadata and shows sticky navigation actions', async () => {
+    storeSession()
+
+    mockCreateScenePageFetch()
+
+    renderCreateScenePage()
+
+    const nameField = screen.getByLabelText(/scene name/i)
+    const descriptionField = screen.getByLabelText(/description/i)
+    const playlistsField = screen.getByLabelText(/playlists/i)
+    const thumbnailField = screen.getByLabelText(/upload thumbnail file/i)
+    const tagSearchField = await screen.findByLabelText(/select existing tags/i)
+
+    expect(
+      nameField.compareDocumentPosition(descriptionField) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+    expect(
+      descriptionField.compareDocumentPosition(playlistsField) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+    expect(
+      playlistsField.compareDocumentPosition(thumbnailField) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+    expect(
+      thumbnailField.compareDocumentPosition(tagSearchField) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+
+    expect(screen.getByRole('button', { name: /^back$/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /^next$/i })).toBeEnabled()
+    expect(screen.getByRole('button', { name: /create scene/i })).toBeInTheDocument()
+  })
+
   it('loads available tags and lets the user select more than one before saving', async () => {
     storeSession()
 
@@ -308,6 +343,30 @@ describe('CreateScenePage', () => {
     expect(screen.getByLabelText(/rotation speed/i)).toBeInTheDocument()
     expect(screen.queryByLabelText(/camera orientation mode/i)).not.toBeInTheDocument()
     expect(screen.queryByLabelText(/scene data json/i)).not.toBeInTheDocument()
+  })
+
+  it('moves between sections with the next and back buttons and keeps the menu in sync', async () => {
+    storeSession()
+
+    mockCreateScenePageFetch()
+
+    const user = userEvent.setup()
+
+    renderCreateScenePage()
+
+    const sectionMenu = screen.getByLabelText(/jump to section/i)
+
+    expect(sectionMenu).toHaveValue('scene')
+
+    await user.click(screen.getByRole('button', { name: /^next$/i }))
+
+    expect(screen.getByRole('heading', { name: /^camera$/i })).toBeInTheDocument()
+    expect(sectionMenu).toHaveValue('camera')
+
+    await user.click(screen.getByRole('button', { name: /^back$/i }))
+
+    expect(screen.getByRole('heading', { name: /^scene$/i })).toBeInTheDocument()
+    expect(sectionMenu).toHaveValue('scene')
   })
 
   it('splits pass ordering into its own section and groups effects into categorized cards', async () => {

--- a/src/pages/CreateScenePage.test.tsx
+++ b/src/pages/CreateScenePage.test.tsx
@@ -119,7 +119,7 @@ afterEach(() => {
 })
 
 describe('CreateScenePage', () => {
-  it('renders the expanded MAGE engine editor with the full section menu available', async () => {
+  it('renders the details step first while keeping the full section menu available', async () => {
     storeSession()
 
     mockCreateScenePageFetch()
@@ -128,17 +128,17 @@ describe('CreateScenePage', () => {
 
     expect(screen.getByRole('heading', { name: /create scene/i })).toBeInTheDocument()
     expect(screen.queryByRole('tab', { name: /basic/i })).not.toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: /^scene$/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /^details$/i })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: /^scene$/i })).not.toBeInTheDocument()
     expect(screen.queryByRole('heading', { name: /^camera$/i })).not.toBeInTheDocument()
     expect(screen.queryByRole('heading', { name: /^motion$/i })).not.toBeInTheDocument()
     expect(screen.queryByRole('heading', { name: /^effects$/i })).not.toBeInTheDocument()
-    expect(screen.getByRole('option', { name: /^prism core$/i })).toBeInTheDocument()
-    expect(screen.getByRole('option', { name: /^chroma storm$/i })).toBeInTheDocument()
-    expect(screen.queryByRole('option', { name: /^aurora drift$/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('option', { name: /^details$/i })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: /^scene$/i })).toBeInTheDocument()
     expect(screen.getByRole('option', { name: /pass order/i })).toBeInTheDocument()
     expect(screen.getByRole('option', { name: /advanced/i })).toBeInTheDocument()
     expect(screen.queryByLabelText(/scene data json/i)).not.toBeInTheDocument()
-    expect(screen.getByLabelText(/custom shader/i)).toBeInTheDocument()
+    expect(screen.queryByLabelText(/custom shader/i)).not.toBeInTheDocument()
     expect(screen.getByTestId('mage-player')).toHaveTextContent('preview-ready')
   })
 
@@ -183,6 +183,7 @@ describe('CreateScenePage', () => {
     const thumbnailField = screen.getByLabelText(/upload thumbnail file/i)
     const tagSearchField = await screen.findByLabelText(/select existing tags/i)
 
+    expect(screen.getByRole('heading', { name: /^details$/i })).toBeInTheDocument()
     expect(
       nameField.compareDocumentPosition(descriptionField) &
         Node.DOCUMENT_POSITION_FOLLOWING,
@@ -356,17 +357,19 @@ describe('CreateScenePage', () => {
 
     const sectionMenu = screen.getByLabelText(/jump to section/i)
 
-    expect(sectionMenu).toHaveValue('scene')
+    expect(sectionMenu).toHaveValue('details')
 
     await user.click(screen.getByRole('button', { name: /^next$/i }))
 
-    expect(screen.getByRole('heading', { name: /^camera$/i })).toBeInTheDocument()
-    expect(sectionMenu).toHaveValue('camera')
+    expect(screen.getByRole('heading', { name: /^scene$/i })).toBeInTheDocument()
+    expect(sectionMenu).toHaveValue('scene')
+    expect(screen.getByLabelText(/custom shader/i)).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: /^back$/i }))
 
-    expect(screen.getByRole('heading', { name: /^scene$/i })).toBeInTheDocument()
-    expect(sectionMenu).toHaveValue('scene')
+    expect(screen.getByRole('heading', { name: /^details$/i })).toBeInTheDocument()
+    expect(sectionMenu).toHaveValue('details')
+    expect(screen.queryByLabelText(/custom shader/i)).not.toBeInTheDocument()
   })
 
   it('splits pass ordering into its own section and groups effects into categorized cards', async () => {

--- a/src/pages/CreateScenePage.test.tsx
+++ b/src/pages/CreateScenePage.test.tsx
@@ -133,10 +133,12 @@ describe('CreateScenePage', () => {
     expect(screen.queryByRole('heading', { name: /^camera$/i })).not.toBeInTheDocument()
     expect(screen.queryByRole('heading', { name: /^motion$/i })).not.toBeInTheDocument()
     expect(screen.queryByRole('heading', { name: /^effects$/i })).not.toBeInTheDocument()
-    expect(screen.getByRole('option', { name: /^details$/i })).toBeInTheDocument()
-    expect(screen.getByRole('option', { name: /^scene$/i })).toBeInTheDocument()
-    expect(screen.getByRole('option', { name: /pass order/i })).toBeInTheDocument()
-    expect(screen.getByRole('option', { name: /advanced/i })).toBeInTheDocument()
+    expect(screen.getByRole('navigation', { name: /section navigation/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^details$/i })).toHaveAttribute('aria-current', 'step')
+    expect(screen.getByRole('button', { name: /^scene$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^pass order$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^confirm$/i })).toBeInTheDocument()
+    expect(screen.queryByLabelText(/jump to section/i)).not.toBeInTheDocument()
     expect(screen.queryByLabelText(/scene data json/i)).not.toBeInTheDocument()
     expect(screen.queryByLabelText(/custom shader/i)).not.toBeInTheDocument()
     expect(screen.getByTestId('mage-player')).toHaveTextContent('preview-ready')
@@ -329,9 +331,11 @@ describe('CreateScenePage', () => {
 
     mockCreateScenePageFetch()
 
+    const user = userEvent.setup()
+
     renderCreateScenePage()
 
-    fireEvent.change(screen.getByLabelText(/jump to section/i), { target: { value: 'motion' } })
+    await user.click(screen.getByRole('button', { name: /^motion$/i }))
 
     expect(screen.getByRole('heading', { name: /^motion$/i })).toBeInTheDocument()
     expect(screen.getByLabelText(/auto rotate/i)).toBeInTheDocument()
@@ -355,21 +359,63 @@ describe('CreateScenePage', () => {
 
     renderCreateScenePage()
 
-    const sectionMenu = screen.getByLabelText(/jump to section/i)
+    const detailsStep = screen.getByRole('button', { name: /^details$/i })
+    const sceneStep = screen.getByRole('button', { name: /^scene$/i })
 
-    expect(sectionMenu).toHaveValue('details')
+    expect(detailsStep).toHaveAttribute('aria-current', 'step')
+    expect(sceneStep).not.toHaveAttribute('aria-current')
 
     await user.click(screen.getByRole('button', { name: /^next$/i }))
 
     expect(screen.getByRole('heading', { name: /^scene$/i })).toBeInTheDocument()
-    expect(sectionMenu).toHaveValue('scene')
+    expect(sceneStep).toHaveAttribute('aria-current', 'step')
     expect(screen.getByLabelText(/custom shader/i)).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: /^back$/i }))
 
     expect(screen.getByRole('heading', { name: /^details$/i })).toBeInTheDocument()
-    expect(sectionMenu).toHaveValue('details')
+    expect(detailsStep).toHaveAttribute('aria-current', 'step')
     expect(screen.queryByLabelText(/custom shader/i)).not.toBeInTheDocument()
+  })
+
+  it('switches the shader select to Custom Shader when the source no longer matches a built-in shader', async () => {
+    storeSession()
+
+    mockCreateScenePageFetch()
+
+    const user = userEvent.setup()
+
+    renderCreateScenePage()
+
+    await user.click(screen.getByRole('button', { name: /^scene$/i }))
+
+    const shaderSelect = screen.getByLabelText(/^shader$/i)
+    const shaderSource = screen.getByLabelText(/custom shader/i)
+
+    await user.clear(shaderSource)
+    await user.type(shaderSource, 'let customSize = input()')
+
+    expect(shaderSelect).toHaveValue('custom')
+    expect(screen.getByRole('option', { name: /^custom shader$/i })).toBeInTheDocument()
+  })
+
+  it('marks previous required sections as needing attention when you move past them incomplete', async () => {
+    storeSession()
+
+    mockCreateScenePageFetch()
+
+    const user = userEvent.setup()
+
+    renderCreateScenePage()
+
+    const detailsStep = screen.getByRole('button', { name: /^details$/i })
+
+    await user.click(screen.getByRole('button', { name: /^scene$/i }))
+
+    expect(screen.getByRole('heading', { name: /^scene$/i })).toBeInTheDocument()
+    expect(detailsStep).toHaveClass('scene-editor-stepper__button--invalid')
+    expect(detailsStep).not.toHaveClass('scene-editor-stepper__button--complete')
+    expect(detailsStep).toHaveAttribute('title', 'Scene name is required.')
   })
 
   it('splits pass ordering into its own section and groups effects into categorized cards', async () => {
@@ -377,9 +423,11 @@ describe('CreateScenePage', () => {
 
     mockCreateScenePageFetch()
 
+    const user = userEvent.setup()
+
     renderCreateScenePage()
 
-    fireEvent.change(screen.getByLabelText(/jump to section/i), { target: { value: 'effects' } })
+    await user.click(screen.getByRole('button', { name: /^effects$/i }))
 
     expect(screen.getByRole('heading', { name: /^effects$/i })).toBeInTheDocument()
     expect(screen.queryByRole('heading', { name: /^pass order$/i })).not.toBeInTheDocument()
@@ -392,7 +440,7 @@ describe('CreateScenePage', () => {
     expect(screen.queryByText(/^additional passes$/i)).not.toBeInTheDocument()
     expect(screen.getByText(/^output pass$/i)).toBeInTheDocument()
 
-    fireEvent.change(screen.getByLabelText(/jump to section/i), { target: { value: 'pass-order' } })
+    await user.click(screen.getByRole('button', { name: /^pass order$/i }))
 
     expect(screen.getByRole('heading', { name: /^pass order$/i })).toBeInTheDocument()
     expect(screen.getByText(/^output$/i)).toBeInTheDocument()
@@ -416,7 +464,7 @@ describe('CreateScenePage', () => {
     renderCreateScenePage()
 
     await user.type(screen.getByLabelText(/scene name/i), 'Aurora Drift')
-    fireEvent.change(screen.getByLabelText(/jump to section/i), { target: { value: 'camera' } })
+    await user.click(screen.getByRole('button', { name: /^camera$/i }))
     expect(screen.getByRole('heading', { name: /^camera$/i })).toBeInTheDocument()
     fireEvent.change(screen.getByLabelText(/camera orientation/i), { target: { value: '90' } })
     await user.click(screen.getByRole('button', { name: /create scene/i }))
@@ -637,18 +685,43 @@ describe('CreateScenePage', () => {
     expect(createAttempted).toBe(false)
   })
 
-  it('surfaces advanced MAGE engine fields and the raw JSON editor in the Advanced section', async () => {
+  it('moves advanced controls into collapsible groups and uses confirm as the final review step', async () => {
     storeSession()
 
     mockCreateScenePageFetch()
 
+    const user = userEvent.setup()
+
     renderCreateScenePage()
 
-    fireEvent.change(screen.getByLabelText(/jump to section/i), { target: { value: 'advanced' } })
+    await user.click(screen.getByRole('button', { name: /^camera$/i }))
 
-    expect(screen.getByRole('heading', { name: /^advanced$/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /^camera$/i })).toBeInTheDocument()
+    expect(screen.queryByLabelText(/camera orientation mode/i)).not.toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /enable advanced/i }))
     expect(screen.getByLabelText(/camera orientation mode/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/camera orientation speed/i)).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /disable advanced/i }))
+    expect(screen.queryByLabelText(/camera orientation mode/i)).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /^motion$/i }))
+
+    expect(screen.getByRole('heading', { name: /^motion$/i })).toBeInTheDocument()
+    expect(screen.queryByLabelText(/state size/i)).not.toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /enable advanced/i }))
+    expect(screen.getByLabelText(/state size/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/volume multiplier/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /^confirm$/i }))
+
+    expect(screen.getByRole('heading', { name: /^confirm$/i })).toBeInTheDocument()
+    expect(screen.getByText(/^scene name$/i)).toBeInTheDocument()
+    expect(screen.getByText(/^motion & effects$/i)).toBeInTheDocument()
+    expect(screen.queryByText(/^advanced camera$/i)).not.toBeInTheDocument()
+    expect(screen.getByText(/^runtime seed$/i)).toBeInTheDocument()
+    expect(screen.queryByLabelText(/scene data json/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /show shader/i })).not.toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /show raw json/i }))
     expect(screen.getByLabelText(/scene data json/i)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /format json/i })).toBeInTheDocument()
   })

--- a/src/pages/CreateScenePage.tsx
+++ b/src/pages/CreateScenePage.tsx
@@ -402,12 +402,14 @@ export function CreateScenePage() {
   const [errors, setErrors] = useState<CreateSceneFormErrors>({});
   const [tagsLoading, setTagsLoading] = useState(true);
   const [tagsError, setTagsError] = useState<string | null>(null);
+  const [isActionBarStuck, setIsActionBarStuck] = useState(false);
   const [pendingTagAttachment, setPendingTagAttachment] =
     useState<PendingTagAttachment | null>(null);
   const [isCreatingTag, setIsCreatingTag] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const tagDropdownRef = useRef<HTMLDivElement | null>(null);
   const thumbnailFileInputRef = useRef<HTMLInputElement | null>(null);
+  const actionBarSentinelRef = useRef<HTMLDivElement | null>(null);
 
   const formErrorId = useId();
   const tagSearchInputId = useId();
@@ -544,6 +546,29 @@ export function CreateScenePage() {
       setIsTagDropdownOpen(false);
     }
   }, [isTagDropdownOpen, pendingTagAttachment]);
+
+  useEffect(() => {
+    const sentinel = actionBarSentinelRef.current;
+
+    if (!sentinel || typeof IntersectionObserver === "undefined") {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setIsActionBarStuck(entry.intersectionRatio < 1);
+      },
+      {
+        threshold: 1,
+      },
+    );
+
+    observer.observe(sentinel);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
 
   function renderAdditionalPassCard(passConfig: AdditionalPassConfig) {
     return (
@@ -1464,7 +1489,7 @@ export function CreateScenePage() {
                 description="Choose the visual style, background environment, and overall size of the scene."
                 title="Scene"
               >
-                <div className="scene-editor-grid scene-editor-grid--3">
+                <div className="scene-editor-grid">
                   <SelectField
                     description={
                       selectedShaderScene?.description ??
@@ -2389,49 +2414,6 @@ export function CreateScenePage() {
               </SceneSection>
             ) : null}
 
-            <div className="scene-editor-action-bar">
-              <div className="scene-editor-action-bar__meta">
-                <span className="scene-editor-toolbar__eyebrow">Section</span>
-                <strong>{currentSection.title}</strong>
-                <span>
-                  {currentSectionIndex + 1} of {EDITOR_SECTIONS.length}
-                </span>
-              </div>
-
-              <div className="scene-editor-action-bar__buttons">
-                <button
-                  className="scene-secondary-button scene-editor-nav-button"
-                  disabled={!previousSection || isSubmitting}
-                  onClick={() => handleSectionStep(-1)}
-                  type="button"
-                >
-                  Back
-                </button>
-
-                <button
-                  className="scene-secondary-button scene-editor-nav-button"
-                  disabled={!nextSection || isSubmitting}
-                  onClick={() => handleSectionStep(1)}
-                  type="button"
-                >
-                  Next
-                </button>
-
-                <button
-                  className="demo-link auth-submit scene-editor-submit"
-                  disabled={isSubmitting}
-                  type="submit"
-                >
-                  {isSubmitting
-                    ? pendingTagAttachment
-                      ? "Retrying tag attachment..."
-                      : "Creating scene..."
-                    : pendingTagAttachment
-                      ? "Retry tag attachment"
-                      : "Create scene"}
-                </button>
-              </div>
-            </div>
           </div>
 
           <aside className="scene-editor-preview">
@@ -2451,6 +2433,62 @@ export function CreateScenePage() {
               />
             </section>
           </aside>
+
+          <div
+            className={
+              isActionBarStuck
+                ? "scene-editor-action-bar scene-editor-action-bar--stuck"
+                : "scene-editor-action-bar"
+            }
+          >
+            <div className="scene-editor-action-bar__meta">
+              <span className="scene-editor-toolbar__eyebrow">Section</span>
+              <strong>{currentSection.title}</strong>
+              <span>
+                {currentSectionIndex + 1} of {EDITOR_SECTIONS.length}
+              </span>
+            </div>
+
+            <div className="scene-editor-action-bar__buttons">
+              <button
+                className="scene-secondary-button scene-editor-nav-button"
+                disabled={!previousSection || isSubmitting}
+                onClick={() => handleSectionStep(-1)}
+                type="button"
+              >
+                Back
+              </button>
+
+              <button
+                className="scene-secondary-button scene-editor-nav-button"
+                disabled={!nextSection || isSubmitting}
+                onClick={() => handleSectionStep(1)}
+                type="button"
+              >
+                Next
+              </button>
+
+              <button
+                className="demo-link auth-submit scene-editor-submit"
+                disabled={isSubmitting}
+                type="submit"
+              >
+                {isSubmitting
+                  ? pendingTagAttachment
+                    ? "Retrying tag attachment..."
+                    : "Creating scene..."
+                  : pendingTagAttachment
+                    ? "Retry tag attachment"
+                    : "Create scene"}
+              </button>
+            </div>
+          </div>
+
+          <div
+            aria-hidden="true"
+            className="scene-editor-action-bar-sentinel"
+            ref={actionBarSentinelRef}
+          />
         </div>
       </form>
     </AuthPage>

--- a/src/pages/CreateScenePage.tsx
+++ b/src/pages/CreateScenePage.tsx
@@ -42,6 +42,7 @@ type CreateSceneFormErrors = Partial<
   Record<"form" | "name" | "newTag" | "sceneData" | "tags" | "thumbnail", string>
 >;
 type EditorSectionId =
+  | "details"
   | "advanced"
   | "camera"
   | "effects"
@@ -74,6 +75,10 @@ type EditorSectionConfig = {
 };
 
 const EDITOR_SECTIONS: EditorSectionConfig[] = [
+  {
+    id: "details",
+    title: "Details",
+  },
   {
     id: "scene",
     title: "Scene",
@@ -379,7 +384,7 @@ export function CreateScenePage() {
   const navigate = useNavigate();
 
   const [sectionMenuValue, setSectionMenuValue] =
-    useState<EditorSectionId>("scene");
+    useState<EditorSectionId>("details");
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [thumbnailMode, setThumbnailMode] = useState<ThumbnailMode>("skip");
@@ -1407,10 +1412,10 @@ export function CreateScenePage() {
               </div>
             ) : null}
 
-            {sectionMenuValue === "scene" ? (
+            {sectionMenuValue === "details" ? (
               <SceneSection
-                description="Start with the scene metadata, then tune the visual style and environment."
-                title="Scene"
+                description="Start with the saved scene metadata before moving into the engine controls."
+                title="Details"
               >
                 <div className="scene-editor-stack">
                   {renderSceneNameField()}
@@ -1451,14 +1456,14 @@ export function CreateScenePage() {
                   {renderTagEditor()}
                 </div>
 
-                <div className="scene-editor-section__subheader">
-                  <h3>Visualizer</h3>
-                  <p>
-                    Choose the shader, skybox, and overall scene scale that the
-                    engine will render.
-                  </p>
-                </div>
+              </SceneSection>
+            ) : null}
 
+            {sectionMenuValue === "scene" ? (
+              <SceneSection
+                description="Choose the visual style, background environment, and overall size of the scene."
+                title="Scene"
+              >
                 <div className="scene-editor-grid scene-editor-grid--3">
                   <SelectField
                     description={

--- a/src/pages/CreateScenePage.tsx
+++ b/src/pages/CreateScenePage.tsx
@@ -462,6 +462,17 @@ export function CreateScenePage() {
           ),
     [availableTags, pendingTagAttachment],
   );
+  const currentSectionIndex = Math.max(
+    0,
+    EDITOR_SECTIONS.findIndex((section) => section.id === sectionMenuValue),
+  );
+  const currentSection = EDITOR_SECTIONS[currentSectionIndex] ?? EDITOR_SECTIONS[0];
+  const previousSection =
+    currentSectionIndex > 0 ? EDITOR_SECTIONS[currentSectionIndex - 1] : null;
+  const nextSection =
+    currentSectionIndex < EDITOR_SECTIONS.length - 1
+      ? EDITOR_SECTIONS[currentSectionIndex + 1]
+      : null;
 
   useEffect(() => {
     let isCurrent = true;
@@ -637,6 +648,17 @@ export function CreateScenePage() {
 
   function handleSectionJump(nextSectionId: EditorSectionId) {
     setSectionMenuValue(nextSectionId);
+  }
+
+  function handleSectionStep(direction: -1 | 1) {
+    const nextIndex = currentSectionIndex + direction;
+    const nextSectionConfig = EDITOR_SECTIONS[nextIndex];
+
+    if (!nextSectionConfig) {
+      return;
+    }
+
+    handleSectionJump(nextSectionConfig.id);
   }
 
   function handleRawSceneDataChange(nextValue: string) {
@@ -881,6 +903,276 @@ export function CreateScenePage() {
     return failures;
   }
 
+  function renderSceneNameField() {
+    return (
+      <div className="field-group">
+        <label htmlFor="name">Scene Name</label>
+        <input
+          id="name"
+          minLength={2}
+          name="name"
+          onChange={(event) => handleNameChange(event.currentTarget.value)}
+          placeholder="Aurora Drift"
+          required
+          type="text"
+          value={name}
+          aria-describedby={errors.name ? "name-error" : "name-hint"}
+          aria-invalid={Boolean(errors.name)}
+        />
+        {errors.name ? (
+          <p className="field-error" id="name-error" role="alert">
+            {errors.name}
+          </p>
+        ) : (
+          <p className="field-hint" id="name-hint">
+            Start with a memorable name.
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  function renderTagEditor() {
+    return (
+      <div className="field-group">
+        <div className="scene-tag-editor__header">
+          <span className="scene-tag-editor__label">Tags</span>
+          {pendingTagAttachment ? (
+            <span className="field-hint">
+              Retry mode for scene #{pendingTagAttachment.sceneId}
+            </span>
+          ) : null}
+        </div>
+
+        <p className="field-hint">
+          Search existing tags. If there is no exact match, add it from the
+          dropdown before saving.
+        </p>
+
+        {tagsError ? (
+          <div className="scene-tag-editor__status">
+            <p className="field-error" role="alert">
+              {tagsError}
+            </p>
+            <button
+              className="scene-secondary-button"
+              disabled={tagsLoading}
+              onClick={() => {
+                void reloadAvailableTags();
+              }}
+              type="button"
+            >
+              Retry tag load
+            </button>
+          </div>
+        ) : null}
+
+        <div
+          className="scene-tag-editor__picker"
+          role="group"
+          aria-label="Available tags"
+        >
+          {tagsLoading ? (
+            <div className="tag-filter-bar" aria-label="Available tags loading">
+              {Array.from({ length: TAG_SKELETON_COUNT }, (_, index) => (
+                <span
+                  key={index}
+                  className="tag-pill tag-pill--skeleton"
+                  aria-hidden="true"
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="scene-tag-dropdown" ref={tagDropdownRef}>
+              <div className="scene-tag-dropdown__search">
+                <label htmlFor={tagSearchInputId}>Select existing tags</label>
+                <input
+                  aria-controls="scene-tag-dropdown-panel"
+                  aria-describedby={errors.newTag ? "tag-editor-error" : undefined}
+                  aria-expanded={isTagDropdownOpen}
+                  aria-invalid={Boolean(errors.newTag)}
+                  disabled={Boolean(pendingTagAttachment) || isCreatingTag}
+                  id={tagSearchInputId}
+                  onChange={(event) =>
+                    handleTagSearchChange(event.currentTarget.value)
+                  }
+                  onClick={openTagDropdown}
+                  onFocus={openTagDropdown}
+                  onKeyDown={(event) => {
+                    if (event.key !== "Enter") {
+                      return;
+                    }
+
+                    if (canCreateTagFromSearch) {
+                      event.preventDefault();
+                      void handleCreateTag();
+                      return;
+                    }
+
+                    if (filteredSelectableTags.length === 1) {
+                      event.preventDefault();
+                      toggleTagSelection(filteredSelectableTags[0].tagId);
+                    }
+                  }}
+                  placeholder="Search or add tags"
+                  type="text"
+                  value={tagSearchValue}
+                />
+              </div>
+
+              {isTagDropdownOpen ? (
+                <div
+                  className="scene-tag-dropdown__panel"
+                  id="scene-tag-dropdown-panel"
+                >
+                  {filteredSelectableTags.length > 0 || canCreateTagFromSearch ? (
+                    <div className="scene-tag-dropdown__options">
+                      {filteredSelectableTags.map((tag) => (
+                        <button
+                          key={tag.tagId}
+                          className="scene-tag-dropdown__option"
+                          disabled={isCreatingTag}
+                          onClick={() => toggleTagSelection(tag.tagId)}
+                          type="button"
+                        >
+                          {tag.name}
+                        </button>
+                      ))}
+                      {canCreateTagFromSearch ? (
+                        <button
+                          className="scene-tag-dropdown__option scene-tag-dropdown__option--create"
+                          disabled={isCreatingTag}
+                          onClick={() => {
+                            void handleCreateTag();
+                          }}
+                          type="button"
+                        >
+                          {isCreatingTag
+                            ? `Adding "${normalizedTagSearchValue}"...`
+                            : `Add tag "${normalizedTagSearchValue}"`}
+                        </button>
+                      ) : null}
+                    </div>
+                  ) : availableTags.length === 0 && !normalizedTagSearchValue ? (
+                    <p className="field-hint">
+                      No tags exist yet. Type a name to add the first one.
+                    </p>
+                  ) : isExactMatchedTagSelected ? (
+                    <p className="field-hint">That tag is already selected.</p>
+                  ) : selectableTags.length === 0 ? (
+                    <p className="field-hint">
+                      All available tags are already selected.
+                    </p>
+                  ) : (
+                    <p className="field-hint">No matching unselected tags.</p>
+                  )}
+                </div>
+              ) : null}
+            </div>
+          )}
+        </div>
+
+        <div className="scene-tag-editor__selected">
+          <span className="scene-tag-editor__selected-label">Selected tags</span>
+          {selectedTags.length > 0 ? (
+            <div className="scene-tag-editor__selected-list">
+              {selectedTags.map((tag) => (
+                <button
+                  key={tag.tagId}
+                  className="tag-pill tag-pill--active"
+                  disabled={Boolean(pendingTagAttachment)}
+                  onClick={() => toggleTagSelection(tag.tagId)}
+                  type="button"
+                >
+                  {tag.name}
+                </button>
+              ))}
+            </div>
+          ) : (
+            <p className="field-hint">No tags selected yet.</p>
+          )}
+        </div>
+
+        {errors.newTag ? (
+          <p className="field-error" id="tag-editor-error" role="alert">
+            {errors.newTag}
+          </p>
+        ) : null}
+
+        {pendingRetryTags.length > 0 ? (
+          <p className="field-hint">
+            Waiting to retry attachment for:{" "}
+            <strong>{pendingRetryTags.map((tag) => tag.name).join(", ")}</strong>
+          </p>
+        ) : null}
+      </div>
+    );
+  }
+
+  function renderThumbnailField() {
+    return (
+      <div className="field-group">
+        <label htmlFor={thumbnailInputId}>Thumbnail</label>
+        <div className="scene-thumbnail-picker">
+          <input
+            accept="image/jpeg,image/png,image/webp,image/gif"
+            aria-label="Upload thumbnail file"
+            className="scene-thumbnail-input"
+            id={thumbnailInputId}
+            onChange={(event) =>
+              handleThumbnailFileChange(event.currentTarget.files)
+            }
+            ref={thumbnailFileInputRef}
+            type="file"
+          />
+
+          <div className="scene-thumbnail-picker__grid">
+            <button
+              className={`scene-thumbnail-choice${
+                thumbnailMode === "upload" ? " is-selected" : ""
+              }`}
+              onClick={handleThumbnailUploadClick}
+              type="button"
+            >
+              <span className="scene-thumbnail-choice__eyebrow">Upload</span>
+              <strong className="scene-thumbnail-choice__title">Upload File</strong>
+              <span className="scene-thumbnail-choice__description">
+                Use a custom image.
+              </span>
+            </button>
+
+            <button
+              className={`scene-thumbnail-choice${
+                thumbnailMode === "skip" ? " is-selected" : ""
+              }`}
+              onClick={() => handleThumbnailModeChange("skip")}
+              type="button"
+            >
+              <span className="scene-thumbnail-choice__eyebrow">Optional</span>
+              <strong className="scene-thumbnail-choice__title">
+                Skip for Now
+              </strong>
+              <span className="scene-thumbnail-choice__description">
+                Create the scene without a thumbnail.
+              </span>
+            </button>
+          </div>
+
+          {thumbnailFileName ? (
+            <p className="field-hint">
+              Selected file: <strong>{thumbnailFileName}</strong>
+            </p>
+          ) : null}
+          {errors.thumbnail ? (
+            <p className="field-error" role="alert">
+              {errors.thumbnail}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+
   function movePass(passId: ScenePassId, direction: -1 | 1) {
     if (passId === "outputPass") {
       return;
@@ -1063,334 +1355,6 @@ export function CreateScenePage() {
         <div className="scene-editor-layout">
           <div className="scene-editor-main">
             <div className="scene-editor-toolbar">
-              <div className="field-group scene-editor-toolbar__name">
-                <label htmlFor="name">Scene Name</label>
-                <input
-                  id="name"
-                  minLength={2}
-                  name="name"
-                  onChange={(event) =>
-                    handleNameChange(event.currentTarget.value)
-                  }
-                  placeholder="Aurora Drift"
-                  required
-                  type="text"
-                  value={name}
-                  aria-describedby={errors.name ? "name-error" : "name-hint"}
-                  aria-invalid={Boolean(errors.name)}
-                />
-                {errors.name ? (
-                  <p className="field-error" id="name-error" role="alert">
-                    {errors.name}
-                  </p>
-                ) : (
-                  <p className="field-hint" id="name-hint">
-                    Start with a memorable name.
-                  </p>
-                )}
-              </div>
-
-              <div className="scene-editor-toolbar__metadata">
-                <div className="field-group">
-                  <label htmlFor="description">Description</label>
-                  <textarea
-                    id="description"
-                    onChange={(event) =>
-                      setDescription(event.currentTarget.value)
-                    }
-                    placeholder="Describe the mood, motion, or moment this scene is built for."
-                    rows={5}
-                    value={description}
-                  />
-                </div>
-
-                <div className="field-group">
-                  <div className="scene-tag-editor__header">
-                    <span className="scene-tag-editor__label">Tags</span>
-                    {pendingTagAttachment ? (
-                      <span className="field-hint">
-                        Retry mode for scene #{pendingTagAttachment.sceneId}
-                      </span>
-                    ) : null}
-                  </div>
-
-                  <p className="field-hint">
-                    Search existing tags. If there is no exact match, add it
-                    from the dropdown before saving.
-                  </p>
-
-                  {tagsError ? (
-                    <div className="scene-tag-editor__status">
-                      <p className="field-error" role="alert">
-                        {tagsError}
-                      </p>
-                      <button
-                        className="scene-secondary-button"
-                        disabled={tagsLoading}
-                        onClick={() => {
-                          void reloadAvailableTags();
-                        }}
-                        type="button"
-                      >
-                        Retry tag load
-                      </button>
-                    </div>
-                  ) : null}
-
-                  <div
-                    className="scene-tag-editor__picker"
-                    role="group"
-                    aria-label="Available tags"
-                  >
-                    {tagsLoading ? (
-                      <div
-                        className="tag-filter-bar"
-                        aria-label="Available tags loading"
-                      >
-                        {Array.from(
-                          { length: TAG_SKELETON_COUNT },
-                          (_, index) => (
-                            <span
-                              key={index}
-                              className="tag-pill tag-pill--skeleton"
-                              aria-hidden="true"
-                            />
-                          ),
-                        )}
-                      </div>
-                    ) : (
-                      <div
-                        className="scene-tag-dropdown"
-                        ref={tagDropdownRef}
-                      >
-                        <div className="scene-tag-dropdown__search">
-                          <label htmlFor={tagSearchInputId}>
-                            Select existing tags
-                          </label>
-                          <input
-                            aria-controls="scene-tag-dropdown-panel"
-                            aria-describedby={
-                              errors.newTag ? "tag-editor-error" : undefined
-                            }
-                            aria-expanded={isTagDropdownOpen}
-                            aria-invalid={Boolean(errors.newTag)}
-                            disabled={
-                              Boolean(pendingTagAttachment) || isCreatingTag
-                            }
-                            id={tagSearchInputId}
-                            onChange={(event) =>
-                              handleTagSearchChange(event.currentTarget.value)
-                            }
-                            onClick={openTagDropdown}
-                            onFocus={openTagDropdown}
-                            onKeyDown={(event) => {
-                              if (event.key !== "Enter") {
-                                return;
-                              }
-
-                              if (canCreateTagFromSearch) {
-                                event.preventDefault();
-                                void handleCreateTag();
-                                return;
-                              }
-
-                              if (filteredSelectableTags.length === 1) {
-                                event.preventDefault();
-                                toggleTagSelection(
-                                  filteredSelectableTags[0].tagId,
-                                );
-                              }
-                            }}
-                            placeholder="Search or add tags"
-                            type="text"
-                            value={tagSearchValue}
-                          />
-                        </div>
-
-                        {isTagDropdownOpen ? (
-                          <div
-                            className="scene-tag-dropdown__panel"
-                            id="scene-tag-dropdown-panel"
-                          >
-                            {filteredSelectableTags.length > 0 ||
-                            canCreateTagFromSearch ? (
-                              <div className="scene-tag-dropdown__options">
-                                {filteredSelectableTags.map((tag) => (
-                                  <button
-                                    key={tag.tagId}
-                                    className="scene-tag-dropdown__option"
-                                    disabled={isCreatingTag}
-                                    onClick={() => toggleTagSelection(tag.tagId)}
-                                    type="button"
-                                  >
-                                    {tag.name}
-                                  </button>
-                                ))}
-                                {canCreateTagFromSearch ? (
-                                  <button
-                                    className="scene-tag-dropdown__option scene-tag-dropdown__option--create"
-                                    disabled={isCreatingTag}
-                                    onClick={() => {
-                                      void handleCreateTag();
-                                    }}
-                                    type="button"
-                                  >
-                                    {isCreatingTag
-                                      ? `Adding "${normalizedTagSearchValue}"...`
-                                      : `Add tag "${normalizedTagSearchValue}"`}
-                                  </button>
-                                ) : null}
-                              </div>
-                            ) : availableTags.length === 0 &&
-                              !normalizedTagSearchValue ? (
-                              <p className="field-hint">
-                                No tags exist yet. Type a name to add the first
-                                one.
-                              </p>
-                            ) : isExactMatchedTagSelected ? (
-                              <p className="field-hint">
-                                That tag is already selected.
-                              </p>
-                            ) : selectableTags.length === 0 ? (
-                              <p className="field-hint">
-                                All available tags are already selected.
-                              </p>
-                            ) : (
-                              <p className="field-hint">
-                                No matching unselected tags.
-                              </p>
-                            )}
-                          </div>
-                        ) : null}
-                      </div>
-                    )}
-                  </div>
-
-                  <div className="scene-tag-editor__selected">
-                    <span className="scene-tag-editor__selected-label">
-                      Selected tags
-                    </span>
-                    {selectedTags.length > 0 ? (
-                      <div className="scene-tag-editor__selected-list">
-                        {selectedTags.map((tag) => (
-                          <button
-                            key={tag.tagId}
-                            className="tag-pill tag-pill--active"
-                            disabled={Boolean(pendingTagAttachment)}
-                            onClick={() => toggleTagSelection(tag.tagId)}
-                            type="button"
-                          >
-                            {tag.name}
-                          </button>
-                        ))}
-                      </div>
-                    ) : (
-                      <p className="field-hint">No tags selected yet.</p>
-                    )}
-                  </div>
-
-                  {errors.newTag ? (
-                    <p className="field-error" id="tag-editor-error" role="alert">
-                      {errors.newTag}
-                    </p>
-                  ) : null}
-
-                  {pendingRetryTags.length > 0 ? (
-                    <p className="field-hint">
-                      Waiting to retry attachment for:{" "}
-                      <strong>
-                        {pendingRetryTags.map((tag) => tag.name).join(", ")}
-                      </strong>
-                    </p>
-                  ) : null}
-                </div>
-
-                <div className="field-group">
-                  <label htmlFor={thumbnailInputId}>Thumbnail</label>
-                  <div className="scene-thumbnail-picker">
-                    <input
-                      accept="image/jpeg,image/png,image/webp,image/gif"
-                      aria-label="Upload thumbnail file"
-                      className="scene-thumbnail-input"
-                      id={thumbnailInputId}
-                      onChange={(event) =>
-                        handleThumbnailFileChange(event.currentTarget.files)
-                      }
-                      ref={thumbnailFileInputRef}
-                      type="file"
-                    />
-
-                    <div className="scene-thumbnail-picker__grid">
-                      <button
-                        className={`scene-thumbnail-choice${
-                          thumbnailMode === "upload" ? " is-selected" : ""
-                        }`}
-                        onClick={handleThumbnailUploadClick}
-                        type="button"
-                      >
-                        <span className="scene-thumbnail-choice__eyebrow">
-                          Upload
-                        </span>
-                        <strong className="scene-thumbnail-choice__title">
-                          Upload File
-                        </strong>
-                        <span className="scene-thumbnail-choice__description">
-                          Use a custom image.
-                        </span>
-                      </button>
-
-                      <button
-                        className={`scene-thumbnail-choice${
-                          thumbnailMode === "skip" ? " is-selected" : ""
-                        }`}
-                        onClick={() => handleThumbnailModeChange("skip")}
-                        type="button"
-                      >
-                        <span className="scene-thumbnail-choice__eyebrow">
-                          Optional
-                        </span>
-                        <strong className="scene-thumbnail-choice__title">
-                          Skip for Now
-                        </strong>
-                        <span className="scene-thumbnail-choice__description">
-                          Create the scene without a thumbnail.
-                        </span>
-                      </button>
-                    </div>
-
-                    {thumbnailFileName ? (
-                      <p className="field-hint">
-                        Selected file: <strong>{thumbnailFileName}</strong>
-                      </p>
-                    ) : null}
-                    {errors.thumbnail ? (
-                      <p className="field-error" role="alert">
-                        {errors.thumbnail}
-                      </p>
-                    ) : null}
-                  </div>
-                </div>
-
-                <div className="field-group">
-                  <label htmlFor="playlists">Playlists</label>
-                  <select
-                    className="scene-select"
-                    id="playlists"
-                    onChange={(event) =>
-                      setPlaylistValue(event.currentTarget.value)
-                    }
-                    value={playlistValue}
-                  >
-                    <option value="">Select playlist</option>
-                    {PLAYLIST_OPTIONS.map((option) => (
-                      <option key={option.value} value={option.value}>
-                        {option.label}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              </div>
-
               <div className="scene-editor-toolbar__controls">
                 <div className="scene-editor-toolbar__control-group scene-editor-toolbar__control-group--navigation">
                   <div className="scene-editor-toolbar__control-copy">
@@ -1403,6 +1367,10 @@ export function CreateScenePage() {
                     >
                       Jump To Section
                     </label>
+                    <p className="scene-editor-toolbar__hint">
+                      {currentSectionIndex + 1} of {EDITOR_SECTIONS.length}:{" "}
+                      {currentSection.title}
+                    </p>
                   </div>
 
                   <div className="scene-editor-toolbar__navigation-shell">
@@ -1441,9 +1409,56 @@ export function CreateScenePage() {
 
             {sectionMenuValue === "scene" ? (
               <SceneSection
-                description="Choose the visual style, background environment, and overall size of the scene."
+                description="Start with the scene metadata, then tune the visual style and environment."
                 title="Scene"
               >
+                <div className="scene-editor-stack">
+                  {renderSceneNameField()}
+
+                  <div className="field-group">
+                    <label htmlFor="description">Description</label>
+                    <textarea
+                      id="description"
+                      onChange={(event) =>
+                        setDescription(event.currentTarget.value)
+                      }
+                      placeholder="Describe the mood, motion, or moment this scene is built for."
+                      rows={5}
+                      value={description}
+                    />
+                  </div>
+
+                  <div className="field-group">
+                    <label htmlFor="playlists">Playlists</label>
+                    <select
+                      className="scene-select"
+                      id="playlists"
+                      onChange={(event) =>
+                        setPlaylistValue(event.currentTarget.value)
+                      }
+                      value={playlistValue}
+                    >
+                      <option value="">Select playlist</option>
+                      {PLAYLIST_OPTIONS.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  {renderThumbnailField()}
+                  {renderTagEditor()}
+                </div>
+
+                <div className="scene-editor-section__subheader">
+                  <h3>Visualizer</h3>
+                  <p>
+                    Choose the shader, skybox, and overall scene scale that the
+                    engine will render.
+                  </p>
+                </div>
+
                 <div className="scene-editor-grid scene-editor-grid--3">
                   <SelectField
                     description={
@@ -2369,19 +2384,49 @@ export function CreateScenePage() {
               </SceneSection>
             ) : null}
 
-            <button
-              className="demo-link auth-submit scene-editor-submit"
-              disabled={isSubmitting}
-              type="submit"
-            >
-              {isSubmitting
-                ? pendingTagAttachment
-                  ? "Retrying tag attachment..."
-                  : "Creating scene..."
-                : pendingTagAttachment
-                  ? "Retry tag attachment"
-                  : "Create scene"}
-            </button>
+            <div className="scene-editor-action-bar">
+              <div className="scene-editor-action-bar__meta">
+                <span className="scene-editor-toolbar__eyebrow">Section</span>
+                <strong>{currentSection.title}</strong>
+                <span>
+                  {currentSectionIndex + 1} of {EDITOR_SECTIONS.length}
+                </span>
+              </div>
+
+              <div className="scene-editor-action-bar__buttons">
+                <button
+                  className="scene-secondary-button scene-editor-nav-button"
+                  disabled={!previousSection || isSubmitting}
+                  onClick={() => handleSectionStep(-1)}
+                  type="button"
+                >
+                  Back
+                </button>
+
+                <button
+                  className="scene-secondary-button scene-editor-nav-button"
+                  disabled={!nextSection || isSubmitting}
+                  onClick={() => handleSectionStep(1)}
+                  type="button"
+                >
+                  Next
+                </button>
+
+                <button
+                  className="demo-link auth-submit scene-editor-submit"
+                  disabled={isSubmitting}
+                  type="submit"
+                >
+                  {isSubmitting
+                    ? pendingTagAttachment
+                      ? "Retrying tag attachment..."
+                      : "Creating scene..."
+                    : pendingTagAttachment
+                      ? "Retry tag attachment"
+                      : "Create scene"}
+                </button>
+              </div>
+            </div>
           </div>
 
           <aside className="scene-editor-preview">

--- a/src/pages/CreateScenePage.tsx
+++ b/src/pages/CreateScenePage.tsx
@@ -1,4 +1,4 @@
-import type { FormEvent } from "react";
+import type { FormEvent, PropsWithChildren, ReactNode } from "react";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../auth/AuthContext";
@@ -42,8 +42,8 @@ type CreateSceneFormErrors = Partial<
   Record<"form" | "name" | "newTag" | "sceneData" | "tags" | "thumbnail", string>
 >;
 type EditorSectionId =
+  | "confirm"
   | "details"
-  | "advanced"
   | "camera"
   | "effects"
   | "motion"
@@ -100,12 +100,13 @@ const EDITOR_SECTIONS: EditorSectionConfig[] = [
     title: "Pass Order",
   },
   {
-    id: "advanced",
-    title: "Advanced",
+    id: "confirm",
+    title: "Confirm",
   },
 ];
 
 const initialSceneData = sanitizeSceneData(createDefaultSceneData());
+const initialSceneModel = getSceneEditorModel(initialSceneData);
 const PLAYLIST_OPTIONS = [
   {
     label: "Featured Collection",
@@ -274,18 +275,135 @@ function formatDegrees(value: number) {
   return `${Math.round(value)}\u00B0`;
 }
 
-function NavigationIcon() {
+function CheckIcon() {
   return (
     <svg aria-hidden="true" viewBox="0 0 24 24">
       <path
-        d="M12 3.8a8.2 8.2 0 1 0 8.2 8.2A8.2 8.2 0 0 0 12 3.8Zm0 14.9a6.7 6.7 0 1 1 6.7-6.7 6.7 6.7 0 0 1-6.7 6.7Z"
-        fill="currentColor"
-      />
-      <path
-        d="M14.9 8.3 9.8 10.6a.8.8 0 0 0-.4.4l-2.3 5.1a.4.4 0 0 0 .5.5l5.1-2.3a.8.8 0 0 0 .4-.4l2.3-5.1a.4.4 0 0 0-.5-.5Zm-2.8 4.8-2.4 1.1 1.1-2.4 2.4-1.1Z"
+        d="m9.55 16.65-4.2-4.2 1.4-1.4 2.8 2.8 7.65-7.65 1.4 1.4Z"
         fill="currentColor"
       />
     </svg>
+  );
+}
+
+function AlertIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24">
+      <path d="M11 6h2v8h-2zm0 10h2v2h-2z" fill="currentColor" />
+    </svg>
+  );
+}
+
+function FieldGroupLabel({
+  description,
+  htmlFor,
+  label,
+}: {
+  description?: string;
+  htmlFor?: string;
+  label: string;
+}) {
+  return (
+    <div className="scene-field__copy">
+      <div className="scene-field__label-row">
+        {htmlFor ? (
+          <label className="scene-field__label" htmlFor={htmlFor}>
+            {label}
+          </label>
+        ) : (
+          <span className="scene-field__label">{label}</span>
+        )}
+      </div>
+      {description ? (
+        <p className="scene-field__description">{description}</p>
+      ) : null}
+    </div>
+  );
+}
+
+function CollapsibleEditorGroup({
+  children,
+  hideLabel,
+  id,
+  isOpen,
+  onToggle,
+  showLabel,
+}: PropsWithChildren<{
+  hideLabel?: string;
+  id: string;
+  isOpen: boolean;
+  onToggle: () => void;
+  showLabel?: string;
+}>) {
+  return (
+    <section className="scene-editor-collapsible">
+      <button
+        aria-controls={id}
+        aria-expanded={isOpen}
+        className="scene-editor-collapsible__toggle"
+        onClick={onToggle}
+        type="button"
+      >
+        {isOpen ? hideLabel ?? "Hide Advanced" : showLabel ?? "Show Advanced"}
+      </button>
+
+      {isOpen ? (
+        <div className="scene-editor-collapsible__content" id={id}>
+          {children}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function ConfirmSummarySection({
+  children,
+  title,
+}: PropsWithChildren<{
+  title: string;
+}>) {
+  return (
+    <section className="scene-confirm-section">
+      <h3 className="scene-confirm-section__title">{title}</h3>
+      <dl className="scene-confirm-section__list">{children}</dl>
+    </section>
+  );
+}
+
+function ConfirmSummaryItem({
+  label,
+  value,
+}: {
+  label: string;
+  value: ReactNode;
+}) {
+  return (
+    <div className="scene-confirm-section__item">
+      <dt className="scene-confirm-section__term">{label}</dt>
+      <dd className="scene-confirm-section__value">{value}</dd>
+    </div>
+  );
+}
+
+function ConfirmSummaryPills({
+  emptyLabel,
+  values,
+}: {
+  emptyLabel: string;
+  values: string[];
+}) {
+  if (values.length === 0) {
+    return <span>{emptyLabel}</span>;
+  }
+
+  return (
+    <span className="scene-confirm-pills">
+      {values.map((value) => (
+        <span className="scene-confirm-pill" key={value}>
+          {value}
+        </span>
+      ))}
+    </span>
   );
 }
 
@@ -332,31 +450,58 @@ function describePassState(passId: ScenePassId, sceneModel: SceneEditorModel) {
 
 function validateForm(name: string, sceneDataText: string) {
   const errors: CreateSceneFormErrors = {};
-  let parsedSceneData: SceneData | null = null;
+  const nameError = validateSceneName(name);
+  const { error: sceneDataError, parsedSceneData } =
+    validateSceneDataText(sceneDataText);
 
-  if (!name.trim()) {
-    errors.name = "Scene name is required.";
-  } else if (name.trim().length < 2) {
-    errors.name = "Scene name must be at least 2 characters.";
+  if (nameError) {
+    errors.name = nameError;
   }
 
-  if (!sceneDataText.trim()) {
-    errors.sceneData = "Scene data is required.";
-  } else {
-    try {
-      parsedSceneData = parseSceneDataJson(sceneDataText.trim());
-    } catch (error) {
-      errors.sceneData =
-        error instanceof Error && error.message.trim()
-          ? error.message
-          : "Scene data must be valid JSON.";
-    }
+  if (sceneDataError) {
+    errors.sceneData = sceneDataError;
   }
 
   return {
     errors,
     parsedSceneData,
   };
+}
+
+function validateSceneName(name: string) {
+  if (!name.trim()) {
+    return "Scene name is required.";
+  }
+
+  if (name.trim().length < 2) {
+    return "Scene name must be at least 2 characters.";
+  }
+
+  return null;
+}
+
+function validateSceneDataText(sceneDataText: string) {
+  if (!sceneDataText.trim()) {
+    return {
+      error: "Scene data is required.",
+      parsedSceneData: null,
+    };
+  }
+
+  try {
+    return {
+      error: null,
+      parsedSceneData: parseSceneDataJson(sceneDataText.trim()),
+    };
+  } catch (error) {
+    return {
+      error:
+        error instanceof Error && error.message.trim()
+          ? error.message
+          : "Scene data must be valid JSON.",
+      parsedSceneData: null,
+    };
+  }
 }
 
 function validateThumbnailFile(file: File | null) {
@@ -403,6 +548,16 @@ export function CreateScenePage() {
   const [tagsLoading, setTagsLoading] = useState(true);
   const [tagsError, setTagsError] = useState<string | null>(null);
   const [isActionBarStuck, setIsActionBarStuck] = useState(false);
+  const [isCameraAdvancedEnabled, setIsCameraAdvancedEnabled] = useState(false);
+  const [isMotionAdvancedEnabled, setIsMotionAdvancedEnabled] = useState(false);
+  const [cameraAdvancedDraft, setCameraAdvancedDraft] = useState(() => ({
+    camOrientationMode: initialSceneModel.intent.camOrientationMode,
+    camOrientationSpeed: initialSceneModel.intent.camOrientationSpeed,
+  }));
+  const [motionRuntimeDraft, setMotionRuntimeDraft] = useState(
+    () => initialSceneModel.state,
+  );
+  const [isConfirmJsonOpen, setIsConfirmJsonOpen] = useState(false);
   const [pendingTagAttachment, setPendingTagAttachment] =
     useState<PendingTagAttachment | null>(null);
   const [isCreatingTag, setIsCreatingTag] = useState(false);
@@ -415,10 +570,33 @@ export function CreateScenePage() {
   const tagSearchInputId = useId();
   const thumbnailInputId = useId();
   const titleId = "create-scene-title";
+
+  function buildEffectiveSceneData(sourceSceneData: SceneData) {
+    let nextSceneData = sourceSceneData;
+
+    if (!isCameraAdvancedEnabled) {
+      nextSceneData = mergeSceneEditorBranch(nextSceneData, "intent", {
+        ...getSceneEditorModel(nextSceneData).intent,
+        camOrientationMode: initialSceneModel.intent.camOrientationMode,
+        camOrientationSpeed: initialSceneModel.intent.camOrientationSpeed,
+      });
+    }
+
+    if (!isMotionAdvancedEnabled) {
+      nextSceneData = mergeSceneEditorBranch(
+        nextSceneData,
+        "state",
+        initialSceneModel.state,
+      );
+    }
+
+    return sanitizeSceneData(nextSceneData);
+  }
+
   const sceneModel = useMemo(() => getSceneEditorModel(sceneData), [sceneData]);
   const previewSceneData = useMemo(
-    () => sanitizeSceneData(sceneData),
-    [sceneData],
+    () => buildEffectiveSceneData(sceneData),
+    [sceneData, isCameraAdvancedEnabled, isMotionAdvancedEnabled],
   );
   const shaderSelection = useMemo(
     () => buildShaderOptions(sceneModel.visualizer.shader),
@@ -480,6 +658,18 @@ export function CreateScenePage() {
     currentSectionIndex < EDITOR_SECTIONS.length - 1
       ? EDITOR_SECTIONS[currentSectionIndex + 1]
       : null;
+  const detailsSectionIssueMessages = [
+    validateSceneName(name),
+    thumbnailMode === "upload" ? validateThumbnailFile(thumbnailFile) : null,
+  ].filter((message): message is string => Boolean(message));
+  const confirmSectionIssueMessage = validateSceneDataText(sceneDataText).error;
+  const sectionIssuesById: Partial<Record<EditorSectionId, string | null>> = {
+    confirm: confirmSectionIssueMessage,
+    details:
+      detailsSectionIssueMessages.length > 0
+        ? detailsSectionIssueMessages.join(" ")
+        : null,
+  };
 
   useEffect(() => {
     let isCurrent = true;
@@ -631,6 +821,41 @@ export function CreateScenePage() {
     applySceneData(mergeSceneEditorBranch(sceneData, branch, nextBranch));
   }
 
+  function handleCameraAdvancedToggle(nextValue: boolean) {
+    if (nextValue) {
+      setIsCameraAdvancedEnabled(true);
+      updateBranch("intent", (currentIntent) => ({
+        ...currentIntent,
+        camOrientationMode: cameraAdvancedDraft.camOrientationMode,
+        camOrientationSpeed: cameraAdvancedDraft.camOrientationSpeed,
+      }));
+      return;
+    }
+
+    setCameraAdvancedDraft({
+      camOrientationMode: sceneModel.intent.camOrientationMode,
+      camOrientationSpeed: sceneModel.intent.camOrientationSpeed,
+    });
+    setIsCameraAdvancedEnabled(false);
+    updateBranch("intent", (currentIntent) => ({
+      ...currentIntent,
+      camOrientationMode: initialSceneModel.intent.camOrientationMode,
+      camOrientationSpeed: initialSceneModel.intent.camOrientationSpeed,
+    }));
+  }
+
+  function handleMotionAdvancedToggle(nextValue: boolean) {
+    if (nextValue) {
+      setIsMotionAdvancedEnabled(true);
+      updateBranch("state", () => motionRuntimeDraft);
+      return;
+    }
+
+    setMotionRuntimeDraft(sceneModel.state);
+    setIsMotionAdvancedEnabled(false);
+    updateBranch("state", () => initialSceneModel.state);
+  }
+
   function handleNameChange(nextValue: string) {
     setName(nextValue);
     clearErrors("name", "form");
@@ -705,7 +930,7 @@ export function CreateScenePage() {
   function handleFormatJson() {
     try {
       const parsedSceneData = parseSceneDataJson(sceneDataText);
-      applySceneData(parsedSceneData);
+      applySceneData(buildEffectiveSceneData(parsedSceneData));
     } catch (error) {
       setErrors((currentErrors) => ({
         ...currentErrors,
@@ -936,7 +1161,7 @@ export function CreateScenePage() {
   function renderSceneNameField() {
     return (
       <div className="field-group">
-        <label htmlFor="name">Scene Name</label>
+        <FieldGroupLabel htmlFor="name" label="Scene Name" />
         <input
           id="name"
           minLength={2}
@@ -966,7 +1191,7 @@ export function CreateScenePage() {
     return (
       <div className="field-group">
         <div className="scene-tag-editor__header">
-          <span className="scene-tag-editor__label">Tags</span>
+          <FieldGroupLabel label="Tags" />
           {pendingTagAttachment ? (
             <span className="field-hint">
               Retry mode for scene #{pendingTagAttachment.sceneId}
@@ -1142,7 +1367,7 @@ export function CreateScenePage() {
   function renderThumbnailField() {
     return (
       <div className="field-group">
-        <label htmlFor={thumbnailInputId}>Thumbnail</label>
+        <FieldGroupLabel htmlFor={thumbnailInputId} label="Thumbnail" />
         <div className="scene-thumbnail-picker">
           <input
             accept="image/jpeg,image/png,image/webp,image/gif"
@@ -1201,6 +1426,241 @@ export function CreateScenePage() {
         </div>
       </div>
     );
+  }
+
+  function renderCameraAdvancedFields() {
+    return (
+      <div className="scene-editor-grid">
+        <NumberField
+          description="Experimental compact scene field exported by the library."
+          id="camera-orientation-mode"
+          label="Camera Orientation Mode"
+          min={0}
+          onChange={(nextValue) =>
+            updateBranch("intent", (currentIntent) => ({
+              ...currentIntent,
+              camOrientationMode: Math.max(0, Math.round(nextValue)),
+            }))
+          }
+          step={1}
+          value={sceneModel.intent.camOrientationMode}
+        />
+
+        <NumberField
+          description="Experimental compact scene field exported by the library."
+          id="camera-orientation-speed"
+          label="Camera Orientation Speed"
+          min={0}
+          onChange={(nextValue) =>
+            updateBranch("intent", (currentIntent) => ({
+              ...currentIntent,
+              camOrientationSpeed: nextValue,
+            }))
+          }
+          step={0.1}
+          value={sceneModel.intent.camOrientationSpeed}
+        />
+      </div>
+    );
+  }
+
+  function renderRuntimeStateFields() {
+    return (
+      <div className="scene-editor-grid">
+        <NumberField
+          description="Low-level runtime state."
+          id="state-size"
+          label="State Size"
+          onChange={(nextValue) =>
+            updateBranch("state", (currentState) => ({
+              ...currentState,
+              size: nextValue,
+            }))
+          }
+          step={0.01}
+          value={sceneModel.state.size}
+        />
+        <NumberField
+          description="Initial runtime pointer state."
+          id="state-pointer-down"
+          label="Pointer Down"
+          onChange={(nextValue) =>
+            updateBranch("state", (currentState) => ({
+              ...currentState,
+              pointerDown: nextValue,
+            }))
+          }
+          step={0.01}
+          value={sceneModel.state.pointerDown}
+        />
+        <NumberField
+          description="Initial smoothed pointer state."
+          id="state-current-pointer-down"
+          label="Current Pointer"
+          onChange={(nextValue) =>
+            updateBranch("state", (currentState) => ({
+              ...currentState,
+              currPointerDown: nextValue,
+            }))
+          }
+          step={0.01}
+          value={sceneModel.state.currPointerDown}
+        />
+        <NumberField
+          description="Initial runtime audio input."
+          id="state-current-audio"
+          label="Current Audio"
+          onChange={(nextValue) =>
+            updateBranch("state", (currentState) => ({
+              ...currentState,
+              currAudio: nextValue,
+            }))
+          }
+          step={0.01}
+          value={sceneModel.state.currAudio}
+        />
+        <NumberField
+          description="Initial runtime time value."
+          id="state-time"
+          label="State Time"
+          onChange={(nextValue) =>
+            updateBranch("state", (currentState) => ({
+              ...currentState,
+              time: nextValue,
+            }))
+          }
+          step={0.01}
+          value={sceneModel.state.time}
+        />
+        <NumberField
+          description="Initial runtime volume multiplier."
+          id="state-volume"
+          label="Volume Multiplier"
+          onChange={(nextValue) =>
+            updateBranch("state", (currentState) => ({
+              ...currentState,
+              volume_multiplier: nextValue,
+            }))
+          }
+          step={0.01}
+          value={sceneModel.state.volume_multiplier}
+        />
+      </div>
+    );
+  }
+
+  function renderRawSceneDataEditor() {
+    return (
+      <div className="field-group">
+        <div className="scene-advanced-header">
+          <div>
+            <FieldGroupLabel
+              description="Inspect and edit the raw scene JSON directly."
+              htmlFor="sceneData"
+              label="Scene Data JSON"
+            />
+            <p className="field-hint">
+              Raw scene data stays available here. While the JSON is invalid,
+              the preview keeps the last valid scene state.
+            </p>
+          </div>
+          <button
+            className="scene-secondary-button"
+            onClick={handleFormatJson}
+            type="button"
+          >
+            Format JSON
+          </button>
+        </div>
+        <textarea
+          aria-describedby={
+            errors.sceneData ? "sceneData-error" : "sceneData-hint"
+          }
+          aria-invalid={Boolean(errors.sceneData)}
+          className="scene-textarea scene-textarea--code"
+          id="sceneData"
+          name="sceneData"
+          onChange={(event) => handleRawSceneDataChange(event.currentTarget.value)}
+          required
+          rows={16}
+          value={sceneDataText}
+        />
+        {errors.sceneData ? (
+          <p className="field-error" id="sceneData-error" role="alert">
+            {errors.sceneData}
+          </p>
+        ) : (
+          <p className="field-hint" id="sceneData-hint">
+            Structured controls above keep this JSON in sync with the current
+            scene.
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  function formatOptionalText(value: string) {
+    return value.trim() ? value.trim() : "Not set";
+  }
+
+  function formatVectorSummary(value: { x: number; y: number; z: number }) {
+    return (
+      <span className="scene-confirm-vector">
+        {(["x", "y", "z"] as const).map((axis) => (
+          <span className="scene-confirm-vector__item" key={axis}>
+            <span className="scene-confirm-vector__axis">
+              {axis.toUpperCase()}
+            </span>
+            <span className="scene-confirm-vector__value">
+              {formatFixed(value[axis])}
+            </span>
+          </span>
+        ))}
+      </span>
+    );
+  }
+
+  function formatRuntimeStateSummary() {
+    const runtimeStatePairs: Array<[string, number, number]> = [
+      ["Size", sceneModel.state.size, initialSceneModel.state.size] as [
+        string,
+        number,
+        number,
+      ],
+      [
+        "Pointer",
+        sceneModel.state.pointerDown,
+        initialSceneModel.state.pointerDown,
+      ] as [string, number, number],
+      [
+        "Current Pointer",
+        sceneModel.state.currPointerDown,
+        initialSceneModel.state.currPointerDown,
+      ] as [string, number, number],
+      [
+        "Current Audio",
+        sceneModel.state.currAudio,
+        initialSceneModel.state.currAudio,
+      ] as [string, number, number],
+      ["Time", sceneModel.state.time, initialSceneModel.state.time] as [
+        string,
+        number,
+        number,
+      ],
+      [
+        "Volume",
+        sceneModel.state.volume_multiplier,
+        initialSceneModel.state.volume_multiplier,
+      ] as [string, number, number],
+    ].filter(([, value, initialValue]) => value !== initialValue);
+
+    if (runtimeStatePairs.length === 0) {
+      return "Default";
+    }
+
+    return runtimeStatePairs
+      .map(([label, value]) => `${label} ${formatFixed(value)}`)
+      .join(" • ");
   }
 
   function movePass(passId: ScenePassId, direction: -1 | 1) {
@@ -1287,7 +1747,9 @@ export function CreateScenePage() {
       return;
     }
 
-    const sanitizedSceneData = sanitizeSceneData(parsedSceneData ?? sceneData);
+    const sanitizedSceneData = buildEffectiveSceneData(
+      parsedSceneData ?? sceneData,
+    );
 
     setIsSubmitting(true);
     setErrors({});
@@ -1387,46 +1849,54 @@ export function CreateScenePage() {
             <div className="scene-editor-toolbar">
               <div className="scene-editor-toolbar__controls">
                 <div className="scene-editor-toolbar__control-group scene-editor-toolbar__control-group--navigation">
-                  <div className="scene-editor-toolbar__control-copy">
-                    <span className="scene-editor-toolbar__eyebrow">
-                      Navigation
-                    </span>
-                    <label
-                      className="scene-field__label"
-                      htmlFor="section-jump"
-                    >
-                      Jump To Section
-                    </label>
-                    <p className="scene-editor-toolbar__hint">
-                      {currentSectionIndex + 1} of {EDITOR_SECTIONS.length}:{" "}
-                      {currentSection.title}
-                    </p>
-                  </div>
+                  <nav
+                    aria-label="Section navigation"
+                    className="scene-editor-stepper"
+                  >
+                    <ol className="scene-editor-stepper__list">
+                      {EDITOR_SECTIONS.map((section, index) => {
+                        const isActive = section.id === currentSection.id;
+                        const isPrevious = index < currentSectionIndex;
+                        const issueMessage = sectionIssuesById[section.id];
+                        const hasIssues = Boolean(issueMessage);
+                        const isInvalid = isPrevious && hasIssues;
+                        const isComplete = isPrevious && !hasIssues;
 
-                  <div className="scene-editor-toolbar__navigation-shell">
-                    <span
-                      aria-hidden="true"
-                      className="scene-editor-toolbar__navigation-icon"
-                    >
-                      <NavigationIcon />
-                    </span>
-                    <select
-                      className="scene-select scene-select--navigation"
-                      id="section-jump"
-                      onChange={(event) =>
-                        handleSectionJump(
-                          event.currentTarget.value as EditorSectionId,
-                        )
-                      }
-                      value={sectionMenuValue}
-                    >
-                      {EDITOR_SECTIONS.map((section) => (
-                        <option key={section.id} value={section.id}>
-                          {section.title}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
+                        return (
+                          <li
+                            className="scene-editor-stepper__item"
+                            key={section.id}
+                          >
+                            <button
+                              aria-current={isActive ? "step" : undefined}
+                              className={
+                                isActive
+                                  ? "scene-editor-stepper__button scene-editor-stepper__button--active"
+                                  : isInvalid
+                                    ? "scene-editor-stepper__button scene-editor-stepper__button--invalid"
+                                  : isComplete
+                                    ? "scene-editor-stepper__button scene-editor-stepper__button--complete"
+                                    : "scene-editor-stepper__button"
+                              }
+                              onClick={() => handleSectionJump(section.id)}
+                              title={isInvalid ? issueMessage ?? undefined : undefined}
+                              type="button"
+                            >
+                              <span className="scene-editor-stepper__label">
+                                {section.title}
+                              </span>
+                              <span
+                                aria-hidden="true"
+                                className="scene-editor-stepper__marker"
+                              >
+                                {isInvalid ? <AlertIcon /> : isComplete ? <CheckIcon /> : null}
+                              </span>
+                            </button>
+                          </li>
+                        );
+                      })}
+                    </ol>
+                  </nav>
                 </div>
               </div>
             </div>
@@ -1446,7 +1916,7 @@ export function CreateScenePage() {
                   {renderSceneNameField()}
 
                   <div className="field-group">
-                    <label htmlFor="description">Description</label>
+                    <FieldGroupLabel htmlFor="description" label="Description" />
                     <textarea
                       id="description"
                       onChange={(event) =>
@@ -1459,7 +1929,7 @@ export function CreateScenePage() {
                   </div>
 
                   <div className="field-group">
-                    <label htmlFor="playlists">Playlists</label>
+                    <FieldGroupLabel htmlFor="playlists" label="Playlists" />
                     <select
                       className="scene-select"
                       id="playlists"
@@ -1551,7 +2021,11 @@ export function CreateScenePage() {
                 </div>
 
                 <div className="field-group">
-                  <label htmlFor="shader-source">Custom Shader</label>
+                  <FieldGroupLabel
+                    description="Edit the actual shader source saved into visualizer.shader for this scene."
+                    htmlFor="shader-source"
+                    label="Custom Shader"
+                  />
                   <textarea
                     className="scene-textarea"
                     id="shader-source"
@@ -1564,10 +2038,6 @@ export function CreateScenePage() {
                     rows={12}
                     value={sceneModel.visualizer.shader}
                   />
-                  <p className="field-hint">
-                    This is the actual `visualizer.shader` source that ships in
-                    the scene. Choosing a shader above swaps this text.
-                  </p>
                 </div>
               </SceneSection>
             ) : null}
@@ -1577,80 +2047,94 @@ export function CreateScenePage() {
                 description="Set the starting view, framing, and lens settings for the scene."
                 title="Camera"
               >
-                <div className="scene-editor-grid scene-editor-grid--2">
-                  <Vector3Field
-                    description="The camera position in the scene."
-                    id="camera-position"
-                    label="Camera Position"
-                    onChange={(nextValue) =>
-                      updateBranch("controls", (currentControls) => ({
-                        ...currentControls,
-                        position0: nextValue,
-                      }))
-                    }
-                    value={sceneModel.controls.position0}
-                  />
+                <div className="scene-editor-stack">
+                  <div className="scene-editor-grid">
+                    <Vector3Field
+                      description="The camera position in the scene."
+                      id="camera-position"
+                      label="Camera Position"
+                      onChange={(nextValue) =>
+                        updateBranch("controls", (currentControls) => ({
+                          ...currentControls,
+                          position0: nextValue,
+                        }))
+                      }
+                      value={sceneModel.controls.position0}
+                    />
 
-                  <Vector3Field
-                    description="Where the camera points while the scene loads."
-                    id="camera-target"
-                    label="Camera Target"
-                    onChange={(nextValue) =>
-                      updateBranch("controls", (currentControls) => ({
-                        ...currentControls,
-                        target0: nextValue,
-                      }))
-                    }
-                    value={sceneModel.controls.target0}
-                  />
+                    <Vector3Field
+                      description="Where the camera points while the scene loads."
+                      id="camera-target"
+                      label="Camera Target"
+                      onChange={(nextValue) =>
+                        updateBranch("controls", (currentControls) => ({
+                          ...currentControls,
+                          target0: nextValue,
+                        }))
+                      }
+                      value={sceneModel.controls.target0}
+                    />
 
-                  <SliderField
-                    description="How wide the camera lens feels."
-                    formatValue={(value) => formatFixed(value, 0)}
-                    id="field-of-view"
-                    label="FOV"
-                    max={359}
-                    min={1}
-                    onChange={(nextValue) =>
-                      updateBranch("intent", (currentIntent) => ({
-                        ...currentIntent,
-                        fov: nextValue,
-                      }))
-                    }
-                    step={1}
-                    value={sceneModel.intent.fov}
-                  />
+                    <SliderField
+                      description="How wide the camera lens feels."
+                      formatValue={(value) => formatFixed(value, 0)}
+                      id="field-of-view"
+                      label="FOV"
+                      max={359}
+                      min={1}
+                      onChange={(nextValue) =>
+                        updateBranch("intent", (currentIntent) => ({
+                          ...currentIntent,
+                          fov: nextValue,
+                        }))
+                      }
+                      step={1}
+                      value={sceneModel.intent.fov}
+                    />
 
-                  <SliderField
-                    description="Displayed in degrees while the engine still stores radians."
-                    formatValue={formatDegrees}
-                    id="camera-tilt"
-                    label="Camera Orientation"
-                    max={360}
-                    min={0}
-                    onChange={(nextValue) =>
-                      updateBranch("intent", (currentIntent) => ({
-                        ...currentIntent,
-                        camTilt: toRadians(nextValue),
-                      }))
-                    }
-                    step={1}
-                    value={toDegrees(sceneModel.intent.camTilt)}
-                  />
+                    <SliderField
+                      description="Displayed in degrees while the engine still stores radians."
+                      formatValue={formatDegrees}
+                      id="camera-tilt"
+                      label="Camera Orientation"
+                      max={360}
+                      min={0}
+                      onChange={(nextValue) =>
+                        updateBranch("intent", (currentIntent) => ({
+                          ...currentIntent,
+                          camTilt: toRadians(nextValue),
+                        }))
+                      }
+                      step={1}
+                      value={toDegrees(sceneModel.intent.camTilt)}
+                    />
 
-                  <NumberField
-                    description="Free-form camera zoom for precise framing."
-                    id="zoom"
-                    label="Zoom"
-                    onChange={(nextValue) =>
-                      updateBranch("controls", (currentControls) => ({
-                        ...currentControls,
-                        zoom0: nextValue,
-                      }))
+                    <NumberField
+                      description="Free-form camera zoom for precise framing."
+                      id="zoom"
+                      label="Zoom"
+                      onChange={(nextValue) =>
+                        updateBranch("controls", (currentControls) => ({
+                          ...currentControls,
+                          zoom0: nextValue,
+                        }))
+                      }
+                      step={0.1}
+                      value={sceneModel.controls.zoom0}
+                    />
+                  </div>
+
+                  <CollapsibleEditorGroup
+                    hideLabel="Disable Advanced"
+                    id="camera-advanced-options"
+                    isOpen={isCameraAdvancedEnabled}
+                    onToggle={() =>
+                      handleCameraAdvancedToggle(!isCameraAdvancedEnabled)
                     }
-                    step={0.1}
-                    value={sceneModel.controls.zoom0}
-                  />
+                    showLabel="Enable Advanced"
+                  >
+                    {renderCameraAdvancedFields()}
+                  </CollapsibleEditorGroup>
                 </div>
               </SceneSection>
             ) : null}
@@ -1660,131 +2144,145 @@ export function CreateScenePage() {
                 description="Adjust how the scene moves and how strongly it responds to audio and input."
                 title="Motion"
               >
-                <div className="scene-editor-grid scene-editor-grid--2">
-                  <NumberField
-                    description="Overall engine time multiplier."
-                    id="time-multiplier"
-                    label="Time Multiplier"
-                    onChange={(nextValue) =>
-                      updateBranch("intent", (currentIntent) => ({
-                        ...currentIntent,
-                        time_multiplier: nextValue,
-                      }))
-                    }
-                    step={0.05}
-                    value={sceneModel.intent.time_multiplier}
-                  />
-
-                  <SliderField
-                    description="Scales the incoming audio signal before the engine applies its response curve."
-                    id="audio-gain"
-                    label="Audio Gain"
-                    max={2}
-                    min={0.01}
-                    onChange={(nextValue) =>
-                      updateBranch("intent", (currentIntent) => ({
-                        ...currentIntent,
-                        minimizing_factor: nextValue,
-                      }))
-                    }
-                    step={0.01}
-                    value={sceneModel.intent.minimizing_factor}
-                  />
-
-                  <SliderField
-                    description="Shapes how sharply the audio response ramps up. Higher values make peaks more selective."
-                    id="audio-curve"
-                    label="Audio Curve"
-                    max={10}
-                    min={1}
-                    onChange={(nextValue) =>
-                      updateBranch("intent", (currentIntent) => ({
-                        ...currentIntent,
-                        power_factor: nextValue,
-                      }))
-                    }
-                    step={0.1}
-                    value={sceneModel.intent.power_factor}
-                  />
-
-                  <SliderField
-                    description="Controls how much pointer-down influence lingers after release for shaders that read pointer input."
-                    id="pointer-release-hold"
-                    label="Pointer Release Hold"
-                    max={1}
-                    min={0}
-                    onChange={(nextValue) =>
-                      updateBranch("intent", (currentIntent) => ({
-                        ...currentIntent,
-                        pointerDownMultiplier: nextValue,
-                      }))
-                    }
-                    step={0.01}
-                    value={sceneModel.intent.pointerDownMultiplier}
-                  />
-
-                  <SliderField
-                    description="How quickly the auto rotation travels when enabled."
-                    id="rotation-speed"
-                    label="Rotation Speed"
-                    max={50}
-                    min={0.1}
-                    onChange={(nextValue) =>
-                      updateBranch("intent", (currentIntent) => ({
-                        ...currentIntent,
-                        autoRotateSpeed: nextValue,
-                      }))
-                    }
-                    step={0.1}
-                    value={sceneModel.intent.autoRotateSpeed}
-                  />
-
-                  <SliderField
-                    description="Base audio-reactive speed shaping used by the engine."
-                    id="base-speed"
-                    label="Base Speed"
-                    max={0.9}
-                    min={0.01}
-                    onChange={(nextValue) =>
-                      updateBranch("intent", (currentIntent) => ({
-                        ...currentIntent,
-                        base_speed: nextValue,
-                      }))
-                    }
-                    step={0.01}
-                    value={sceneModel.intent.base_speed}
-                  />
-
-                  <SliderField
-                    description="How quickly the reactive size settles toward its latest value."
-                    id="easing-speed"
-                    label="Easing Speed"
-                    max={0.9}
-                    min={0.01}
-                    onChange={(nextValue) =>
-                      updateBranch("intent", (currentIntent) => ({
-                        ...currentIntent,
-                        easing_speed: nextValue,
-                      }))
-                    }
-                    step={0.01}
-                    value={sceneModel.intent.easing_speed}
-                  />
-
-                  <div className="scene-editor-grid__item--full">
-                    <ToggleField
-                      checked={sceneModel.intent.autoRotate}
-                      description="Keep the scene gently rotating on its own."
-                      id="auto-rotate"
-                      label="Auto Rotate"
+                <div className="scene-editor-stack">
+                  <div className="scene-editor-grid">
+                    <NumberField
+                      description="Overall engine time multiplier."
+                      id="time-multiplier"
+                      label="Time Multiplier"
                       onChange={(nextValue) =>
                         updateBranch("intent", (currentIntent) => ({
                           ...currentIntent,
-                          autoRotate: nextValue,
+                          time_multiplier: nextValue,
                         }))
                       }
+                      step={0.05}
+                      value={sceneModel.intent.time_multiplier}
                     />
+
+                    <SliderField
+                      description="Scales the incoming audio signal before the engine applies its response curve."
+                      id="audio-gain"
+                      label="Audio Gain"
+                      max={2}
+                      min={0.01}
+                      onChange={(nextValue) =>
+                        updateBranch("intent", (currentIntent) => ({
+                          ...currentIntent,
+                          minimizing_factor: nextValue,
+                        }))
+                      }
+                      step={0.01}
+                      value={sceneModel.intent.minimizing_factor}
+                    />
+
+                    <SliderField
+                      description="Shapes how sharply the audio response ramps up. Higher values make peaks more selective."
+                      id="audio-curve"
+                      label="Audio Curve"
+                      max={10}
+                      min={1}
+                      onChange={(nextValue) =>
+                        updateBranch("intent", (currentIntent) => ({
+                          ...currentIntent,
+                          power_factor: nextValue,
+                        }))
+                      }
+                      step={0.1}
+                      value={sceneModel.intent.power_factor}
+                    />
+
+                    <SliderField
+                      description="Controls how much pointer-down influence lingers after release for shaders that read pointer input."
+                      id="pointer-release-hold"
+                      label="Pointer Release Hold"
+                      max={1}
+                      min={0}
+                      onChange={(nextValue) =>
+                        updateBranch("intent", (currentIntent) => ({
+                          ...currentIntent,
+                          pointerDownMultiplier: nextValue,
+                        }))
+                      }
+                      step={0.01}
+                      value={sceneModel.intent.pointerDownMultiplier}
+                    />
+
+                    <SliderField
+                      description="How quickly the auto rotation travels when enabled."
+                      id="rotation-speed"
+                      label="Rotation Speed"
+                      max={50}
+                      min={0.1}
+                      onChange={(nextValue) =>
+                        updateBranch("intent", (currentIntent) => ({
+                          ...currentIntent,
+                          autoRotateSpeed: nextValue,
+                        }))
+                      }
+                      step={0.1}
+                      value={sceneModel.intent.autoRotateSpeed}
+                    />
+
+                    <SliderField
+                      description="Base audio-reactive speed shaping used by the engine."
+                      id="base-speed"
+                      label="Base Speed"
+                      max={0.9}
+                      min={0.01}
+                      onChange={(nextValue) =>
+                        updateBranch("intent", (currentIntent) => ({
+                          ...currentIntent,
+                          base_speed: nextValue,
+                        }))
+                      }
+                      step={0.01}
+                      value={sceneModel.intent.base_speed}
+                    />
+
+                    <SliderField
+                      description="How quickly the reactive size settles toward its latest value."
+                      id="easing-speed"
+                      label="Easing Speed"
+                      max={0.9}
+                      min={0.01}
+                      onChange={(nextValue) =>
+                        updateBranch("intent", (currentIntent) => ({
+                          ...currentIntent,
+                          easing_speed: nextValue,
+                        }))
+                      }
+                      step={0.01}
+                      value={sceneModel.intent.easing_speed}
+                    />
+
+                    <div className="scene-editor-grid__item--full">
+                      <ToggleField
+                        checked={sceneModel.intent.autoRotate}
+                        description="Keep the scene gently rotating on its own."
+                        id="auto-rotate"
+                        label="Auto Rotate"
+                        onChange={(nextValue) =>
+                          updateBranch("intent", (currentIntent) => ({
+                            ...currentIntent,
+                            autoRotate: nextValue,
+                          }))
+                        }
+                      />
+                    </div>
                   </div>
+
+                  <CollapsibleEditorGroup
+                    hideLabel="Disable Advanced"
+                    id="motion-runtime-state"
+                    isOpen={isMotionAdvancedEnabled}
+                    onToggle={() =>
+                      handleMotionAdvancedToggle(!isMotionAdvancedEnabled)
+                    }
+                    showLabel="Enable Advanced"
+                  >
+                    {renderRuntimeStateFields()}
+                  </CollapsibleEditorGroup>
                 </div>
               </SceneSection>
             ) : null}
@@ -1883,11 +2381,6 @@ export function CreateScenePage() {
                               outputPass: nextValue,
                             },
                           }))
-                        }
-                        footer={
-                          <p className="scene-effect-footnote">
-                            {selectedToneMapping.description}
-                          </p>
                         }
                         title="Output Pass"
                       >
@@ -2200,7 +2693,12 @@ export function CreateScenePage() {
                     return (
                       <li className="scene-pass-order__item" key={passId}>
                         <div className="scene-pass-order__copy">
-                          <strong>{PASS_LABELS[passId]}</strong>
+                          <div className="scene-pass-order__header">
+                            <strong>{PASS_LABELS[passId]}</strong>
+                            <span className="scene-pass-order__index">
+                              {index + 1}
+                            </span>
+                          </div>
                           <span>{describePassState(passId, sceneModel)}</span>
                         </div>
                         <div className="scene-pass-order__actions">
@@ -2233,183 +2731,162 @@ export function CreateScenePage() {
               </SceneSection>
             ) : null}
 
-            {sectionMenuValue === "advanced" ? (
+            {sectionMenuValue === "confirm" ? (
               <SceneSection
-                description="Edit advanced settings, startup values, and raw scene JSON."
-                title="Advanced"
+                description="Review the scene setup before creating it and expand the raw JSON only if you need a final low-level check."
+                title="Confirm"
               >
-                <div className="scene-advanced-stack">
-                  <div className="scene-editor-grid scene-editor-grid--2">
-                    <NumberField
-                      description="Experimental compact scene field exported by the library."
-                      id="camera-orientation-mode"
-                      label="Camera Orientation Mode"
-                      min={0}
-                      onChange={(nextValue) =>
-                        updateBranch("intent", (currentIntent) => ({
-                          ...currentIntent,
-                          camOrientationMode: Math.max(
-                            0,
-                            Math.round(nextValue),
-                          ),
-                        }))
-                      }
-                      step={1}
-                      value={sceneModel.intent.camOrientationMode}
-                    />
+                <div className="scene-editor-stack">
+                  <div className="scene-confirm-summary">
+                    <ConfirmSummarySection title="Details">
+                      <ConfirmSummaryItem
+                        label="Scene Name"
+                        value={formatOptionalText(name)}
+                      />
+                      <ConfirmSummaryItem
+                        label="Description"
+                        value={formatOptionalText(description)}
+                      />
+                      <ConfirmSummaryItem
+                        label="Playlist"
+                        value={
+                          playlistValue
+                            ? PLAYLIST_OPTIONS.find(
+                                (option) => option.value === playlistValue,
+                              )?.label ?? playlistValue
+                            : "Not set"
+                        }
+                      />
+                      <ConfirmSummaryItem
+                        label="Thumbnail"
+                        value={
+                          thumbnailMode === "upload"
+                            ? thumbnailFileName || "Upload selected"
+                            : "Skipped"
+                        }
+                      />
+                      <ConfirmSummaryItem
+                        label="Tags"
+                        value={
+                          <ConfirmSummaryPills
+                            emptyLabel="None selected"
+                            values={selectedTags.map((tag) => tag.name)}
+                          />
+                        }
+                      />
+                    </ConfirmSummarySection>
 
-                    <NumberField
-                      description="Experimental compact scene field exported by the library."
-                      id="camera-orientation-speed"
-                      label="Camera Orientation Speed"
-                      min={0}
-                      onChange={(nextValue) =>
-                        updateBranch("intent", (currentIntent) => ({
-                          ...currentIntent,
-                          camOrientationSpeed: nextValue,
-                        }))
-                      }
-                      step={0.1}
-                      value={sceneModel.intent.camOrientationSpeed}
-                    />
+                    <ConfirmSummarySection title="Visual Setup">
+                      <ConfirmSummaryItem
+                        label="Shader"
+                        value={selectedShaderScene?.label ?? "Custom Shader"}
+                      />
+                      <ConfirmSummaryItem
+                        label="Skybox"
+                        value={
+                          SKYBOX_OPTIONS.find(
+                            (option) =>
+                              option.value === sceneModel.visualizer.skyboxPreset,
+                          )?.label ?? String(sceneModel.visualizer.skyboxPreset)
+                        }
+                      />
+                      <ConfirmSummaryItem
+                        label="Scale"
+                        value={formatFixed(sceneModel.visualizer.scale, 0)}
+                      />
+                    </ConfirmSummarySection>
+
+                    <ConfirmSummarySection title="Camera">
+                      <ConfirmSummaryItem
+                        label="Position"
+                        value={formatVectorSummary(sceneModel.controls.position0)}
+                      />
+                      <ConfirmSummaryItem
+                        label="Target"
+                        value={formatVectorSummary(sceneModel.controls.target0)}
+                      />
+                      <ConfirmSummaryItem
+                        label="FOV"
+                        value={formatFixed(sceneModel.intent.fov, 0)}
+                      />
+                      <ConfirmSummaryItem
+                        label="Orientation"
+                        value={formatDegrees(toDegrees(sceneModel.intent.camTilt))}
+                      />
+                      <ConfirmSummaryItem
+                        label="Zoom"
+                        value={formatFixed(sceneModel.controls.zoom0)}
+                      />
+                      {isCameraAdvancedEnabled ? (
+                        <ConfirmSummaryItem
+                          label="Advanced Camera"
+                          value={"Mode " + sceneModel.intent.camOrientationMode + ", Speed " + formatFixed(
+                            sceneModel.intent.camOrientationSpeed,
+                          )}
+                        />
+                      ) : null}
+                    </ConfirmSummarySection>
+
+                    <ConfirmSummarySection title="Motion & Effects">
+                      <ConfirmSummaryItem
+                        label="Time Multiplier"
+                        value={formatFixed(sceneModel.intent.time_multiplier)}
+                      />
+                      <ConfirmSummaryItem
+                        label="Audio Gain"
+                        value={formatFixed(sceneModel.intent.minimizing_factor)}
+                      />
+                      <ConfirmSummaryItem
+                        label="Audio Curve"
+                        value={formatFixed(sceneModel.intent.power_factor)}
+                      />
+                      <ConfirmSummaryItem
+                        label="Auto Rotate"
+                        value={sceneModel.intent.autoRotate ? "On" : "Off"}
+                      />
+                      {isMotionAdvancedEnabled ? (
+                        <ConfirmSummaryItem
+                          label="Runtime Seed"
+                          value={formatRuntimeStateSummary()}
+                        />
+                      ) : null}
+                      <ConfirmSummaryItem
+                        label="Tone Mapping"
+                        value={selectedToneMapping.label}
+                      />
+                      <ConfirmSummaryItem
+                        label="Exposure"
+                        value={formatFixed(sceneModel.fx.toneMapping.exposure)}
+                      />
+                      <ConfirmSummaryItem
+                        label="Enabled Passes"
+                        value={
+                          <ConfirmSummaryPills
+                            emptyLabel="No effect passes enabled"
+                            values={sceneModel.fx.passOrder
+                              .filter(
+                                (passId) =>
+                                  describePassState(passId, sceneModel) ===
+                                  "Enabled",
+                              )
+                              .map((passId) => PASS_LABELS[passId])}
+                          />
+                        }
+                      />
+                    </ConfirmSummarySection>
                   </div>
 
-                  <div className="field-group">
-                    <label>Runtime State</label>
-                    <p className="field-hint">
-                      Seed low-level engine values for debugging or for scenes
-                      that depend on non-default startup state.
-                    </p>
-                  </div>
-                  <div className="scene-editor-grid scene-editor-grid--3">
-                    <NumberField
-                      description="Low-level runtime state."
-                      id="state-size"
-                      label="State Size"
-                      onChange={(nextValue) =>
-                        updateBranch("state", (currentState) => ({
-                          ...currentState,
-                          size: nextValue,
-                        }))
-                      }
-                      step={0.01}
-                      value={sceneModel.state.size}
-                    />
-                    <NumberField
-                      description="Initial runtime pointer state."
-                      id="state-pointer-down"
-                      label="Pointer Down"
-                      onChange={(nextValue) =>
-                        updateBranch("state", (currentState) => ({
-                          ...currentState,
-                          pointerDown: nextValue,
-                        }))
-                      }
-                      step={0.01}
-                      value={sceneModel.state.pointerDown}
-                    />
-                    <NumberField
-                      description="Initial smoothed pointer state."
-                      id="state-current-pointer-down"
-                      label="Current Pointer"
-                      onChange={(nextValue) =>
-                        updateBranch("state", (currentState) => ({
-                          ...currentState,
-                          currPointerDown: nextValue,
-                        }))
-                      }
-                      step={0.01}
-                      value={sceneModel.state.currPointerDown}
-                    />
-                    <NumberField
-                      description="Initial runtime audio input."
-                      id="state-current-audio"
-                      label="Current Audio"
-                      onChange={(nextValue) =>
-                        updateBranch("state", (currentState) => ({
-                          ...currentState,
-                          currAudio: nextValue,
-                        }))
-                      }
-                      step={0.01}
-                      value={sceneModel.state.currAudio}
-                    />
-                    <NumberField
-                      description="Initial runtime time value."
-                      id="state-time"
-                      label="State Time"
-                      onChange={(nextValue) =>
-                        updateBranch("state", (currentState) => ({
-                          ...currentState,
-                          time: nextValue,
-                        }))
-                      }
-                      step={0.01}
-                      value={sceneModel.state.time}
-                    />
-                    <NumberField
-                      description="Initial runtime volume multiplier."
-                      id="state-volume"
-                      label="Volume Multiplier"
-                      onChange={(nextValue) =>
-                        updateBranch("state", (currentState) => ({
-                          ...currentState,
-                          volume_multiplier: nextValue,
-                        }))
-                      }
-                      step={0.01}
-                      value={sceneModel.state.volume_multiplier}
-                    />
-                  </div>
-
-                  <div className="field-group">
-                    <div className="scene-advanced-header">
-                      <div>
-                        <label htmlFor="sceneData">Scene Data JSON</label>
-                        <p className="field-hint">
-                          Raw scene data stays available here. While the JSON is
-                          invalid, the preview keeps the last valid scene
-                          state.
-                        </p>
-                      </div>
-                      <button
-                        className="scene-secondary-button"
-                        onClick={handleFormatJson}
-                        type="button"
-                      >
-                        Format JSON
-                      </button>
-                    </div>
-                    <textarea
-                      aria-describedby={
-                        errors.sceneData ? "sceneData-error" : "sceneData-hint"
-                      }
-                      aria-invalid={Boolean(errors.sceneData)}
-                      className="scene-textarea scene-textarea--code"
-                      id="sceneData"
-                      name="sceneData"
-                      onChange={(event) =>
-                        handleRawSceneDataChange(event.currentTarget.value)
-                      }
-                      required
-                      rows={16}
-                      value={sceneDataText}
-                    />
-                    {errors.sceneData ? (
-                      <p
-                        className="field-error"
-                        id="sceneData-error"
-                        role="alert"
-                      >
-                        {errors.sceneData}
-                      </p>
-                    ) : (
-                      <p className="field-hint" id="sceneData-hint">
-                        Structured controls above keep this JSON in sync with
-                        the current scene.
-                      </p>
-                    )}
-                  </div>
+                  <CollapsibleEditorGroup
+                    hideLabel="Hide Raw JSON"
+                    id="confirm-raw-json"
+                    isOpen={isConfirmJsonOpen}
+                    onToggle={() =>
+                      setIsConfirmJsonOpen((currentValue) => !currentValue)
+                    }
+                    showLabel="Show Raw JSON"
+                  >
+                    {renderRawSceneDataEditor()}
+                  </CollapsibleEditorGroup>
                 </div>
               </SceneSection>
             ) : null}


### PR DESCRIPTION
## Summary

Refine the create-scene flow into a cleaner step-by-step editor with better control styling, simpler advanced toggles, and a lighter final review experience.

## What changed

### Shared editor styling

- unified editor control styling across sliders, selects, toggles, and other inputs
- updated effect cards so enabled-only settings render in a cleaner dependent block instead of feeling overly nested
- aligned pass-order items with the rest of the editor card system

### Create-scene flow

- split scene details into their own first step
- kept section navigation with back/next actions and sticky bottom controls
- improved section validation feedback in the stepper
- added hover tooltips for invalid prior sections

### Advanced settings and review

- moved advanced-only settings into simpler inline enable/disable sections
- only use advanced camera/runtime values when those advanced sections are enabled
- simplified the confirm step into a cleaner review layout
- removed noisier confirm details like raw shader summary and redundant pass-order summary
- improved confirm formatting for vector values and enabled-pass display

## Verification

- `npm run test -- src/pages/CreateScenePage.test.tsx`
- `npm run build`