### PR TITLE
69 add configurable initial playback state and hover playpause control to the embedded mage player

### DIFF
--- a/docs/engine-integration.md
+++ b/docs/engine-integration.md
@@ -14,7 +14,7 @@ That keeps engine-specific startup, loading, and disposal logic in one place.
 
 ## Current Integration
 
-The adapter loads the engine dynamically, creates it for a canvas, loads a scene blob, and disposes it on unmount.
+The adapter loads the engine dynamically, creates it for a canvas, loads a scene blob, enables mouse-driven canvas interaction, exposes shared play/pause controls, suppresses the package's built-in control chrome, and disposes it on unmount.
 
 Relevant files:
 
@@ -40,6 +40,8 @@ The adapter is doing more than forwarding calls:
 - it keeps engine imports out of route components
 - it validates scene blobs before loading
 - it applies the current startup workaround for the published engine so scenes do not stall at time `0`
+- it centralizes pause/resume behavior so every embedded `MagePlayer` uses the same playback model
+- it turns on the engine's orbit-style canvas interaction while hiding the package's built-in presets and tweakpane UI
 
 ## Current Caveats
 

--- a/docs/player-component.md
+++ b/docs/player-component.md
@@ -17,6 +17,7 @@
 - `sceneBlob`: `MageSceneBlob | null | undefined`
 - `ariaLabel?`: optional canvas label
 - `className?`: optional wrapper class
+- `initialPlayback?`: `'playing' | 'paused'` starting playback mode for the loaded scene
 - `log?`: optional engine logging flag
 
 Example:
