### PR TITLE
Fix/mage player disable engine controls

### DIFF
--- a/docs/engine-integration.md
+++ b/docs/engine-integration.md
@@ -14,7 +14,7 @@ That keeps engine-specific startup, loading, and disposal logic in one place.
 
 ## Current Integration
 
-The adapter loads the engine dynamically, creates it for a canvas, loads a scene blob, enables mouse-driven canvas interaction, exposes shared play/pause controls, suppresses the package's built-in control chrome, and disposes it on unmount.
+The adapter loads the engine dynamically, creates it for a canvas, loads a scene blob, exposes shared play/pause controls, and disposes it on unmount.
 
 Relevant files:
 
@@ -41,10 +41,11 @@ The adapter is doing more than forwarding calls:
 - it validates scene blobs before loading
 - it applies the current startup workaround for the published engine so scenes do not stall at time `0`
 - it centralizes pause/resume behavior so every embedded `MagePlayer` uses the same playback model
-- it turns on the engine's orbit-style canvas interaction while hiding the package's built-in presets and tweakpane UI
+- it keeps the package's native control system disabled because the published engine currently couples that path to unstable UI/bootstrap behavior
 
 ## Current Caveats
 
 - The published package types are still incomplete for the runtime behavior the frontend uses. The adapter keeps a small local bridge type for that gap.
 - The engine bundle still emits `eval` warnings during `vite build`. The build succeeds, but those warnings are coming from the published package.
 - The engine bundle is very large and still triggers Vite chunk-size warnings. That does not block builds, but it is a real startup-cost concern.
+- Mouse-driven engine orbit controls are intentionally disabled for now. The last attempt to enable them by default triggered engine-owned UI/bootstrap paths that broke runtime playback in the published package.

--- a/docs/engine-integration.md
+++ b/docs/engine-integration.md
@@ -14,7 +14,7 @@ That keeps engine-specific startup, loading, and disposal logic in one place.
 
 ## Current Integration
 
-The adapter loads the engine dynamically, creates it for a canvas, loads a scene blob, exposes shared play/pause controls, and disposes it on unmount.
+The adapter loads the engine dynamically, creates it for a canvas, loads a scene blob, leaves the package's native control system enabled, exposes shared play/pause controls, and disposes it on unmount.
 
 Relevant files:
 
@@ -41,11 +41,11 @@ The adapter is doing more than forwarding calls:
 - it validates scene blobs before loading
 - it applies the current startup workaround for the published engine so scenes do not stall at time `0`
 - it centralizes pause/resume behavior so every embedded `MagePlayer` uses the same playback model
-- it keeps the package's native control system disabled because the published engine currently couples that path to unstable UI/bootstrap behavior
+- it relies on the package's built-in control bootstrap for mouse-driven camera interaction
 
 ## Current Caveats
 
 - The published package types are still incomplete for the runtime behavior the frontend uses. The adapter keeps a small local bridge type for that gap.
 - The engine bundle still emits `eval` warnings during `vite build`. The build succeeds, but those warnings are coming from the published package.
 - The engine bundle is very large and still triggers Vite chunk-size warnings. That does not block builds, but it is a real startup-cost concern.
-- Mouse-driven engine orbit controls are intentionally disabled for now. The last attempt to enable them by default triggered engine-owned UI/bootstrap paths that broke runtime playback in the published package.
+- Enabling mouse-driven controls also means the published package may render its own control chrome alongside the app's custom playback bar.

--- a/docs/player-component.md
+++ b/docs/player-component.md
@@ -62,13 +62,12 @@ Pages should pass the raw `sceneData` object returned by the backend instead of 
 - `sceneBlob={null}` or `undefined` shows the empty state
 - the engine is created once the canvas mounts
 - the current scene is applied when both the player and a valid `sceneBlob` are available
-- the player enables the engine's mouse-driven canvas controls by default so users can drag/orbit the scene
 - `initialPlayback="paused"` freezes the scene on its current frame until the user presses `Play`
 - `initialPlayback="playing"` keeps the scene running and shows a `Pause` control instead
 - when the player is ready, hover or keyboard focus reveals a playback bar at the bottom of the viewport
 - on touch devices the playback bar stays visible so the control is not hover-only
 - the playback button toggles shared pause/resume state without remounting the engine instance
