### PR TITLE
Profile save settings flow

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,3 +21,6 @@ This directory holds focused implementation notes for the MAGE frontend. The rep
 
 - [registration-page.md](./registration-page.md)  
   Registration flow behavior, redirect path, and backend request shape.
+
+- [settings-page.md](./settings-page.md)  
+  Profile edit flow, save behavior, and authenticated update request shape.

--- a/docs/settings-page.md
+++ b/docs/settings-page.md
@@ -1,0 +1,73 @@
+# Settings Page
+
+## Overview
+
+The settings page shows the authenticated user's profile details and allows them to save updated
+`firstName`, `lastName`, and `displayName` values through the backend profile endpoint. The
+frontend keeps the email field read-only and refreshes the shared auth session after a successful
+save so updated name values remain available across the app.
+
+Route:
+
+- `/settings`
+
+Access:
+
+- authenticated-only through the shared route guard
+
+## Related Files
+
+- `src/pages/SettingsPage.tsx`
+- `src/pages/SettingsPage.test.tsx`
+- `src/auth/AuthContext.tsx`
+- `src/auth/AuthContext.test.tsx`
+- `src/lib/authForm.ts`
+
+## Request Flow
+
+Primary request:
+
+- `PUT /api/users/me`
+
+Expected request body:
+
+```json
+{
+  "firstName": "Scene",
+  "lastName": "Artist",
+  "displayName": "Scene Artist"
+}
+```
+
+Requests are sent through `authenticatedFetch()`, which applies the bearer token and clears the
+stored session automatically if the backend returns `401`.
+
+## User-Facing Behavior
+
+- initializes the form from persisted `firstName`, `lastName`, and `displayName` values
+- keeps the email field read-only
+- disables the save button until a name field changes
+- shows a loading state while the save request is in flight
+- surfaces backend field validation details when present
+- shows a generic unavailable message when the save request fails
+- updates the shared auth session through `updateAuthenticatedUser()` after a successful save
+- keeps `displayName` as the public-facing name used on scenes, comments, and other attribution surfaces
+
+## Auth Session Notes
+
+Successful saves update the in-memory auth state and the stored `mage.auth.session` snapshot. That
+lets a subsequent app reload restore the saved profile values without waiting for another manual
+edit.
+
+## Tests
+
+Main coverage lives in:
+
+- `src/pages/SettingsPage.test.tsx`
+- `src/auth/AuthContext.test.tsx`
+
+Run them with:
+
+```bash
+npm run test
+```

--- a/src/App.css
+++ b/src/App.css
@@ -820,8 +820,35 @@
   gap: 16px;
 }
 