@@ -34,6 +35,7 @@ export function SceneDetail({
       <h1>{scene.name}</h1>
       <MagePlayer
         ariaLabel={`${scene.name} preview`}
+        initialPlayback="playing"
         sceneBlob={scene.sceneData}
       />
     </section>
@@ -60,6 +62,13 @@ Pages should pass the raw `sceneData` object returned by the backend instead of 
 - `sceneBlob={null}` or `undefined` shows the empty state
 - the engine is created once the canvas mounts
 - the current scene is applied when both the player and a valid `sceneBlob` are available
+- the player enables the engine's mouse-driven canvas controls by default so users can drag/orbit the scene
+- `initialPlayback="paused"` freezes the scene on its current frame until the user presses `Play`
+- `initialPlayback="playing"` keeps the scene running and shows a `Pause` control instead
+- when the player is ready, hover or keyboard focus reveals a playback bar at the bottom of the viewport
+- on touch devices the playback bar stays visible so the control is not hover-only
+- the playback button toggles shared pause/resume state without remounting the engine instance
+- the package's built-in tweakpane/preset chrome is suppressed so only the app's player UI is shown
 - invalid scene data produces a recoverable error overlay instead of crashing the page
 - the engine instance is disposed on unmount
 
@@ -68,6 +77,13 @@ Pages should pass the raw `sceneData` object returned by the backend instead of 
 - do not call `initMAGE()` directly from route components
 - keep engine-specific logic inside `src/lib/magePlayerAdapter.ts`
 - if a page swaps scenes, pass the next `sceneBlob` to the same `MagePlayer` instance and let the component reload it
+- use `initialPlayback` from route code instead of building page-specific play/pause overlays
+
+## Current Route Defaults
+
+- `HomePage` starts its hero preview in `playing`
+- `SceneDetailPage` starts the main watch player in `playing`
+- `CreateScenePage` starts the editor preview in `playing`
 
 ## Tests
 

--- a/src/App.css
+++ b/src/App.css
@@ -505,6 +505,81 @@
   height: 100%;
 }
 
+.mage-player__controls {
+  position: absolute;
+  inset: auto 0 0 0;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-start;
+  padding: 44px 18px 18px;
+  border-bottom-left-radius: inherit;
+  border-bottom-right-radius: inherit;
+  background: linear-gradient(
+    180deg,
+    rgba(6, 13, 16, 0),
+    rgba(6, 13, 16, 0.12) 20%,
+    rgba(6, 13, 16, 0.7) 74%,
+    rgba(6, 13, 16, 0.92)
+  );
+  opacity: 0;
+  transform: translateY(14px);
+  pointer-events: none;
+  transition:
+    opacity 180ms ease,
+    transform 180ms ease;
+  z-index: 1;
+}
+
+.mage-player__control-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  padding: 0;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--text);
+  font: inherit;
+  cursor: pointer;
+  transition:
+    background-color 160ms ease,
+    color 160ms ease,
+    transform 160ms ease,
+    border-color 160ms ease;
+}
+
+.mage-player__control-button:hover,
+.mage-player__control-button:focus-visible {
+  background: rgba(99, 240, 214, 0.22);
+  border-color: rgba(99, 240, 214, 0.34);
+  color: var(--accent);
+  outline: none;
+}
+
+.mage-player__control-button:active {
+  transform: translateY(1px);
+}
+
+.mage-player__control-icon {
+  display: inline-flex;
+  width: 1rem;
+  height: 1rem;
+}
+
+.mage-player__control-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.mage-player[data-state="ready"] .mage-player__viewport:hover .mage-player__controls,
+.mage-player[data-state="ready"] .mage-player__viewport:focus-within .mage-player__controls {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
 .mage-player__overlay {
   position: absolute;
   inset: 0;
@@ -968,6 +1043,10 @@
 
 .scene-detail-stage .mage-player__overlay {
   border-radius: inherit;
+}
+
+.scene-detail-stage .mage-player__controls {
+  padding: 48px 20px 20px;
 }
 
 .mage-watch__summary {
@@ -3455,6 +3534,15 @@
     padding: 22px;
   }
 
+  .mage-player__controls {
+    padding: 34px 14px 14px;
+  }
+
+  .mage-player__control-button {
+    width: 44px;
+    height: 44px;
+  }
+
   .scene-detail-description-card,
   .scene-detail-comments-panel {
     padding: 16px;
@@ -3950,4 +4038,18 @@
     grid-template-columns: 1fr;
     gap: 16px;
   }
+}
+
+@media (hover: none), (pointer: coarse) {
+  .mage-player[data-state="ready"] .mage-player__controls {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+}
+
+[data-mage-player-ui-suppressed="true"] {
+  display: none !important;
+  visibility: hidden !important;
+  pointer-events: none !important;
 }

--- a/src/components/MagePlayer.test.tsx
+++ b/src/components/MagePlayer.test.tsx
@@ -1,21 +1,37 @@
 import { render, screen, waitFor } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { MagePlayer } from './MagePlayer'
-import { createMagePlayer, type MagePlayerController } from '../lib/magePlayerAdapter'
+import {
+  createMagePlayer,
+  type MagePlayerController,
+  type MagePlayerPlaybackState,
+} from '../lib/magePlayerAdapter'
 
 vi.mock('../lib/magePlayerAdapter', () => ({
   createMagePlayer: vi.fn(),
 }))
 
 function createController(overrides: Partial<MagePlayerController> = {}): MagePlayerController {
+  let playbackState: MagePlayerPlaybackState = 'playing'
+
   return {
     dispose: vi.fn(),
+    getPlaybackState: vi.fn(() => playbackState),
     loadSceneBlob: vi.fn(),
+    setPlaybackState: vi.fn((nextPlaybackState: MagePlayerPlaybackState) => {
+      playbackState = nextPlaybackState
+      return playbackState
+    }),
     ...overrides,
   }
 }
 
 describe('MagePlayer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('loads a scene blob and disposes the engine on unmount', async () => {
     const controller = createController()
     vi.mocked(createMagePlayer).mockResolvedValue(controller)
@@ -33,9 +49,13 @@ describe('MagePlayer', () => {
     await waitFor(() => {
       expect(createMagePlayer).toHaveBeenCalledTimes(1)
       expect(controller.loadSceneBlob).toHaveBeenCalledWith(sceneBlob)
+      expect(controller.setPlaybackState).toHaveBeenLastCalledWith('playing')
     })
 
     expect(screen.queryByText('Loading scene preview.')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /pause scene playback/i })).toHaveAccessibleName(
+      'Pause scene playback',
+    )
 
     unmount()
 
@@ -70,6 +90,7 @@ describe('MagePlayer', () => {
     await waitFor(() => {
       expect(vi.mocked(createMagePlayer).mock.calls.length).toBe(initialCreateCount)
       expect(controller.loadSceneBlob).toHaveBeenCalledWith(secondSceneBlob)
+      expect(controller.setPlaybackState).toHaveBeenLastCalledWith('playing')
     })
   })
 
@@ -114,5 +135,49 @@ describe('MagePlayer', () => {
     })
 
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('supports a paused initial playback state and toggles playback from the shared control bar', async () => {
+    const controller = createController()
+    vi.mocked(createMagePlayer).mockResolvedValue(controller)
+
+    const user = userEvent.setup()
+    const sceneBlob = {
+      visualizer: {
+        skyboxPreset: 6,
+      },
+    }
+
+    render(<MagePlayer initialPlayback="paused" sceneBlob={sceneBlob} />)
+
+    expect(screen.queryByRole('button', { name: /scene playback/i })).not.toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(controller.loadSceneBlob).toHaveBeenCalledWith(sceneBlob)
+      expect(controller.setPlaybackState).toHaveBeenLastCalledWith('paused')
+    })
+
+    const playbackButton = screen.getByRole('button', { name: /play scene playback/i })
+    expect(playbackButton).toHaveAttribute('aria-pressed', 'false')
+    expect(playbackButton).toHaveAccessibleName('Play scene playback')
+
+    await user.click(playbackButton)
+
+    expect(controller.setPlaybackState).toHaveBeenLastCalledWith('playing')
+    expect(playbackButton).toHaveAttribute('aria-pressed', 'true')
+    expect(playbackButton).toHaveAccessibleName('Pause scene playback')
+    await waitFor(() => {
+      expect(playbackButton).not.toHaveFocus()
+    })
+  })
+
+  it('suppresses playback controls while the player is empty', async () => {
+    const controller = createController()
+    vi.mocked(createMagePlayer).mockResolvedValue(controller)
+
+    render(<MagePlayer sceneBlob={null} />)
+
+    expect(await screen.findByText('No scene selected.')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /scene playback/i })).not.toBeInTheDocument()
   })
 })