-- the package's built-in tweakpane/preset chrome is suppressed so only the app's player UI is shown
+- native engine orbit/tweakpane controls are currently disabled while the published package's control bootstrap remains unstable
 - invalid scene data produces a recoverable error overlay instead of crashing the page
 - the engine instance is disposed on unmount
 

--- a/docs/player-component.md
+++ b/docs/player-component.md
@@ -62,12 +62,13 @@ Pages should pass the raw `sceneData` object returned by the backend instead of 
 - `sceneBlob={null}` or `undefined` shows the empty state
 - the engine is created once the canvas mounts
 - the current scene is applied when both the player and a valid `sceneBlob` are available
+- the package's native engine controls are enabled, so mouse-driven camera interaction comes from the engine
 - `initialPlayback="paused"` freezes the scene on its current frame until the user presses `Play`
 - `initialPlayback="playing"` keeps the scene running and shows a `Pause` control instead
 - when the player is ready, hover or keyboard focus reveals a playback bar at the bottom of the viewport
 - on touch devices the playback bar stays visible so the control is not hover-only
 - the playback button toggles shared pause/resume state without remounting the engine instance
-- native engine orbit/tweakpane controls are currently disabled while the published package's control bootstrap remains unstable
+- native engine UI may appear in addition to the app's custom playback bar while this mode is enabled
 - invalid scene data produces a recoverable error overlay instead of crashing the page
 - the engine instance is disposed on unmount
 

--- a/src/App.css
+++ b/src/App.css
@@ -4047,9 +4047,3 @@
     pointer-events: auto;
   }
 }
-
-[data-mage-player-ui-suppressed="true"] {
-  display: none !important;
-  visibility: hidden !important;
-  pointer-events: none !important;
-}

