### PR TITLE
Disable native MAGE controls in embedded player

### DIFF
--- a/docs/engine-integration.md
+++ b/docs/engine-integration.md
@@ -41,7 +41,7 @@ The adapter is doing more than forwarding calls:
 - it validates scene blobs before loading
 - it applies the current startup workaround for the published engine so scenes do not stall at time `0`
 - it centralizes pause/resume behavior so every embedded `MagePlayer` uses the same playback model
-- it relies on the package's built-in control bootstrap for mouse-driven camera interaction
+- it starts the engine without the package's built-in controls bootstrap, so embedded player UI stays frontend-owned
 
 ## Current Caveats
 

--- a/docs/player-component.md
+++ b/docs/player-component.md
@@ -62,13 +62,13 @@ Pages should pass the raw `sceneData` object returned by the backend instead of 
 - `sceneBlob={null}` or `undefined` shows the empty state
 - the engine is created once the canvas mounts
 - the current scene is applied when both the player and a valid `sceneBlob` are available
-- the package's native engine controls are enabled, so mouse-driven camera interaction comes from the engine
+- the package's native engine controls are disabled, so the engine's built-in controls UI does not appear
 - `initialPlayback="paused"` freezes the scene on its current frame until the user presses `Play`
 - `initialPlayback="playing"` keeps the scene running and shows a `Pause` control instead
 - when the player is ready, hover or keyboard focus reveals a playback bar at the bottom of the viewport
 - on touch devices the playback bar stays visible so the control is not hover-only
 - the playback button toggles shared pause/resume state without remounting the engine instance
-- native engine UI may appear in addition to the app's custom playback bar while this mode is enabled
+- the app's custom playback bar is the only player UI shown by default
 - invalid scene data produces a recoverable error overlay instead of crashing the page
 - the engine instance is disposed on unmount
 

--- a/src/lib/magePlayerAdapter.test.ts
+++ b/src/lib/magePlayerAdapter.test.ts
@@ -50,7 +50,7 @@ describe('createMagePlayer', () => {
       canvas,
       log: false,
       withControls: {
-        active: true,
+        active: false,
         integrated: false,
       },
     })
@@ -122,7 +122,7 @@ describe('createMagePlayer', () => {
     expect(engineMocks.play).not.toHaveBeenCalled()
   })
 
-  it('enables native engine controls alongside the shared playback chrome', async () => {
+  it('disables native engine controls so only shared playback chrome is shown', async () => {
     const { createMagePlayer } = await import('./magePlayerAdapter')
     const canvas = document.createElement('canvas')
 
@@ -133,7 +133,7 @@ describe('createMagePlayer', () => {
       canvas,
       log: false,
       withControls: {
-        active: true,
+        active: false,
         integrated: false,
       },
     })

--- a/src/lib/magePlayerAdapter.ts
+++ b/src/lib/magePlayerAdapter.ts
@@ -13,7 +13,7 @@ const SCENE_BLOB_KEYS = [
 
 const MIN_RUNNING_ENGINE_TIME = 1 / 60
 const DEFAULT_ENGINE_CONTROLS = {
-  active: true,
+  active: false,
   integrated: false,
 } as const
 


### PR DESCRIPTION
## Summary

This PR disables the native `@notrac/mage` controls bootstrap for embedded players so the engine's built-in UI no longer appears in the frontend player surfaces.

The shared React playback bar remains intact, but the frontend no longer initializes the engine with native controls enabled.

## What Changed

- changed the shared player adapter to initialize `@notrac/mage` with controls disabled
- updated adapter tests to assert that native controls are off
- updated player and engine integration docs to reflect that embedded player UI is frontend-owned

## Behavior

- embedded players no longer show the engine's built-in controls UI
- the shared frontend play/pause controls continue to work as before
- this change only affects the native engine controls bootstrap used by the shared player adapter

## Testing

Ran:

- `npm test -- --run src/lib/magePlayerAdapter.test.ts`
- `npm run build`
