### PR TITLE
Fix MagePlayer adapter test typing for build

### DIFF
--- a/src/lib/magePlayerAdapter.test.ts
+++ b/src/lib/magePlayerAdapter.test.ts
@@ -16,6 +16,17 @@ vi.mock('@notrac/mage', () => ({
   initMAGE: engineMocks.initMAGE,
 }))
 
+type EngineInstance = {
+  captureThumbnail?: unknown
+  dispose: typeof engineMocks.dispose
+  getEngineTime: typeof engineMocks.getEngineTime
+  loadPreset: typeof engineMocks.loadPreset
+  pause: typeof engineMocks.pause
+  play: typeof engineMocks.play
+  setEngineTime: typeof engineMocks.setEngineTime
+  start: typeof engineMocks.start
+}
+
 describe('createMagePlayer', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -139,26 +150,22 @@ describe('createMagePlayer', () => {
       `,
     )
 
-    let engineInstance: Record<string, unknown> | null = null
+    const engineInstance: EngineInstance = {
+      captureThumbnail: engineMocks.captureThumbnail,
+      dispose: engineMocks.dispose,
+      getEngineTime: engineMocks.getEngineTime,
+      loadPreset: engineMocks.loadPreset,
+      pause: engineMocks.pause,
+      play: engineMocks.play,
+      setEngineTime: engineMocks.setEngineTime,
+      start: engineMocks.start,
+    }
 
-    engineMocks.initMAGE.mockImplementation(() => {
-      engineInstance = {
-        captureThumbnail: engineMocks.captureThumbnail,
-        dispose: engineMocks.dispose,
-        getEngineTime: engineMocks.getEngineTime,
-        loadPreset: engineMocks.loadPreset,
-        pause: engineMocks.pause,
-        play: engineMocks.play,
-        setEngineTime: engineMocks.setEngineTime,
-        start: engineMocks.start,
-      }
-
-      return engineInstance
-    })
+    engineMocks.initMAGE.mockReturnValue(engineInstance)
 
     const player = await createMagePlayer(canvas)
 
-    expect(engineInstance?.captureThumbnail).toBeUndefined()
+    expect(engineInstance.captureThumbnail).toBeUndefined()
     expect(document.querySelector('.mage-embedded-presets')).toHaveAttribute(
       'data-mage-player-ui-suppressed',
       'true',


### PR DESCRIPTION
## Summary

Fixes the frontend production build failure introduced after merging #74.

This PR updates the `magePlayerAdapter` test typing so the repository passes the TypeScript compile step used by `npm run build` and Docker deploys.

## What Changed

- replaced the nullable `engineInstance` reassignment pattern in `src/lib/magePlayerAdapter.test.ts`
- introduced an explicit typed mock engine instance for the UI suppression test
- kept the test coverage and runtime behavior the same while making the test compatible with strict TypeScript compilation

## Why

The previous test passed in Vitest, but failed during the production build because `tsc -b` type-checks files under `src`, including test files. TypeScript could not safely narrow the reassigned `engineInstance` value and treated the later `captureThumbnail` access as invalid.

## Testing

Ran:

- `npm run build`
- `npm run lint`
- `npm test -- --run src/lib/magePlayerAdapter.test.ts`

## Result

- production build succeeds again
- no runtime application code changed
- fix is isolated to the failing test file