+.settings-actions {
+  display: flex;
+  gap: 12px;
+  align-items: stretch;
+  justify-content: flex-end;
+}
+
+.settings-action-button {
+  width: auto;
+  min-width: 168px;
+  min-height: 40px;
+  padding: 0 14px;
+  justify-content: center;
+  flex: 0 0 auto;
+}
+
+.settings-save-button:disabled,
+.settings-save-button:disabled:hover {
+  cursor: not-allowed;
+  opacity: 0.58;
+  transform: none;
+  box-shadow: none;
+  color: rgba(245, 251, 249, 0.7);
+  background: rgba(99, 240, 214, 0.14);
+  border: 1px solid rgba(99, 240, 214, 0.18);
+}
+
 .settings-reset-button {
-  justify-self: start;
+  justify-self: auto;
 }
 
 .scene-empty-state {
@@ -3391,6 +3418,14 @@
 
   .settings-section {
     padding: 20px;
+  }
+
+  .settings-actions {
+    flex-wrap: wrap;
+  }
+
+  .settings-actions .settings-action-button {
+    width: auto;
   }
 
   .scene-detail-watch .mage-player-shell {

--- a/src/auth/AuthContext.test.tsx
+++ b/src/auth/AuthContext.test.tsx
@@ -27,7 +27,14 @@ const restoredUser: AuthenticatedUser = {
 }
 
 function AuthHarness() {
-  const { authenticatedFetch, isAuthenticated, isRestoringSession, logout, user } = useAuth()
+  const {
+    authenticatedFetch,
+    isAuthenticated,
+    isRestoringSession,
+    logout,
+    updateAuthenticatedUser,
+    user,
+  } = useAuth()
 
   return (
     <div>
@@ -35,8 +42,26 @@ function AuthHarness() {
         {isRestoringSession ? 'restoring' : isAuthenticated ? 'authenticated' : 'signed-out'}
       </div>
       <div data-testid="auth-user-email">{user?.email ?? 'none'}</div>
+      <div data-testid="auth-user-display-name">{user?.displayName ?? 'none'}</div>
       <button type="button" onClick={logout}>
         Log out
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          if (!user) {
+            return
+          }
+
+          updateAuthenticatedUser({
+            ...user,
+            firstName: 'Updated',
+            lastName: 'Artist',
+            displayName: 'Updated Artist',
+          })
+        }}
+      >
+        Update profile snapshot
       </button>
       <button
         type="button"
@@ -148,6 +173,33 @@ describe('AuthProvider', () => {
     expect(window.localStorage.getItem(AUTH_SESSION_STORAGE_KEY)).toBeNull()
     expect(screen.getByTestId('auth-status')).toHaveTextContent('signed-out')
     expect(screen.getByTestId('auth-user-email')).toHaveTextContent('none')
+  })
+
+  it('persists updated authenticated user details into the stored session', async () => {
+    storeSession()
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(restoredUser))
+
+    const user = userEvent.setup()
+
+    renderAuthHarness()
+
+    expect(await screen.findByText('restored-user@example.com')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /update profile snapshot/i }))
+
+    const persistedSession = JSON.parse(
+      window.localStorage.getItem(AUTH_SESSION_STORAGE_KEY) ?? 'null',
+    ) as { user: AuthenticatedUser | null }
+
+    expect(persistedSession.user).toEqual(
+      expect.objectContaining({
+        firstName: 'Updated',
+        lastName: 'Artist',
+        displayName: 'Updated Artist',
+      }),
+    )
+    expect(screen.getByTestId('auth-user-display-name')).toHaveTextContent('Updated Artist')
   })
 
   it('authenticated requests send the bearer token and clear auth state on a 401', async () => {

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -11,6 +11,8 @@ import { buildApiUrl } from '../lib/api'
 export type AuthenticatedUser = {
   userId: number | null
   email: string
+  firstName?: string
+  lastName?: string
   displayName: string
   authProvider: string
   createdAt?: string
@@ -27,6 +29,7 @@ type AuthContextValue = {
   isAuthenticated: boolean
   isRestoringSession: boolean
   completeLoginSession: (session: StoredAuthSession) => void
+  updateAuthenticatedUser: (user: AuthenticatedUser) => void
   logout: () => void
   authenticatedFetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
 }
@@ -37,6 +40,24 @@ const AuthContext = createContext<AuthContextValue | undefined>(undefined)
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
+}
+
+function splitDisplayName(displayName: string) {
+  const trimmedDisplayName = displayName.trim()
+
+  if (!trimmedDisplayName) {
+    return {
+      firstName: '',
+      lastName: '',
+    }
+  }
+
+  const [firstName = '', ...remainingParts] = trimmedDisplayName.split(/\s+/)
+
+  return {
+    firstName,
+    lastName: remainingParts.join(' '),
+  }
 }
 
 function readStoredUser(value: unknown): AuthenticatedUser | null {
@@ -54,10 +75,15 @@ function readStoredUser(value: unknown): AuthenticatedUser | null {
     typeof value.displayName === 'string' && value.displayName.trim()
       ? value.displayName
       : email
+  const derivedNames = splitDisplayName(displayName)
 
   return {
     userId: typeof value.userId === 'number' ? value.userId : null,
     email,
+    firstName:
+      typeof value.firstName === 'string' ? value.firstName : derivedNames.firstName,
+    lastName:
+      typeof value.lastName === 'string' ? value.lastName : derivedNames.lastName,
     displayName,
     authProvider: typeof value.authProvider === 'string' ? value.authProvider : 'LOCAL',
     createdAt: typeof value.createdAt === 'string' ? value.createdAt : undefined,
@@ -118,6 +144,22 @@ export function AuthProvider({ children }: PropsWithChildren) {
   function completeLoginSession(nextSession: StoredAuthSession) {
     persistSession(nextSession)
     setSession(nextSession)
+  }
+
+  function updateAuthenticatedUser(nextUser: AuthenticatedUser) {
+    setSession((currentSession) => {
+      if (!currentSession) {
+        return currentSession
+      }
+
+      const nextSession = {
+        ...currentSession,
+        user: nextUser,
+      }
+
+      persistSession(nextSession)
+      return nextSession
+    })
   }
 
   async function authenticatedFetch(input: RequestInfo | URL, init: RequestInit = {}) {
@@ -203,6 +245,7 @@ export function AuthProvider({ children }: PropsWithChildren) {
     isAuthenticated: Boolean(session?.accessToken && session?.user),
     isRestoringSession,
     completeLoginSession,
+    updateAuthenticatedUser,
     logout: clearSession,
     authenticatedFetch,
   }

--- a/src/components/Layout.test.tsx
+++ b/src/components/Layout.test.tsx
@@ -13,10 +13,13 @@ let authState = {
   isAuthenticated: false,
   isRestoringSession: false,
   logout: logoutMock,
+  updateAuthenticatedUser: vi.fn(),
   user: null as null | {
     authProvider: string
     displayName: string
     email: string
+    firstName?: string
+    lastName?: string
     userId: number | null
   },
 }
@@ -45,6 +48,7 @@ describe('Layout', () => {
       isAuthenticated: false,
       isRestoringSession: false,
       logout: logoutMock,
+      updateAuthenticatedUser: vi.fn(),
       user: null,
     }
   })

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -9,10 +9,13 @@ let authState = {
   isAuthenticated: false,
   isRestoringSession: false,
   logout: vi.fn(),
+  updateAuthenticatedUser: vi.fn(),
   user: null as null | {
     authProvider: string
     displayName: string
     email: string
+    firstName?: string
+    lastName?: string
     userId: number | null
   },
 }
@@ -38,6 +41,7 @@ describe('HomePage', () => {
       isAuthenticated: false,
       isRestoringSession: false,
       logout: vi.fn(),
+      updateAuthenticatedUser: vi.fn(),
       user: null,
     }
   })

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -16,6 +16,8 @@ type LoginFormErrors = Partial<Record<keyof LoginFormValues | 'form', string>>
 type LoginResponse = {
   userId?: number
   email?: string
+  firstName?: string
+  lastName?: string
   displayName?: string
   authProvider?: string
   accessToken?: string
@@ -176,6 +178,8 @@ export function LoginPage() {
       const authenticatedUser: AuthenticatedUser = {
         userId: payload?.userId ?? null,
         email: payload?.email ?? trimmedValues.email,
+        firstName: payload?.firstName,
+        lastName: payload?.lastName,
         displayName: payload?.displayName ?? payload?.email ?? trimmedValues.email,
         authProvider: payload?.authProvider ?? 'LOCAL',
       }

--- a/src/pages/RegisterPage.test.tsx
+++ b/src/pages/RegisterPage.test.tsx
@@ -21,8 +21,6 @@ function renderRegisterPage() {
 }
 
 async function fillValidForm(user: ReturnType<typeof userEvent.setup>) {
-  await user.type(screen.getByLabelText(/first name/i), ' New ')
-  await user.type(screen.getByLabelText(/last name/i), ' User ')
   await user.type(screen.getByLabelText(/display name/i), ' New User ')
   await user.type(screen.getByLabelText(/^email$/i), ' user@example.com ')
   await user.type(screen.getByLabelText(/password/i), 'secret-value')
@@ -37,15 +35,13 @@ describe('RegisterPage', () => {
 
     await user.click(screen.getByRole('button', { name: /create account/i }))
 
-    expect(await screen.findByText('First name is required.')).toBeInTheDocument()
-    expect(screen.getByText('Last name is required.')).toBeInTheDocument()
     expect(await screen.findByText('Display name is required.')).toBeInTheDocument()
     expect(screen.getByText('Email is required.')).toBeInTheDocument()
     expect(screen.getByText('Password is required.')).toBeInTheDocument()
     expect(fetchSpy).not.toHaveBeenCalled()
   })
 
-  it('submits trimmed values, disables the button while loading, and hands the user into login', async () => {
+  it('submits trimmed values with default first and last names, disables the button while loading, and hands the user into login', async () => {
     let resolveResponse: ((value: Response) => void) | undefined
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
       () =>
@@ -67,15 +63,15 @@ describe('RegisterPage', () => {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({
-          firstName: 'New',
-          lastName: 'User',
-          displayName: 'New User',
-          email: 'user@example.com',
-          password: 'secret-value',
-        }),
       }),
     )
+    expect(JSON.parse(String(fetchSpy.mock.calls[0][1]?.body))).toEqual({
+      firstName: 'NoName',
+      lastName: 'NoName',
+      displayName: 'New User',
+      email: 'user@example.com',
+      password: 'secret-value',
+    })
     expect(screen.getByRole('button', { name: /creating account/i })).toBeDisabled()
 
     resolveResponse?.(
@@ -127,8 +123,6 @@ describe('RegisterPage', () => {
         JSON.stringify({
           message: 'Registration failed. Please review your information and try again.',
           details: {
-            firstName: 'firstName must not be blank',
-            lastName: 'lastName must not be blank',
             displayName: 'displayName must not be blank',
             email: 'email must not be blank',
             password: 'password must not be blank',
@@ -149,8 +143,6 @@ describe('RegisterPage', () => {
     await fillValidForm(user)
     await user.click(screen.getByRole('button', { name: /create account/i }))
 
-    expect(await screen.findByText('firstName must not be blank')).toBeInTheDocument()
-    expect(screen.getByText('lastName must not be blank')).toBeInTheDocument()
     expect(await screen.findByText('displayName must not be blank')).toBeInTheDocument()
     expect(screen.getByText('email must not be blank')).toBeInTheDocument()
     expect(screen.getByText('password must not be blank')).toBeInTheDocument()

--- a/src/pages/RegisterPage.test.tsx
+++ b/src/pages/RegisterPage.test.tsx
@@ -21,6 +21,8 @@ function renderRegisterPage() {
 }
 
 async function fillValidForm(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText(/first name/i), ' New ')
+  await user.type(screen.getByLabelText(/last name/i), ' User ')
   await user.type(screen.getByLabelText(/display name/i), ' New User ')
   await user.type(screen.getByLabelText(/^email$/i), ' user@example.com ')
   await user.type(screen.getByLabelText(/password/i), 'secret-value')
@@ -35,6 +37,8 @@ describe('RegisterPage', () => {
 
     await user.click(screen.getByRole('button', { name: /create account/i }))
 
+    expect(await screen.findByText('First name is required.')).toBeInTheDocument()
+    expect(screen.getByText('Last name is required.')).toBeInTheDocument()
     expect(await screen.findByText('Display name is required.')).toBeInTheDocument()
     expect(screen.getByText('Email is required.')).toBeInTheDocument()
     expect(screen.getByText('Password is required.')).toBeInTheDocument()
@@ -64,6 +68,8 @@ describe('RegisterPage', () => {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
+          firstName: 'New',
+          lastName: 'User',
           displayName: 'New User',
           email: 'user@example.com',
           password: 'secret-value',
@@ -121,6 +127,8 @@ describe('RegisterPage', () => {
         JSON.stringify({
           message: 'Registration failed. Please review your information and try again.',
           details: {
+            firstName: 'firstName must not be blank',
+            lastName: 'lastName must not be blank',
             displayName: 'displayName must not be blank',
             email: 'email must not be blank',
             password: 'password must not be blank',
@@ -141,6 +149,8 @@ describe('RegisterPage', () => {
     await fillValidForm(user)
     await user.click(screen.getByRole('button', { name: /create account/i }))
 
+    expect(await screen.findByText('firstName must not be blank')).toBeInTheDocument()
+    expect(screen.getByText('lastName must not be blank')).toBeInTheDocument()
     expect(await screen.findByText('displayName must not be blank')).toBeInTheDocument()
     expect(screen.getByText('email must not be blank')).toBeInTheDocument()
     expect(screen.getByText('password must not be blank')).toBeInTheDocument()

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -6,8 +6,6 @@ import { buildApiUrl } from '../lib/api'
 import { emailPattern, parseApiError } from '../lib/authForm'
 
 type RegistrationFormValues = {
-  firstName: string
-  lastName: string
   displayName: string
   email: string
   password: string
@@ -26,23 +24,16 @@ type RegistrationResponse = {
 }
 
 const initialValues: RegistrationFormValues = {
-  firstName: '',
-  lastName: '',
   displayName: '',
   email: '',
   password: '',
 }
 
+const DEFAULT_REGISTRATION_FIRST_NAME = 'NoName'
+const DEFAULT_REGISTRATION_LAST_NAME = 'NoName'
+
 function validateRegistrationForm(values: RegistrationFormValues): RegistrationFormErrors {
   const errors: RegistrationFormErrors = {}
-
-  if (!values.firstName.trim()) {
-    errors.firstName = 'First name is required.'
-  }
-
-  if (!values.lastName.trim()) {
-    errors.lastName = 'Last name is required.'
-  }
 
   if (!values.displayName.trim()) {
     errors.displayName = 'Display name is required.'
@@ -99,8 +90,6 @@ export function RegisterPage() {
     event.preventDefault()
 
     const trimmedValues = {
-      firstName: values.firstName.trim(),
-      lastName: values.lastName.trim(),
       displayName: values.displayName.trim(),
       email: values.email.trim(),
       password: values.password,
@@ -122,7 +111,11 @@ export function RegisterPage() {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(trimmedValues),
+        body: JSON.stringify({
+          ...trimmedValues,
+          firstName: DEFAULT_REGISTRATION_FIRST_NAME,
+          lastName: DEFAULT_REGISTRATION_LAST_NAME,
+        }),
       })
 
       if (!response.ok) {
@@ -134,8 +127,6 @@ export function RegisterPage() {
             : undefined
 
         setErrors({
-          firstName: backendDetails.firstName,
-          lastName: backendDetails.lastName,
           displayName: backendDetails.displayName,
           email: backendDetails.email,
           password: backendDetails.password,
@@ -176,48 +167,6 @@ export function RegisterPage() {
           />
 
           <form className="auth-form" noValidate onSubmit={handleSubmit}>
-            <div className="field-group">
-              <label htmlFor="firstName">First name</label>
-              <input
-                id="firstName"
-                name="firstName"
-                type="text"
-                autoComplete="given-name"
-                required
-                value={values.firstName}
-                onChange={(event) => handleChange('firstName', event.target.value)}
-                aria-invalid={Boolean(errors.firstName)}
-                aria-describedby={errors.firstName ? 'firstName-error' : undefined}
-                placeholder="Mir"
-              />
-              {errors.firstName ? (
-                <p className="field-error" id="firstName-error" role="alert">
-                  {errors.firstName}
-                </p>
-              ) : null}
-            </div>
-
-            <div className="field-group">
-              <label htmlFor="lastName">Last name</label>
-              <input
-                id="lastName"
-                name="lastName"
-                type="text"
-                autoComplete="family-name"
-                required
-                value={values.lastName}
-                onChange={(event) => handleChange('lastName', event.target.value)}
-                aria-invalid={Boolean(errors.lastName)}
-                aria-describedby={errors.lastName ? 'lastName-error' : undefined}
-                placeholder="Ali"
-              />
-              {errors.lastName ? (
-                <p className="field-error" id="lastName-error" role="alert">
-                  {errors.lastName}
-                </p>
-              ) : null}
-            </div>
-
             <div className="field-group">
               <label htmlFor="displayName">Display name</label>
               <input

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -6,6 +6,8 @@ import { buildApiUrl } from '../lib/api'
 import { emailPattern, parseApiError } from '../lib/authForm'
 
 type RegistrationFormValues = {
+  firstName: string
+  lastName: string
   displayName: string
   email: string
   password: string
@@ -16,12 +18,16 @@ type RegistrationFormErrors = Partial<Record<keyof RegistrationFormValues | 'for
 type RegistrationResponse = {
   userId?: number
   email?: string
+  firstName?: string
+  lastName?: string
   displayName?: string
   authProvider?: string
   created?: boolean
 }
 
 const initialValues: RegistrationFormValues = {
+  firstName: '',
+  lastName: '',
   displayName: '',
   email: '',
   password: '',
@@ -29,6 +35,14 @@ const initialValues: RegistrationFormValues = {
 
 function validateRegistrationForm(values: RegistrationFormValues): RegistrationFormErrors {
   const errors: RegistrationFormErrors = {}
+
+  if (!values.firstName.trim()) {
+    errors.firstName = 'First name is required.'
+  }
+
+  if (!values.lastName.trim()) {
+    errors.lastName = 'Last name is required.'
+  }
 
   if (!values.displayName.trim()) {
     errors.displayName = 'Display name is required.'
@@ -85,6 +99,8 @@ export function RegisterPage() {
     event.preventDefault()
 
     const trimmedValues = {
+      firstName: values.firstName.trim(),
+      lastName: values.lastName.trim(),
       displayName: values.displayName.trim(),
       email: values.email.trim(),
       password: values.password,
@@ -118,6 +134,8 @@ export function RegisterPage() {
             : undefined
 
         setErrors({
+          firstName: backendDetails.firstName,
+          lastName: backendDetails.lastName,
           displayName: backendDetails.displayName,
           email: backendDetails.email,
           password: backendDetails.password,
@@ -158,6 +176,48 @@ export function RegisterPage() {
           />
 
           <form className="auth-form" noValidate onSubmit={handleSubmit}>
+            <div className="field-group">
+              <label htmlFor="firstName">First name</label>
+              <input
+                id="firstName"
+                name="firstName"
+                type="text"
+                autoComplete="given-name"
+                required
+                value={values.firstName}
+                onChange={(event) => handleChange('firstName', event.target.value)}
+                aria-invalid={Boolean(errors.firstName)}
+                aria-describedby={errors.firstName ? 'firstName-error' : undefined}
+                placeholder="Mir"
+              />
+              {errors.firstName ? (
+                <p className="field-error" id="firstName-error" role="alert">
+                  {errors.firstName}
+                </p>
+              ) : null}
+            </div>
+
+            <div className="field-group">
+              <label htmlFor="lastName">Last name</label>
+              <input
+                id="lastName"
+                name="lastName"
+                type="text"
+                autoComplete="family-name"
+                required
+                value={values.lastName}
+                onChange={(event) => handleChange('lastName', event.target.value)}
+                aria-invalid={Boolean(errors.lastName)}
+                aria-describedby={errors.lastName ? 'lastName-error' : undefined}
+                placeholder="Ali"
+              />
+              {errors.lastName ? (
+                <p className="field-error" id="lastName-error" role="alert">
+                  {errors.lastName}
+                </p>
+              ) : null}
+            </div>
+
             <div className="field-group">
               <label htmlFor="displayName">Display name</label>
               <input

--- a/src/pages/SettingsPage.test.tsx
+++ b/src/pages/SettingsPage.test.tsx
@@ -141,6 +141,88 @@ describe('SettingsPage', () => {
     expect(await screen.findByText('Profile details saved.')).toBeInTheDocument()
   })
 
+  it('shows backend validation errors when submitted profile values are invalid', async () => {
+    authState = {
+      ...authState,
+      accessToken: 'token',
+      authenticatedFetch: vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            message: 'Request validation failed.',
+            details: {
+              firstName: 'firstName must not be blank',
+              lastName: 'lastName must not be blank',
+              displayName: 'displayName must not be blank',
+            },
+          }),
+          {
+            status: 400,
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          },
+        ),
+      ),
+      isAuthenticated: true,
+      updateAuthenticatedUser: vi.fn(),
+      user: {
+        authProvider: 'LOCAL',
+        displayName: 'Scene Artist',
+        email: 'artist@example.com',
+        firstName: 'Scene',
+        lastName: 'Artist',
+        userId: 8,
+      },
+    }
+
+    const user = userEvent.setup()
+
+    render(<SettingsPage />)
+
+    await user.clear(screen.getByLabelText(/first name/i))
+    await user.clear(screen.getByLabelText(/last name/i))
+    await user.clear(screen.getByLabelText(/display name/i))
+    await user.click(screen.getByRole('button', { name: /save changes/i }))
+
+    expect(await screen.findByText('firstName must not be blank')).toBeInTheDocument()
+    expect(screen.getByText('lastName must not be blank')).toBeInTheDocument()
+    expect(screen.getByText('displayName must not be blank')).toBeInTheDocument()
+    expect(screen.getByText('Request validation failed.')).toBeInTheDocument()
+    expect(authState.updateAuthenticatedUser).not.toHaveBeenCalled()
+  })
+
+  it('shows a clear error message when the save request fails', async () => {
+    authState = {
+      ...authState,
+      accessToken: 'token',
+      authenticatedFetch: vi.fn().mockRejectedValue(new Error('network down')),
+      isAuthenticated: true,
+      updateAuthenticatedUser: vi.fn(),
+      user: {
+        authProvider: 'LOCAL',
+        displayName: 'Scene Artist',
+        email: 'artist@example.com',
+        firstName: 'Scene',
+        lastName: 'Artist',
+        userId: 8,
+      },
+    }
+
+    const user = userEvent.setup()
+
+    render(<SettingsPage />)
+
+    await user.clear(screen.getByLabelText(/display name/i))
+    await user.type(screen.getByLabelText(/display name/i), 'Updated Artist')
+    await user.click(screen.getByRole('button', { name: /save changes/i }))
+
+    expect(
+      await screen.findByText('Profile updates are unavailable right now. Please try again in a moment.'),
+    ).toBeInTheDocument()
+    expect(authState.updateAuthenticatedUser).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: /save changes/i })).toBeEnabled()
+  })
+
   it('shows a fallback state when the page cannot read a signed-in user', () => {
     render(<SettingsPage />)
 

--- a/src/pages/SettingsPage.test.tsx
+++ b/src/pages/SettingsPage.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { SettingsPage } from './SettingsPage'
 
@@ -9,10 +10,13 @@ let authState = {
   isAuthenticated: false,
   isRestoringSession: false,
   logout: vi.fn(),
+  updateAuthenticatedUser: vi.fn(),
   user: null as null | {
     authProvider: string
     displayName: string
     email: string
+    firstName?: string
+    lastName?: string
     userId: number | null
   },
 }
@@ -30,6 +34,7 @@ describe('SettingsPage', () => {
       isAuthenticated: false,
       isRestoringSession: false,
       logout: vi.fn(),
+      updateAuthenticatedUser: vi.fn(),
       user: null,
     }
   })
@@ -43,6 +48,8 @@ describe('SettingsPage', () => {
         authProvider: 'LOCAL',
         displayName: 'Scene Artist',
         email: 'artist@example.com',
+        firstName: 'Scene',
+        lastName: 'Artist',
         userId: 8,
       },
     }
@@ -56,9 +63,82 @@ describe('SettingsPage', () => {
     ).toBeInTheDocument()
     expect(screen.getByLabelText(/email/i)).toHaveValue('artist@example.com')
     expect(screen.getByLabelText(/first name/i)).toHaveValue('Scene')
+    expect(screen.getByLabelText(/display name/i)).toHaveValue('Scene Artist')
     expect(screen.getByLabelText(/last name/i)).toHaveValue('Artist')
     expect(screen.queryByText('LOCAL')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /save changes/i })).toBeDisabled()
     expect(screen.getByRole('button', { name: /reset password/i })).toBeInTheDocument()
+  })
+
+  it('saves updated names through the authenticated backend flow', async () => {
+    authState = {
+      ...authState,
+      accessToken: 'token',
+      authenticatedFetch: vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            authProvider: 'LOCAL',
+            displayName: 'Updated Artist',
+            email: 'artist@example.com',
+            firstName: 'Updated',
+            lastName: 'Artist',
+            userId: 8,
+          }),
+          {
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          },
+        ),
+      ),
+      isAuthenticated: true,
+      updateAuthenticatedUser: vi.fn(),
+      user: {
+        authProvider: 'LOCAL',
+        displayName: 'Scene Artist',
+        email: 'artist@example.com',
+        firstName: 'Scene',
+        lastName: 'Artist',
+        userId: 8,
+      },
+    }
+
+    const user = userEvent.setup()
+
+    render(<SettingsPage />)
+
+    await user.clear(screen.getByLabelText(/first name/i))
+    await user.type(screen.getByLabelText(/first name/i), 'Updated')
+    await user.clear(screen.getByLabelText(/display name/i))
+    await user.type(screen.getByLabelText(/display name/i), 'Updated Artist')
+    await user.click(screen.getByRole('button', { name: /save changes/i }))
+
+    await waitFor(() =>
+      expect(authState.authenticatedFetch).toHaveBeenCalledWith(
+        '/users/me',
+        expect.objectContaining({
+          method: 'PUT',
+          body: JSON.stringify({
+            firstName: 'Updated',
+            lastName: 'Artist',
+            displayName: 'Updated Artist',
+          }),
+        }),
+      ),
+    )
+
+    await waitFor(() =>
+      expect(authState.updateAuthenticatedUser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          firstName: 'Updated',
+          lastName: 'Artist',
+          displayName: 'Updated Artist',
+        }),
+      ),
+    )
+
+    expect(await screen.findByText('Profile details saved.')).toBeInTheDocument()
   })
 
   it('shows a fallback state when the page cannot read a signed-in user', () => {

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -2,6 +2,9 @@ import { useEffect, useId, useState, type FormEvent } from 'react'
 import { useAuth } from '../auth/AuthContext'
 import { parseApiError } from '../lib/authForm'
 
+const PROFILE_SAVE_UNAVAILABLE_MESSAGE =
+  'Profile updates are unavailable right now. Please try again in a moment.'
+
 type UserProfileResponse = {
   userId: number | null
   email: string
@@ -42,30 +45,36 @@ export function SettingsPage() {
           lastName={user.lastName ?? ''}
           displayName={user.displayName}
           onSave={async (nameFields) => {
-            const response = await authenticatedFetch('/users/me', {
-              method: 'PUT',
-              headers: {
-                'Content-Type': 'application/json',
-              },
-              body: JSON.stringify(nameFields),
-            })
+            try {
+              const response = await authenticatedFetch('/users/me', {
+                method: 'PUT',
+                headers: {
+                  'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(nameFields),
+              })
 
-            if (!response.ok) {
-              const apiError = await parseApiError(response)
+              if (!response.ok) {
+                const apiError = await parseApiError(response)
+                return {
+                  ok: false as const,
+                  details: apiError?.details ?? {},
+                  message: apiError?.message ?? PROFILE_SAVE_UNAVAILABLE_MESSAGE,
+                }
+              }
+
+              const updatedUser = (await response.json()) as UserProfileResponse
+              updateAuthenticatedUser(updatedUser)
+
+              return {
+                ok: true as const,
+              }
+            } catch {
               return {
                 ok: false as const,
-                details: apiError?.details ?? {},
-                message:
-                  apiError?.message ??
-                  'Profile updates are unavailable right now. Please try again in a moment.',
+                details: {},
+                message: PROFILE_SAVE_UNAVAILABLE_MESSAGE,
               }
-            }
-
-            const updatedUser = (await response.json()) as UserProfileResponse
-            updateAuthenticatedUser(updatedUser)
-
-            return {
-              ok: true as const,
             }
           }}
         />
@@ -151,30 +160,6 @@ function ProfileDetailsForm({
         </div>
 
         <div className="field-group">
-          <label htmlFor="settings-first-name">First name</label>
-          <input
-            id="settings-first-name"
-            name="firstName"
-            onChange={(event) =>
-              setNameFields((currentFields) => ({
-                ...currentFields,
-                firstName: event.target.value,
-              }))
-            }
-            aria-describedby={errors.firstName ? 'settings-first-name-error' : undefined}
-            aria-invalid={Boolean(errors.firstName)}
-            placeholder="First name"
-            type="text"
-            value={nameFields.firstName}
-          />
-          {errors.firstName ? (
-            <p className="field-error" id="settings-first-name-error" role="alert">
-              {errors.firstName}
-            </p>
-          ) : null}
-        </div>
-
-        <div className="field-group">
           <label htmlFor="settings-display-name">Display name</label>
           <input
             id="settings-display-name"
@@ -194,6 +179,30 @@ function ProfileDetailsForm({
           {errors.displayName ? (
             <p className="field-error" id="settings-display-name-error" role="alert">
               {errors.displayName}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="field-group">
+          <label htmlFor="settings-first-name">First name</label>
+          <input
+            id="settings-first-name"
+            name="firstName"
+            onChange={(event) =>
+              setNameFields((currentFields) => ({
+                ...currentFields,
+                firstName: event.target.value,
+              }))
+            }
+            aria-describedby={errors.firstName ? 'settings-first-name-error' : undefined}
+            aria-invalid={Boolean(errors.firstName)}
+            placeholder="First name"
+            type="text"
+            value={nameFields.firstName}
+          />
+          {errors.firstName ? (
+            <p className="field-error" id="settings-first-name-error" role="alert">
+              {errors.firstName}
             </p>
           ) : null}
         </div>
@@ -234,17 +243,22 @@ function ProfileDetailsForm({
           </div>
         ) : null}
 
-        <button
-          className="demo-link auth-submit"
-          disabled={!isDirty || isSubmitting}
-          type="submit"
-        >
-          {isSubmitting ? 'Saving...' : 'Save changes'}
-        </button>
+        <div className="settings-actions">
+          <button
+            className="demo-link auth-submit settings-action-button settings-save-button"
+            disabled={!isDirty || isSubmitting}
+            type="submit"
+          >
+            {isSubmitting ? 'Saving...' : 'Save changes'}
+          </button>
 
-        <button className="scene-secondary-button settings-reset-button" type="button">
-          Reset password
-        </button>
+          <button
+            className="scene-secondary-button settings-action-button settings-reset-button"
+            type="button"
+          >
+            Reset password
+          </button>
+        </div>
       </form>
     </section>
   )

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,23 +1,19 @@
-import { useState } from 'react'
+import { useEffect, useId, useState, type FormEvent } from 'react'
 import { useAuth } from '../auth/AuthContext'
+import { parseApiError } from '../lib/authForm'
 
-function splitDisplayName(displayName: string) {
-  const trimmedDisplayName = displayName.trim()
-
-  if (!trimmedDisplayName) {
-    return { firstName: '', lastName: '' }
-  }
-
-  const [firstName = '', ...remainingParts] = trimmedDisplayName.split(/\s+/)
-
-  return {
-    firstName,
-    lastName: remainingParts.join(' '),
-  }
+type UserProfileResponse = {
+  userId: number | null
+  email: string
+  firstName?: string
+  lastName?: string
+  displayName: string
+  authProvider: string
+  createdAt?: string
 }
 
 export function SettingsPage() {
-  const { user } = useAuth()
+  const { authenticatedFetch, updateAuthenticatedUser, user } = useAuth()
 
   if (!user) {
     return (
@@ -41,9 +37,37 @@ export function SettingsPage() {
         </p>
 
         <ProfileDetailsForm
-          key={`${user.email}:${user.displayName}`}
-          displayName={user.displayName}
           email={user.email}
+          firstName={user.firstName ?? ''}
+          lastName={user.lastName ?? ''}
+          displayName={user.displayName}
+          onSave={async (nameFields) => {
+            const response = await authenticatedFetch('/users/me', {
+              method: 'PUT',
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify(nameFields),
+            })
+
+            if (!response.ok) {
+              const apiError = await parseApiError(response)
+              return {
+                ok: false as const,
+                details: apiError?.details ?? {},
+                message:
+                  apiError?.message ??
+                  'Profile updates are unavailable right now. Please try again in a moment.',
+              }
+            }
+
+            const updatedUser = (await response.json()) as UserProfileResponse
+            updateAuthenticatedUser(updatedUser)
+
+            return {
+              ok: true as const,
+            }
+          }}
         />
       </section>
     </main>
@@ -51,16 +75,76 @@ export function SettingsPage() {
 }
 
 type ProfileDetailsFormProps = {
-  displayName: string
   email: string
+  firstName: string
+  lastName: string
+  displayName: string
+  onSave: (nameFields: { firstName: string; lastName: string; displayName: string }) => Promise<
+    | { ok: true }
+    | { ok: false; details: Record<string, string>; message: string }
+  >
 }
 
-function ProfileDetailsForm({ displayName, email }: ProfileDetailsFormProps) {
-  const [nameFields, setNameFields] = useState(() => splitDisplayName(displayName))
+function ProfileDetailsForm({
+  email,
+  firstName,
+  lastName,
+  displayName,
+  onSave,
+}: ProfileDetailsFormProps) {
+  const [nameFields, setNameFields] = useState(() => ({ firstName, lastName, displayName }))
+  const [errors, setErrors] = useState<{
+    firstName?: string
+    lastName?: string
+    displayName?: string
+    form?: string
+  }>({})
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [successMessage, setSuccessMessage] = useState('')
+  const formNoticeId = useId()
+
+  const isDirty =
+    nameFields.firstName !== firstName ||
+    nameFields.lastName !== lastName ||
+    nameFields.displayName !== displayName
+
+  useEffect(() => {
+    setNameFields({ firstName, lastName, displayName })
+  }, [firstName, lastName, displayName])
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    setIsSubmitting(true)
+    setErrors({})
+    setSuccessMessage('')
+
+    try {
+      const result = await onSave({
+        firstName: nameFields.firstName.trim(),
+        lastName: nameFields.lastName.trim(),
+        displayName: nameFields.displayName.trim(),
+      })
+
+      if (!result.ok) {
+        setErrors({
+          firstName: result.details.firstName,
+          lastName: result.details.lastName,
+          displayName: result.details.displayName,
+          form: result.message,
+        })
+        return
+      }
+
+      setSuccessMessage('Profile details saved.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
 
   return (
     <section className="surface surface--soft settings-section" aria-label="Profile details">
-      <div className="settings-fields">
+      <form className="settings-fields" onSubmit={handleSubmit}>
         <div className="field-group">
           <label htmlFor="settings-email">Email</label>
           <input id="settings-email" name="email" readOnly type="email" value={email} />
@@ -77,10 +161,41 @@ function ProfileDetailsForm({ displayName, email }: ProfileDetailsFormProps) {
                 firstName: event.target.value,
               }))
             }
+            aria-describedby={errors.firstName ? 'settings-first-name-error' : undefined}
+            aria-invalid={Boolean(errors.firstName)}
             placeholder="First name"
             type="text"
             value={nameFields.firstName}
           />
+          {errors.firstName ? (
+            <p className="field-error" id="settings-first-name-error" role="alert">
+              {errors.firstName}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="field-group">
+          <label htmlFor="settings-display-name">Display name</label>
+          <input
+            id="settings-display-name"
+            name="displayName"
+            onChange={(event) =>
+              setNameFields((currentFields) => ({
+                ...currentFields,
+                displayName: event.target.value,
+              }))
+            }
+            aria-describedby={errors.displayName ? 'settings-display-name-error' : undefined}
+            aria-invalid={Boolean(errors.displayName)}
+            placeholder="Display name"
+            type="text"
+            value={nameFields.displayName}
+          />
+          {errors.displayName ? (
+            <p className="field-error" id="settings-display-name-error" role="alert">
+              {errors.displayName}
+            </p>
+          ) : null}
         </div>
 
         <div className="field-group">
@@ -94,16 +209,43 @@ function ProfileDetailsForm({ displayName, email }: ProfileDetailsFormProps) {
                 lastName: event.target.value,
               }))
             }
+            aria-describedby={errors.lastName ? 'settings-last-name-error' : undefined}
+            aria-invalid={Boolean(errors.lastName)}
             placeholder="Last name"
             type="text"
             value={nameFields.lastName}
           />
+          {errors.lastName ? (
+            <p className="field-error" id="settings-last-name-error" role="alert">
+              {errors.lastName}
+            </p>
+          ) : null}
         </div>
+
+        {errors.form ? (
+          <div className="form-alert" id={formNoticeId} role="alert">
+            {errors.form}
+          </div>
+        ) : null}
+
+        {successMessage ? (
+          <div className="form-note" role="status">
+            {successMessage}
+          </div>
+        ) : null}
+
+        <button
+          className="demo-link auth-submit"
+          disabled={!isDirty || isSubmitting}
+          type="submit"
+        >
+          {isSubmitting ? 'Saving...' : 'Save changes'}
+        </button>
 
         <button className="scene-secondary-button settings-reset-button" type="button">
           Reset password
         </button>
-      </div>
+      </form>
     </section>
   )
 }


### PR DESCRIPTION
## Summary

Closes #57

This PR finishes the editable profile save flow on the frontend settings page and aligns the current frontend auth/registration contract with the updated backend user-name model.

Included in this branch:
- connect the settings page save action to `PUT /api/users/me`
- initialize settings fields from persisted `firstName`, `lastName`, and `displayName`
- keep `displayName` editable while preserving it as the public-facing name
- update the shared auth session after a successful profile save
- show backend validation errors and a clear fallback error when profile save requests fail
- persist updated auth-session user details so refreshed app state keeps the saved values
- add/update frontend docs for the settings page flow
- refine the settings action layout so save/reset sit on the same row, right-aligned, with a standard disabled state
- update registration to submit default `firstName` and `lastName` values (`NoName`) so registration still works against the current backend contract

## Behavior

- the settings page shows editable `Email`, `Display name`, `First name`, and `Last name` fields
- `Email` remains read-only
- `Save changes` is disabled until a profile field changes
- successful saves update the shared auth state immediately
- backend validation details are shown inline on the settings form
- failed save requests show a clear form-level error
- scenes/comments and other attribution surfaces continue using `displayName`
- registration now sends `displayName`, `email`, `password`, plus default `firstName`/`lastName` values

## Testing

Ran the full frontend test suite:

- `npm test -- --run`

Result:
- `15` test files passed
- `84` tests passed