--- a/src/components/MagePlayer.tsx
+++ b/src/components/MagePlayer.tsx
@@ -1,11 +1,17 @@
-import { useEffect, useRef, useState } from 'react'
-import { createMagePlayer, type MagePlayerController, type MageSceneBlob } from '../lib/magePlayerAdapter'
+import { useEffect, useRef, useState, type MouseEvent as ReactMouseEvent } from 'react'
+import {
+  createMagePlayer,
+  type MagePlayerController,
+  type MagePlayerPlaybackState,
+  type MageSceneBlob,
+} from '../lib/magePlayerAdapter'
 
 type MagePlayerStatus = 'empty' | 'loading' | 'ready' | 'error'
 
 type MagePlayerProps = {
   ariaLabel?: string
   className?: string
+  initialPlayback?: MagePlayerPlaybackState
   log?: boolean
   sceneBlob: MageSceneBlob | null | undefined
 }
@@ -22,18 +28,37 @@ function readErrorMessage(error: unknown) {
   return 'MAGE could not render this scene.'
 }
 
+function PauseIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24">
+      <path d="M7 5h4v14H7zm6 0h4v14h-4z" fill="currentColor" />
+    </svg>
+  )
+}
+
+function PlayIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24">
+      <path d="M8 5.5v13L18.5 12 8 5.5Z" fill="currentColor" />
+    </svg>
+  )
+}
+
 export function MagePlayer({
   ariaLabel = 'MAGE scene preview',
   className,
+  initialPlayback = 'playing',
   log = false,
   sceneBlob,
 }: MagePlayerProps) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const playerRef = useRef<MagePlayerController | null>(null)
   const latestSceneBlobRef = useRef<MageSceneBlob | null | undefined>(sceneBlob)
+  const requestedPlaybackRef = useRef<MagePlayerPlaybackState>(initialPlayback)
 
   const [loadedSceneBlob, setLoadedSceneBlob] = useState<MageSceneBlob | null>(null)
   const [playerVersion, setPlayerVersion] = useState(0)
+  const [playbackState, setPlaybackState] = useState<MagePlayerPlaybackState>(initialPlayback)
   const [loadError, setLoadError] = useState<{ message: string; sceneBlob: MageSceneBlob } | null>(
     null,
   )