--- a/src/lib/magePlayerAdapter.test.ts
+++ b/src/lib/magePlayerAdapter.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const engineMocks = vi.hoisted(() => ({
-  captureThumbnail: vi.fn(),
   dispose: vi.fn(),
   getEngineTime: vi.fn(),
   initMAGE: vi.fn(),
@@ -16,17 +15,6 @@ vi.mock('@notrac/mage', () => ({
   initMAGE: engineMocks.initMAGE,
 }))
 
-type EngineInstance = {
-  captureThumbnail?: unknown
-  dispose: typeof engineMocks.dispose
-  getEngineTime: typeof engineMocks.getEngineTime
-  loadPreset: typeof engineMocks.loadPreset
-  pause: typeof engineMocks.pause
-  play: typeof engineMocks.play
-  setEngineTime: typeof engineMocks.setEngineTime
-  start: typeof engineMocks.start
-}
-
 describe('createMagePlayer', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -34,7 +22,6 @@ describe('createMagePlayer', () => {
     document.body.innerHTML = ''
 
     engineMocks.initMAGE.mockReturnValue({
-      captureThumbnail: engineMocks.captureThumbnail,
       dispose: engineMocks.dispose,
       getEngineTime: engineMocks.getEngineTime,
       loadPreset: engineMocks.loadPreset,
@@ -63,7 +50,7 @@ describe('createMagePlayer', () => {
       canvas,
       log: false,
       withControls: {
-        active: true,
+        active: false,
         integrated: false,
       },
     })
@@ -135,53 +122,21 @@ describe('createMagePlayer', () => {
     expect(engineMocks.play).not.toHaveBeenCalled()
   })
 
-  it('suppresses the package control chrome when engine controls are enabled', async () => {
+  it('keeps native engine controls disabled so the shared player owns playback chrome', async () => {
     const { createMagePlayer } = await import('./magePlayerAdapter')
-    const host = document.createElement('div')
     const canvas = document.createElement('canvas')
-    host.appendChild(canvas)
-    document.body.appendChild(host)
-
-    document.body.insertAdjacentHTML(
-      'beforeend',
-      `
-        <div class="mage-embedded-presets"></div>
-        <div><img alt="controls" /></div>
-      `,
-    )
-
-    const engineInstance: EngineInstance = {
-      captureThumbnail: engineMocks.captureThumbnail,
-      dispose: engineMocks.dispose,
-      getEngineTime: engineMocks.getEngineTime,
-      loadPreset: engineMocks.loadPreset,
-      pause: engineMocks.pause,
-      play: engineMocks.play,
-      setEngineTime: engineMocks.setEngineTime,
-      start: engineMocks.start,
-    }
-
-    engineMocks.initMAGE.mockReturnValue(engineInstance)
 
     const player = await createMagePlayer(canvas)
 
-    expect(engineInstance.captureThumbnail).toBeUndefined()
-    expect(document.querySelector('.mage-embedded-presets')).toHaveAttribute(
-      'data-mage-player-ui-suppressed',
-      'true',
-    )
-    expect(document.querySelector('img[alt="controls"]')?.parentElement).toHaveAttribute(
-      'data-mage-player-ui-suppressed',
-      'true',
-    )
-
-    const latePaneHost = document.createElement('div')
-    latePaneHost.className = 'mage-pane-host'
-    document.body.appendChild(latePaneHost)
-
-    await Promise.resolve()
-
-    expect(latePaneHost).toHaveAttribute('data-mage-player-ui-suppressed', 'true')
+    expect(engineMocks.initMAGE).toHaveBeenLastCalledWith({
+      autoStart: false,
+      canvas,
+      log: false,
+      withControls: {
+        active: false,
+        integrated: false,
+      },
+    })
 
     player.dispose()
   })

--- a/src/lib/magePlayerAdapter.test.ts
+++ b/src/lib/magePlayerAdapter.test.ts
@@ -50,7 +50,7 @@ describe('createMagePlayer', () => {
       canvas,
       log: false,
       withControls: {
-        active: false,
+        active: true,
         integrated: false,
       },
     })
@@ -122,7 +122,7 @@ describe('createMagePlayer', () => {
     expect(engineMocks.play).not.toHaveBeenCalled()
   })
 
-  it('keeps native engine controls disabled so the shared player owns playback chrome', async () => {
+  it('enables native engine controls alongside the shared playback chrome', async () => {
     const { createMagePlayer } = await import('./magePlayerAdapter')
     const canvas = document.createElement('canvas')
 
@@ -133,7 +133,7 @@ describe('createMagePlayer', () => {
       canvas,
       log: false,
       withControls: {
-        active: false,
+        active: true,
         integrated: false,
       },
     })

--- a/src/lib/magePlayerAdapter.ts
+++ b/src/lib/magePlayerAdapter.ts
@@ -13,24 +13,11 @@ const SCENE_BLOB_KEYS = [
 
 const MIN_RUNNING_ENGINE_TIME = 1 / 60
 const DEFAULT_ENGINE_CONTROLS = {
-  active: true,
+  active: false,
   integrated: false,
 } as const
-const SUPPRESSED_ENGINE_UI_ATTRIBUTE = 'data-mage-player-ui-suppressed'
-const SUPPRESSED_ENGINE_UI_SELECTOR = [
-  '.mage-embedded-presets',
-  '.mage-engine-loading-mask',
-  '.mage-fx-layers-overlay',
-  '.mage-fx-studio-overlay',
-  '.mage-fx-studio-dock',
-  '.mage-pane-host',
-  '.mage-scene-camera-dock',
-  '.mage-dock-launcher',
-].join(', ')
-const SUPPRESSED_ENGINE_TOOLTIP_SELECTOR = 'img[alt="controls"]'
 
 type MageEngineBridge = {
-  captureThumbnail?: MAGEEngineAPI['captureThumbnail']
   dispose: MAGEEngineAPI['dispose']
   getEngineTime?: MAGEEngineAPI['getEngineTime']
   pause: MAGEEngineAPI['pause']
@@ -113,65 +100,6 @@ function applyPlaybackState(
   return playbackState
 }
 
-function markEngineUiAsSuppressed(element: Element | null | undefined) {
-  if (!(element instanceof HTMLElement)) {
-    return
-  }
-
-  element.setAttribute(SUPPRESSED_ENGINE_UI_ATTRIBUTE, 'true')
-  element.style.display = 'none'
-  element.style.pointerEvents = 'none'
-}
-
-function hideEmbeddedEngineUi(canvas: HTMLCanvasElement) {
-  if (typeof document === 'undefined') {
-    return
-  }
-
-  const host = canvas.parentElement
-
-  host
-    ?.querySelectorAll('.mage-pane-host, .mage-engine-loading-mask')
-    .forEach((element) => {
-      markEngineUiAsSuppressed(element)
-    })
-
-  document.querySelectorAll(SUPPRESSED_ENGINE_UI_SELECTOR).forEach((element) => {
-    markEngineUiAsSuppressed(element)
-  })
-
-  document.querySelectorAll(SUPPRESSED_ENGINE_TOOLTIP_SELECTOR).forEach((image) => {
-    markEngineUiAsSuppressed(image.parentElement)
-  })
-}
-
-function suppressEmbeddedEngineUi(canvas: HTMLCanvasElement, engine: MageEngineBridge) {
-  // Enabling engine controls also boots the package's own preset/tweakpane UI.
-  // Disable its thumbnail bootstrap path and hide the generated chrome so the
-  // shared React player keeps sole ownership of the visible controls.
-  engine.captureThumbnail = undefined
-  hideEmbeddedEngineUi(canvas)
-
-  const observationRoot = document.body ?? document.documentElement
-
-  if (!observationRoot || typeof MutationObserver === 'undefined') {
-    return () => {}
-  }
-
-  const observer = new MutationObserver(() => {
-    hideEmbeddedEngineUi(canvas)
-  })
-
-  observer.observe(observationRoot, {
-    childList: true,
-    subtree: true,
-  })
-
-  return () => {
-    observer.disconnect()
-  }
-}
-
 async function loadMageEngineModule() {
   if (!mageEngineModulePromise) {
     mageEngineModulePromise = (import('@notrac/mage') as Promise<MageEngineModule>).catch((error) => {
@@ -194,7 +122,6 @@ export async function createMagePlayer(
     log: options.log ?? false,
     withControls: DEFAULT_ENGINE_CONTROLS,
   })
-  const stopSuppressingEngineUi = suppressEmbeddedEngineUi(canvas, engine)
 
   engine.start()
   let playbackState: MagePlayerPlaybackState = 'playing'
@@ -226,7 +153,6 @@ export async function createMagePlayer(
     },
     setPlaybackState,
     dispose() {
-      stopSuppressingEngineUi()
       engine.dispose()
     },
   }

--- a/src/lib/magePlayerAdapter.ts
+++ b/src/lib/magePlayerAdapter.ts
@@ -13,7 +13,7 @@ const SCENE_BLOB_KEYS = [
 
 const MIN_RUNNING_ENGINE_TIME = 1 / 60
 const DEFAULT_ENGINE_CONTROLS = {
-  active: false,
+  active: true,
   integrated: false,
 } as const
 


### PR DESCRIPTION
## Summary

This PR enables the published `@notrac/mage` native control path again for embedded players so users can manipulate the canvas with the mouse.

It removes the frontend-side suppression workaround that was hiding engine-owned control UI and instead lets the package manage its own control bootstrap while the shared React play/pause bar remains available.

## What Changed

- re-enabled native engine controls in `magePlayerAdapter`
- kept the shared React play/pause playback state and bottom control bar
- removed the adapter test expectations that assumed native controls were disabled
- updated player and engine-integration docs to match the restored control behavior
- removed the CSS-based engine UI suppression that is no longer used

## Behavior

- embedded players now initialize `@notrac/mage` with native controls enabled
- users should be able to manipulate the scene with the mouse through the engine’s control system
- the app’s custom play/pause control remains in place
- engine-native UI may appear alongside the custom playback bar while this mode is enabled

## Testing

Ran:

- `npm run build`
- `npm run lint`
- `npm test -- --run`

## Notes

This branch is based on the latest `main` at commit `4385d6c`.