@@ -41,6 +66,19 @@ export function MagePlayer({
   useEffect(() => {
     latestSceneBlobRef.current = sceneBlob
   }, [sceneBlob])
+
+  useEffect(() => {
+    requestedPlaybackRef.current = initialPlayback
+    setPlaybackState(initialPlayback)
+
+    const player = playerRef.current
+
+    if (!player) {
+      return
+    }
+
+    setPlaybackState(player.setPlaybackState(initialPlayback))
+  }, [initialPlayback])
 
   useEffect(() => {
     const canvas = canvasRef.current
@@ -64,6 +102,7 @@ export function MagePlayer({
           }
 
           playerRef.current = nextPlayer
+          setPlaybackState(nextPlayer.setPlaybackState(requestedPlaybackRef.current))
           setPlayerVersion((currentVersion) => currentVersion + 1)
         } catch (error) {
           nextPlayer?.dispose()
@@ -105,6 +144,7 @@ export function MagePlayer({
 
     try {
       player.loadSceneBlob(sceneBlob)
+      const nextPlaybackState = player.setPlaybackState(requestedPlaybackRef.current)
 
       queueMicrotask(() => {
         if (isCancelled) {
@@ -113,6 +153,7 @@ export function MagePlayer({
 
         setLoadError(null)
         setLoadedSceneBlob(sceneBlob)
+        setPlaybackState(nextPlaybackState)
       })
     } catch (error) {
       queueMicrotask(() => {
@@ -154,10 +195,49 @@ export function MagePlayer({
     role = 'alert'
   }
 
+  const playbackLabel = playbackState === 'playing' ? 'Pause' : 'Play'
+
+  function handleTogglePlayback(event: ReactMouseEvent<HTMLButtonElement>) {
+    const player = playerRef.current
+
+    if (!player || status !== 'ready') {
+      return
+    }
+
+    const nextPlaybackState = playbackState === 'playing' ? 'paused' : 'playing'
+    setPlaybackState(player.setPlaybackState(nextPlaybackState))
+
+    // Mouse clicks should not leave the hover bar pinned open via :focus-within.
+    // Keep keyboard-triggered activation focused so keyboard users can continue interacting.
+    if (event.detail > 0) {
+      const controlButton = event.currentTarget
+
+      window.requestAnimationFrame(() => {
+        controlButton.blur()
+      })
+    }
+  }
+
   return (
     <section className={buildClassName('mage-player', className)} data-state={status}>
       <div className="mage-player__viewport" aria-busy={status === 'loading'}>
         <canvas aria-label={ariaLabel} className="mage-player__canvas" ref={canvasRef} />
+        {status === 'ready' ? (
+          <div className="mage-player__controls">
+            <button
+              aria-label={`${playbackLabel} scene playback`}
+              aria-pressed={playbackState === 'playing'}
+              className="mage-player__control-button"
+              onClick={handleTogglePlayback}
+              title={`${playbackLabel} scene playback`}
+              type="button"
+            >
+              <span className="mage-player__control-icon">
+                {playbackState === 'playing' ? <PauseIcon /> : <PlayIcon />}
+              </span>
+            </button>
+          </div>
+        ) : null}
         {status !== 'ready' ? (
           <div className="mage-player__overlay" role={role} aria-live="polite">
             <div className="mage-player__overlay-copy">

--- a/src/lib/magePlayerAdapter.test.ts
+++ b/src/lib/magePlayerAdapter.test.ts
@@ -1,10 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const engineMocks = vi.hoisted(() => ({
+  captureThumbnail: vi.fn(),
   dispose: vi.fn(),
   getEngineTime: vi.fn(),
   initMAGE: vi.fn(),
   loadPreset: vi.fn(),
+  pause: vi.fn(),
+  play: vi.fn(),
   setEngineTime: vi.fn(),
   start: vi.fn(),
 }))
@@ -17,11 +20,15 @@ describe('createMagePlayer', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
+    document.body.innerHTML = ''
 
     engineMocks.initMAGE.mockReturnValue({
+      captureThumbnail: engineMocks.captureThumbnail,
       dispose: engineMocks.dispose,
       getEngineTime: engineMocks.getEngineTime,
       loadPreset: engineMocks.loadPreset,
+      pause: engineMocks.pause,
+      play: engineMocks.play,
       setEngineTime: engineMocks.setEngineTime,
       start: engineMocks.start,
     })
@@ -29,7 +36,7 @@ describe('createMagePlayer', () => {
     engineMocks.loadPreset.mockReturnValue({ visualizer: { shader: 'test' } })
   })
 
-  it('primes engine time and restarts after loading a scene blob', async () => {
+  it('primes engine time and resumes playback after loading a scene blob', async () => {
     const { createMagePlayer } = await import('./magePlayerAdapter')
     const canvas = document.createElement('canvas')
     const sceneBlob = {
@@ -45,7 +52,7 @@ describe('createMagePlayer', () => {
       canvas,
       log: false,
       withControls: {
-        active: false,
+        active: true,
         integrated: false,
       },
     })
@@ -55,7 +62,7 @@ describe('createMagePlayer', () => {
 
     expect(engineMocks.loadPreset).toHaveBeenCalledWith(sceneBlob)
     expect(engineMocks.setEngineTime).toHaveBeenCalledWith(1 / 60)
-    expect(engineMocks.start).toHaveBeenCalledTimes(2)
+    expect(engineMocks.play).toHaveBeenCalledTimes(1)
   })
 
   it('does not reset engine time when it is already past zero', async () => {
@@ -74,6 +81,101 @@ describe('createMagePlayer', () => {
     player.loadSceneBlob(sceneBlob)
 
     expect(engineMocks.setEngineTime).not.toHaveBeenCalled()
-    expect(engineMocks.start).toHaveBeenCalledTimes(2)
+    expect(engineMocks.play).toHaveBeenCalledTimes(1)
+  })
+
+  it('exposes playback state controls for the shared player UI', async () => {
+    const { createMagePlayer } = await import('./magePlayerAdapter')
+    const canvas = document.createElement('canvas')
+
+    const player = await createMagePlayer(canvas)
+
+    expect(player.getPlaybackState()).toBe('playing')
+
+    player.setPlaybackState('paused')
+
+    expect(player.getPlaybackState()).toBe('paused')
+    expect(engineMocks.pause).toHaveBeenCalledTimes(1)
+
+    player.setPlaybackState('playing')
+
+    expect(player.getPlaybackState()).toBe('playing')
+    expect(engineMocks.play).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps a paused scene paused when a new scene blob loads', async () => {
+    const { createMagePlayer } = await import('./magePlayerAdapter')
+    const canvas = document.createElement('canvas')
+    const sceneBlob = {
+      visualizer: {
+        shader: 'test',
+      },
+    }
+
+    const player = await createMagePlayer(canvas)
+
+    engineMocks.pause.mockClear()
+    engineMocks.play.mockClear()
+
+    player.setPlaybackState('paused')
+    player.loadSceneBlob(sceneBlob)
+
+    expect(engineMocks.pause).toHaveBeenCalledTimes(2)
+    expect(engineMocks.play).not.toHaveBeenCalled()
+  })
+
+  it('suppresses the package control chrome when engine controls are enabled', async () => {
+    const { createMagePlayer } = await import('./magePlayerAdapter')
+    const host = document.createElement('div')
+    const canvas = document.createElement('canvas')
+    host.appendChild(canvas)
+    document.body.appendChild(host)
+
+    document.body.insertAdjacentHTML(
+      'beforeend',
+      `
+        <div class="mage-embedded-presets"></div>
+        <div><img alt="controls" /></div>
+      `,
+    )
+
+    let engineInstance: Record<string, unknown> | null = null
+
+    engineMocks.initMAGE.mockImplementation(() => {
+      engineInstance = {
+        captureThumbnail: engineMocks.captureThumbnail,
+        dispose: engineMocks.dispose,
+        getEngineTime: engineMocks.getEngineTime,
+        loadPreset: engineMocks.loadPreset,
+        pause: engineMocks.pause,
+        play: engineMocks.play,
+        setEngineTime: engineMocks.setEngineTime,
+        start: engineMocks.start,
+      }
+
+      return engineInstance
+    })
+
+    const player = await createMagePlayer(canvas)
+
+    expect(engineInstance?.captureThumbnail).toBeUndefined()
+    expect(document.querySelector('.mage-embedded-presets')).toHaveAttribute(
+      'data-mage-player-ui-suppressed',
+      'true',
+    )
+    expect(document.querySelector('img[alt="controls"]')?.parentElement).toHaveAttribute(
+      'data-mage-player-ui-suppressed',
+      'true',
+    )
+
+    const latePaneHost = document.createElement('div')
+    latePaneHost.className = 'mage-pane-host'
+    document.body.appendChild(latePaneHost)
+
+    await Promise.resolve()
+
+    expect(latePaneHost).toHaveAttribute('data-mage-player-ui-suppressed', 'true')
+
+    player.dispose()
   })
 })

--- a/src/lib/magePlayerAdapter.ts
+++ b/src/lib/magePlayerAdapter.ts
@@ -12,14 +12,29 @@ const SCENE_BLOB_KEYS = [
 ] as const
 
 const MIN_RUNNING_ENGINE_TIME = 1 / 60
-const DISABLED_ENGINE_CONTROLS = {
-  active: false,
+const DEFAULT_ENGINE_CONTROLS = {
+  active: true,
   integrated: false,
 } as const
+const SUPPRESSED_ENGINE_UI_ATTRIBUTE = 'data-mage-player-ui-suppressed'
+const SUPPRESSED_ENGINE_UI_SELECTOR = [
+  '.mage-embedded-presets',
+  '.mage-engine-loading-mask',
+  '.mage-fx-layers-overlay',
+  '.mage-fx-studio-overlay',
+  '.mage-fx-studio-dock',
+  '.mage-pane-host',
+  '.mage-scene-camera-dock',
+  '.mage-dock-launcher',
+].join(', ')
+const SUPPRESSED_ENGINE_TOOLTIP_SELECTOR = 'img[alt="controls"]'
 
 type MageEngineBridge = {
+  captureThumbnail?: MAGEEngineAPI['captureThumbnail']
   dispose: MAGEEngineAPI['dispose']
   getEngineTime?: MAGEEngineAPI['getEngineTime']
+  pause: MAGEEngineAPI['pause']
+  play: MAGEEngineAPI['play']
   loadPreset: (scene: unknown) => unknown
   setEngineTime?: (time: number) => boolean
   start: MAGEEngineAPI['start']
@@ -39,9 +54,13 @@ type MageEngineModule = {
 
 export type MageSceneBlob = Record<string, unknown>
 
+export type MagePlayerPlaybackState = 'paused' | 'playing'
+
 export type MagePlayerController = {
   dispose: () => void
+  getPlaybackState: () => MagePlayerPlaybackState
   loadSceneBlob: (sceneBlob: unknown) => void
+  setPlaybackState: (playbackState: MagePlayerPlaybackState) => MagePlayerPlaybackState
 }
 
 export class MagePlayerAdapterError extends Error {}
@@ -78,6 +97,81 @@ function primeEngineTime(engine: MageEngineBridge) {
   }
 }
 
+function applyPlaybackState(
+  engine: MageEngineBridge,
+  playbackState: MagePlayerPlaybackState,
+) {
+  if (playbackState === 'paused') {
+    engine.pause()
+    return playbackState
+  }
+
+  // The published engine can stop immediately when it starts from exactly time 0.
+  // Prime the engine just past zero before resuming so the scene can animate.
+  primeEngineTime(engine)
+  engine.play()
+  return playbackState
+}
+
+function markEngineUiAsSuppressed(element: Element | null | undefined) {
+  if (!(element instanceof HTMLElement)) {
+    return
+  }
+
+  element.setAttribute(SUPPRESSED_ENGINE_UI_ATTRIBUTE, 'true')
+  element.style.display = 'none'
+  element.style.pointerEvents = 'none'
+}
+
+function hideEmbeddedEngineUi(canvas: HTMLCanvasElement) {
+  if (typeof document === 'undefined') {
+    return
+  }
+
+  const host = canvas.parentElement
+
+  host
+    ?.querySelectorAll('.mage-pane-host, .mage-engine-loading-mask')
+    .forEach((element) => {
+      markEngineUiAsSuppressed(element)
+    })
+
+  document.querySelectorAll(SUPPRESSED_ENGINE_UI_SELECTOR).forEach((element) => {
+    markEngineUiAsSuppressed(element)
+  })
+
+  document.querySelectorAll(SUPPRESSED_ENGINE_TOOLTIP_SELECTOR).forEach((image) => {
+    markEngineUiAsSuppressed(image.parentElement)
+  })
+}
+
+function suppressEmbeddedEngineUi(canvas: HTMLCanvasElement, engine: MageEngineBridge) {
+  // Enabling engine controls also boots the package's own preset/tweakpane UI.
+  // Disable its thumbnail bootstrap path and hide the generated chrome so the
+  // shared React player keeps sole ownership of the visible controls.
+  engine.captureThumbnail = undefined
+  hideEmbeddedEngineUi(canvas)
+
+  const observationRoot = document.body ?? document.documentElement
+
+  if (!observationRoot || typeof MutationObserver === 'undefined') {
+    return () => {}
+  }
+
+  const observer = new MutationObserver(() => {
+    hideEmbeddedEngineUi(canvas)
+  })
+
+  observer.observe(observationRoot, {
+    childList: true,
+    subtree: true,
+  })
+
+  return () => {
+    observer.disconnect()
+  }
+}
+
 async function loadMageEngineModule() {
   if (!mageEngineModulePromise) {
     mageEngineModulePromise = (import('@notrac/mage') as Promise<MageEngineModule>).catch((error) => {
@@ -98,12 +192,22 @@ export async function createMagePlayer(
     canvas,
     autoStart: false,
     log: options.log ?? false,
-    withControls: DISABLED_ENGINE_CONTROLS,
+    withControls: DEFAULT_ENGINE_CONTROLS,
   })
+  const stopSuppressingEngineUi = suppressEmbeddedEngineUi(canvas, engine)
 
   engine.start()
+  let playbackState: MagePlayerPlaybackState = 'playing'
+
+  function setPlaybackState(nextPlaybackState: MagePlayerPlaybackState) {
+    playbackState = applyPlaybackState(engine, nextPlaybackState)
+    return playbackState
+  }
 
   return {
+    getPlaybackState() {
+      return playbackState
+    },
     loadSceneBlob(sceneBlob) {
       if (!isMageSceneBlob(sceneBlob)) {
         throw new MagePlayerAdapterError('Scene data is missing required MAGE fields.')
@@ -111,10 +215,7 @@ export async function createMagePlayer(
 
       try {
         loadSceneIntoEngine(engine, sceneBlob)
-        // The published engine can stop immediately when it starts from exactly time 0.
-        // Prime the engine just past zero before restarting so the scene can animate.
-        primeEngineTime(engine)
-        engine.start()
+        setPlaybackState(playbackState)
       } catch (error) {
         if (error instanceof MagePlayerAdapterError) {
           throw error
@@ -123,7 +224,9 @@ export async function createMagePlayer(
         throw new MagePlayerAdapterError('Scene data could not be rendered by the MAGE engine.')
       }
     },
+    setPlaybackState,
     dispose() {
+      stopSuppressingEngineUi()
       engine.dispose()
     },
   }

--- a/src/pages/CreateScenePage.test.tsx
+++ b/src/pages/CreateScenePage.test.tsx
@@ -11,8 +11,16 @@ import { buildApiUrl } from '../lib/api'
 import { CreateScenePage } from './CreateScenePage'
 
 vi.mock('../components/MagePlayer', () => ({
-  MagePlayer: ({ sceneBlob }: { sceneBlob: unknown }) => (
-    <div data-testid="mage-player">{sceneBlob ? 'preview-ready' : 'no-preview'}</div>
+  MagePlayer: ({
+    initialPlayback,
+    sceneBlob,
+  }: {
+    initialPlayback?: string
+    sceneBlob: unknown
+  }) => (
+    <div data-playback={initialPlayback} data-testid="mage-player">
+      {sceneBlob ? 'preview-ready' : 'no-preview'}
+    </div>
   ),
 }))
 
@@ -142,6 +150,7 @@ describe('CreateScenePage', () => {
     expect(screen.queryByLabelText(/scene data json/i)).not.toBeInTheDocument()
     expect(screen.queryByLabelText(/custom shader/i)).not.toBeInTheDocument()
     expect(screen.getByTestId('mage-player')).toHaveTextContent('preview-ready')
+    expect(screen.getByTestId('mage-player')).toHaveAttribute('data-playback', 'playing')
   })
 
   it('renders interactive metadata controls beneath the scene name field', async () => {

--- a/src/pages/CreateScenePage.tsx
+++ b/src/pages/CreateScenePage.tsx
@@ -524,6 +524,37 @@ function validateThumbnailFile(file: File | null) {
   return null;
 }
 
+function buildEffectiveSceneData(
+  sourceSceneData: SceneData,
+  {
+    isCameraAdvancedEnabled,
+    isMotionAdvancedEnabled,
+  }: {
+    isCameraAdvancedEnabled: boolean;
+    isMotionAdvancedEnabled: boolean;
+  },
+) {
+  let nextSceneData = sourceSceneData;
+
+  if (!isCameraAdvancedEnabled) {
+    nextSceneData = mergeSceneEditorBranch(nextSceneData, "intent", {
+      ...getSceneEditorModel(nextSceneData).intent,
+      camOrientationMode: initialSceneModel.intent.camOrientationMode,
+      camOrientationSpeed: initialSceneModel.intent.camOrientationSpeed,
+    });
+  }
+
+  if (!isMotionAdvancedEnabled) {
+    nextSceneData = mergeSceneEditorBranch(
+      nextSceneData,
+      "state",
+      initialSceneModel.state,
+    );
+  }
+
+  return sanitizeSceneData(nextSceneData);
+}
+
 export function CreateScenePage() {
   const { authenticatedFetch } = useAuth();
   const navigate = useNavigate();
@@ -571,31 +602,13 @@ export function CreateScenePage() {
   const thumbnailInputId = useId();
   const titleId = "create-scene-title";
 
-  function buildEffectiveSceneData(sourceSceneData: SceneData) {
-    let nextSceneData = sourceSceneData;
-
-    if (!isCameraAdvancedEnabled) {
-      nextSceneData = mergeSceneEditorBranch(nextSceneData, "intent", {
-        ...getSceneEditorModel(nextSceneData).intent,
-        camOrientationMode: initialSceneModel.intent.camOrientationMode,
-        camOrientationSpeed: initialSceneModel.intent.camOrientationSpeed,
-      });
-    }
-
-    if (!isMotionAdvancedEnabled) {
-      nextSceneData = mergeSceneEditorBranch(
-        nextSceneData,
-        "state",
-        initialSceneModel.state,
-      );
-    }
-
-    return sanitizeSceneData(nextSceneData);
-  }
-
   const sceneModel = useMemo(() => getSceneEditorModel(sceneData), [sceneData]);
   const previewSceneData = useMemo(
-    () => buildEffectiveSceneData(sceneData),
+    () =>
+      buildEffectiveSceneData(sceneData, {
+        isCameraAdvancedEnabled,
+        isMotionAdvancedEnabled,
+      }),
     [sceneData, isCameraAdvancedEnabled, isMotionAdvancedEnabled],
   );
   const shaderSelection = useMemo(
@@ -930,7 +943,12 @@ export function CreateScenePage() {
   function handleFormatJson() {
     try {
       const parsedSceneData = parseSceneDataJson(sceneDataText);
-      applySceneData(buildEffectiveSceneData(parsedSceneData));
+      applySceneData(
+        buildEffectiveSceneData(parsedSceneData, {
+          isCameraAdvancedEnabled,
+          isMotionAdvancedEnabled,
+        }),
+      );
     } catch (error) {
       setErrors((currentErrors) => ({
         ...currentErrors,
@@ -1747,9 +1765,10 @@ export function CreateScenePage() {
       return;
     }
 
-    const sanitizedSceneData = buildEffectiveSceneData(
-      parsedSceneData ?? sceneData,
-    );
+    const sanitizedSceneData = buildEffectiveSceneData(parsedSceneData ?? sceneData, {
+      isCameraAdvancedEnabled,
+      isMotionAdvancedEnabled,
+    });
 
     setIsSubmitting(true);
     setErrors({});
@@ -2906,6 +2925,7 @@ export function CreateScenePage() {
 
               <MagePlayer
                 className="scene-editor-preview__player"
+                initialPlayback="playing"
                 sceneBlob={previewSceneData}
               />
             </section>

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -25,7 +25,9 @@ vi.mock('../auth/AuthContext', () => ({
 }))
 
 vi.mock('../components/MagePlayer', () => ({
-  MagePlayer: () => <div>Preview player</div>,
+  MagePlayer: ({ initialPlayback }: { initialPlayback?: string }) => (
+    <div data-playback={initialPlayback}>Preview player</div>
+  ),
 }))
 
 vi.mock('./ScenesPage', () => ({
@@ -50,7 +52,7 @@ describe('HomePage', () => {
     render(<HomePage />)
 
     expect(screen.getByRole('heading', { name: 'MAGE' })).toBeInTheDocument()
-    expect(screen.getByText('Preview player')).toBeInTheDocument()
+    expect(screen.getByText('Preview player')).toHaveAttribute('data-playback', 'playing')
     expect(screen.queryByRole('link', { name: /browse scenes/i })).not.toBeInTheDocument()
     expect(screen.queryByRole('link', { name: /create an account/i })).not.toBeInTheDocument()
   })

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -68,6 +68,7 @@ export function HomePage() {
       <section className="home-preview-section" aria-label="Live scene preview">
         <MagePlayer
           ariaLabel="MAGE live scene preview"
+          initialPlayback="playing"
           sceneBlob={HOME_PAGE_SCENE}
         />
       </section>

--- a/src/pages/SceneDetailPage.test.tsx
+++ b/src/pages/SceneDetailPage.test.tsx
@@ -16,13 +16,20 @@ vi.mock('../components/MagePlayer', () => ({
   MagePlayer: ({
     ariaLabel,
     className,
+    initialPlayback,
     sceneBlob,
   }: {
     ariaLabel?: string
     className?: string
+    initialPlayback?: string
     sceneBlob: unknown
   }) => (
-    <div aria-label={ariaLabel} className={className} data-testid="mage-player">
+    <div
+      aria-label={ariaLabel}
+      className={className}
+      data-playback={initialPlayback}
+      data-testid="mage-player"
+    >
       {sceneBlob ? 'player-ready' : 'no-scene'}
     </div>
   ),
@@ -171,6 +178,7 @@ describe('SceneDetailPage', () => {
 
     expect(await screen.findByRole('heading', { name: /aurora drift/i })).toBeInTheDocument()
     expect(screen.getByTestId('mage-player')).toHaveTextContent('player-ready')
+    expect(screen.getByTestId('mage-player')).toHaveAttribute('data-playback', 'playing')
     expect(screen.getByRole('heading', { name: /comments/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /upvote 416/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /^show$/i })).toBeInTheDocument()

--- a/src/pages/SceneDetailPage.tsx
+++ b/src/pages/SceneDetailPage.tsx
@@ -225,6 +225,7 @@ export function SceneDetailPage() {
               <MagePlayer
                 ariaLabel={`${scene.name} live render`}
                 className="scene-detail-player"
+                initialPlayback="playing"
                 sceneBlob={scene.sceneData}
               />
             </div>


### PR DESCRIPTION
## Summary

Closes #69

This PR extends the shared embedded `MagePlayer` so routes can choose the initial playback state and users can pause/resume scenes from a shared hover control bar instead of page-specific UI.

It also enables the engine's mouse-driven canvas interaction by default, while suppressing the engine package's built-in control chrome so the app keeps a single consistent player UI.

## What Changed

- added `initialPlayback` support to the shared `MagePlayer` component
- added shared play/pause state management in the player adapter
- added a bottom playback bar that appears on hover/focus and contains the play/pause button
- kept the control accessible for keyboard users and visible on touch devices
- enabled the engine's mouse/canvas interaction by default for embedded players
- suppressed engine-native presets/tweakpane overlays when those controls are enabled
- updated page integrations to pass the intended startup behavior:
  - `HomePage` starts playing
  - `SceneDetailPage` starts playing
  - `CreateScenePage` preview starts playing
- updated player and engine integration docs for the new playback model

## Behavior

- embedded players can start either `playing` or `paused`
- play/pause toggles without remounting the engine
- loading, empty, and error overlays still suppress the playback control when appropriate
- touch users can still access the control without relying on hover
- the engine preview remains interactive with the mouse, but only the app's custom playback UI is shown

## Refactor Notes

- kept playback behavior centralized in `MagePlayer` and `magePlayerAdapter` instead of route-level logic
- consolidated create-scene preview/format/submit scene sanitization through one shared helper path

## Testing

Ran:

- `npm test -- --run`

Result:

- `15` test files passed
- `89` tests passed
