### PR TITLE
Fix/bundled scene preview compat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "mage-frontend",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@notrac/mage": "^1.0.1",
         "react": "^19.2.0",
@@ -27,6 +28,7 @@
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
         "jsdom": "^29.0.1",
+        "patch-package": "^8.0.1",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
         "vite": "^7.3.1",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "prebuild": "patch-package",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "postinstall": "patch-package",
     "test": "vitest run",
     "preview": "vite preview"
   },
@@ -34,6 +36,7 @@
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
     "jsdom": "^29.0.1",
+    "patch-package": "^8.0.1",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
     "vite": "^7.3.1",

--- a/patches/@notrac+mage+1.0.1.patch
+++ b/patches/@notrac+mage+1.0.1.patch
@@ -1,0 +1,21 @@
+diff --git a/node_modules/@notrac/mage/dist/mage-engine.js b/node_modules/@notrac/mage/dist/mage-engine.js
+index 13dcc32..3331322 100644
+--- a/node_modules/@notrac/mage/dist/mage-engine.js
++++ b/node_modules/@notrac/mage/dist/mage-engine.js
+@@ -71848,6 +71848,7 @@ var require_shader_park_core_umd = /* @__PURE__ */ __commonJSMin(((exports, modu
+ 				rotateX,
+ 				rotateY,
+ 				rotateZ,
++				setStepSize,
+ 				mirrorX,
+ 				mirrorY,
+ 				mirrorZ,
+@@ -71879,6 +71880,8 @@ var require_shader_park_core_umd = /* @__PURE__ */ __commonJSMin(((exports, modu
+ 				extrude2D,
+ 				getSpherical,
+ 				mirrorN,
++				torus,
++				cylinder,
+ 				grid,
+ 				repeatLinear,
+ 				repeatRadial,

--- a/src/lib/embeddedShaderScenes.ts
+++ b/src/lib/embeddedShaderScenes.ts
@@ -34,6 +34,8 @@ export const EMBEDDED_SHADER_SCENES: ShaderSceneOption[] = [
     description: 'Bundled engine scene built from stacked grids and box frames.',
     shader: `
       setMaxIterations(101);
+      setStepSize(0.7260629659452175);
+
       let size = input();
       let pointerDown = input();
       time *= .1;
@@ -74,6 +76,8 @@ export const EMBEDDED_SHADER_SCENES: ShaderSceneOption[] = [
     description: 'Bundled engine scene with noisy box frames and layered grid distortion.',
     shader: `
       setMaxIterations(133);
+      setStepSize(0.8632297724861512);
+
       let size = input();
       let pointerDown = input();
       time *= 0.131579219319508;
@@ -119,6 +123,8 @@ export const EMBEDDED_SHADER_SCENES: ShaderSceneOption[] = [
     description: 'Bundled engine scene with twin box frames and green edge-lit motion.',
     shader: `
       setMaxIterations(71);
+      setStepSize(0.4414923770441956);
+
       let size = input();
       let pointerDown = input();
       time *= .1;
@@ -154,6 +160,8 @@ export const EMBEDDED_SHADER_SCENES: ShaderSceneOption[] = [
     description: 'Bundled engine scene with framed cylinders, a noisy core sphere, and a grid floor.',
     shader: `
       setMaxIterations(161);
+      setStepSize(0.7431197197400152);
+
       let size = input();
       let pointerDown = input();
       time *= 0.15934458017140202;
@@ -197,6 +205,8 @@ export const EMBEDDED_SHADER_SCENES: ShaderSceneOption[] = [
     description: 'Bundled engine scene combining a metallic cylinder shell with a central sphere.',
     shader: `
       setMaxIterations(56);
+      setStepSize(0.04586632133333666);
+
       let size = input();
       let pointerDown = input();
       time *= .1;
@@ -229,6 +239,8 @@ export const EMBEDDED_SHADER_SCENES: ShaderSceneOption[] = [
     description: 'Bundled engine scene with a dominant sphere, cylinder, and dense grid accent.',
     shader: `
       setMaxIterations(198);
+      setStepSize(0.8838993805155669);
+
       let size = input();
       let pointerDown = input();
       time *= .1;
@@ -266,6 +278,8 @@ export const EMBEDDED_SHADER_SCENES: ShaderSceneOption[] = [
     description: 'Bundled engine scene with layered grids and a saturated violet sphere.',
     shader: `
       setMaxIterations(193);
+      setStepSize(0.7999169963821687);
+
       let size = input();
       let pointerDown = input();
       time *= .1;
@@ -304,6 +318,8 @@ export const EMBEDDED_SHADER_SCENES: ShaderSceneOption[] = [
     description: 'Bundled engine scene with a torus frame, noisy grids, and a bright center sphere.',
     shader: `
       setMaxIterations(186);
+      setStepSize(0.8615043142034936);
+
       let size = input();
       let pointerDown = input();
       time *= .1;
@@ -350,6 +366,8 @@ export const EMBEDDED_SHADER_SCENES: ShaderSceneOption[] = [
     description: 'Bundled engine scene with orange framing and a tight supporting grid.',
     shader: `
       setMaxIterations(56);
+      setStepSize(0.7549446257595138);
+
       let size = input();
       let pointerDown = input();
       time *= .1;
@@ -386,6 +404,8 @@ export const EMBEDDED_SHADER_SCENES: ShaderSceneOption[] = [
     description: 'Bundled engine scene with a torus and box frame at maximum scale.',
     shader: `
       setMaxIterations(151);
+      setStepSize(0.26597607104610804);
+
       let size = input();
       let pointerDown = input();
       time *= .1;
@@ -421,6 +441,8 @@ export const EMBEDDED_SHADER_SCENES: ShaderSceneOption[] = [
     description: 'Bundled engine scene with color-from-ray direction and sparse mixed primitives.',
     shader: `
       setMaxIterations(96);
+      setStepSize(0.8497186712056144);
+
       let size = input();
       let pointerDown = input();
       time *= 0.663750656570544;
@@ -453,6 +475,8 @@ export const EMBEDDED_SHADER_SCENES: ShaderSceneOption[] = [
     description: 'Bundled engine scene with heavy noise expansion, mixed primitives, and rainbow ray coloring.',
     shader: `
       setMaxIterations(78);
+      setStepSize(0.7369359368566446);
+
       let size = input();
       let pointerDown = input();
       time *= 0.9539348297232683;

--- a/src/lib/embeddedShaderScenes.ts
+++ b/src/lib/embeddedShaderScenes.ts
@@ -34,8 +34,6 @@ export const EMBEDDED_SHADER_SCENES: ShaderSceneOption[] = [
     description: 'Bundled engine scene built from stacked grids and box frames.',
     shader: `
       setMaxIterations(101);
-      setStepSize(0.7260629659452175);
-
       let size = input();
       let pointerDown = input();
       time *= .1;
@@ -76,8 +74,6 @@ export const EMBEDDED_SHADER_SCENES: ShaderSceneOption[] = [
     description: 'Bundled engine scene with noisy box frames and layered grid distortion.',
     shader: `
       setMaxIterations(133);
-      setStepSize(0.8632297724861512);
-
       let size = input();
       let pointerDown = input();
       time *= 0.131579219319508;
@@ -123,8 +119,6 @@ export const EMBEDDED_SHADER_SCENES: ShaderSceneOption[] = [
     description: 'Bundled engine scene with twin box frames and green edge-lit motion.',
     shader: `
       setMaxIterations(71);
-      setStepSize(0.4414923770441956);
-
       let size = input();
       let pointerDown = input();
       time *= .1;
@@ -160,8 +154,6 @@ export const EMBEDDED_SHADER_SCENES: ShaderSceneOption[] = [
     description: 'Bundled engine scene with framed cylinders, a noisy core sphere, and a grid floor.',
     shader: `
       setMaxIterations(161);
-      setStepSize(0.7431197197400152);
-
       let size = input();
       let pointerDown = input();
       time *= 0.15934458017140202;
@@ -205,8 +197,6 @@ export const EMBEDDED_SHADER_SCENES: ShaderSceneOption[] = [
     description: 'Bundled engine scene combining a metallic cylinder shell with a central sphere.',
     shader: `
       setMaxIterations(56);
-      setStepSize(0.04586632133333666);
-
       let size = input();
       let pointerDown = input();
       time *= .1;
@@ -239,8 +229,6 @@ export const EMBEDDED_SHADER_SCENES: ShaderSceneOption[] = [
     description: 'Bundled engine scene with a dominant sphere, cylinder, and dense grid accent.',
     shader: `
       setMaxIterations(198);
-      setStepSize(0.8838993805155669);
-
       let size = input();
       let pointerDown = input();
       time *= .1;
@@ -278,8 +266,6 @@ export const EMBEDDED_SHADER_SCENES: ShaderSceneOption[] = [
     description: 'Bundled engine scene with layered grids and a saturated violet sphere.',
     shader: `
       setMaxIterations(193);
-      setStepSize(0.7999169963821687);
-
       let size = input();
       let pointerDown = input();
       time *= .1;
@@ -318,8 +304,6 @@ export const EMBEDDED_SHADER_SCENES: ShaderSceneOption[] = [
     description: 'Bundled engine scene with a torus frame, noisy grids, and a bright center sphere.',
     shader: `
       setMaxIterations(186);
-      setStepSize(0.8615043142034936);
-
       let size = input();
       let pointerDown = input();
       time *= .1;
@@ -366,8 +350,6 @@ export const EMBEDDED_SHADER_SCENES: ShaderSceneOption[] = [
     description: 'Bundled engine scene with orange framing and a tight supporting grid.',
     shader: `
       setMaxIterations(56);
-      setStepSize(0.7549446257595138);
-
       let size = input();
       let pointerDown = input();
       time *= .1;
@@ -404,8 +386,6 @@ export const EMBEDDED_SHADER_SCENES: ShaderSceneOption[] = [
     description: 'Bundled engine scene with a torus and box frame at maximum scale.',
     shader: `
       setMaxIterations(151);
-      setStepSize(0.26597607104610804);
-
       let size = input();
       let pointerDown = input();
       time *= .1;
@@ -441,8 +421,6 @@ export const EMBEDDED_SHADER_SCENES: ShaderSceneOption[] = [
     description: 'Bundled engine scene with color-from-ray direction and sparse mixed primitives.',
     shader: `
       setMaxIterations(96);
-      setStepSize(0.8497186712056144);
-
       let size = input();
       let pointerDown = input();
       time *= 0.663750656570544;
@@ -475,8 +453,6 @@ export const EMBEDDED_SHADER_SCENES: ShaderSceneOption[] = [
     description: 'Bundled engine scene with heavy noise expansion, mixed primitives, and rainbow ray coloring.',
     shader: `
       setMaxIterations(78);
-      setStepSize(0.7369359368566446);
-
       let size = input();
       let pointerDown = input();
       time *= 0.9539348297232683;

--- a/src/lib/magePlayerAdapter.test.ts
+++ b/src/lib/magePlayerAdapter.test.ts
@@ -34,7 +34,7 @@ describe('createMagePlayer', () => {
     engineMocks.loadPreset.mockReturnValue({ visualizer: { shader: 'test' } })
   })
 
-  it('primes engine time and resumes playback after loading a scene blob', async () => {
+  it('primes engine time and restarts the engine after loading a scene blob', async () => {
     const { createMagePlayer } = await import('./magePlayerAdapter')
     const canvas = document.createElement('canvas')
     const sceneBlob = {
@@ -60,7 +60,8 @@ describe('createMagePlayer', () => {
 
     expect(engineMocks.loadPreset).toHaveBeenCalledWith(sceneBlob)
     expect(engineMocks.setEngineTime).toHaveBeenCalledWith(1 / 60)
-    expect(engineMocks.play).toHaveBeenCalledTimes(1)
+    expect(engineMocks.start).toHaveBeenCalledTimes(2)
+    expect(engineMocks.play).not.toHaveBeenCalled()
   })
 
   it('does not reset engine time when it is already past zero', async () => {
@@ -79,16 +80,43 @@ describe('createMagePlayer', () => {
     player.loadSceneBlob(sceneBlob)
 
     expect(engineMocks.setEngineTime).not.toHaveBeenCalled()
-    expect(engineMocks.play).toHaveBeenCalledTimes(1)
+    expect(engineMocks.start).toHaveBeenCalledTimes(2)
+    expect(engineMocks.play).not.toHaveBeenCalled()
   })
 
-  it('exposes playback state controls for the shared player UI', async () => {
+  it('tracks playback state before the first scene load without touching the engine', async () => {
     const { createMagePlayer } = await import('./magePlayerAdapter')
     const canvas = document.createElement('canvas')
 
     const player = await createMagePlayer(canvas)
 
     expect(player.getPlaybackState()).toBe('playing')
+
+    player.setPlaybackState('paused')
+
+    expect(player.getPlaybackState()).toBe('paused')
+    player.setPlaybackState('playing')
+
+    expect(player.getPlaybackState()).toBe('playing')
+    expect(engineMocks.pause).not.toHaveBeenCalled()
+    expect(engineMocks.play).not.toHaveBeenCalled()
+  })
+
+  it('exposes playback state controls for the shared player UI after a scene is loaded', async () => {
+    const { createMagePlayer } = await import('./magePlayerAdapter')
+    const canvas = document.createElement('canvas')
+    const sceneBlob = {
+      visualizer: {
+        shader: 'test',
+      },
+    }
+
+    const player = await createMagePlayer(canvas)
+
+    player.loadSceneBlob(sceneBlob)
+
+    engineMocks.pause.mockClear()
+    engineMocks.play.mockClear()
 
     player.setPlaybackState('paused')
 
@@ -112,14 +140,36 @@ describe('createMagePlayer', () => {
 
     const player = await createMagePlayer(canvas)
 
+    engineMocks.start.mockClear()
     engineMocks.pause.mockClear()
     engineMocks.play.mockClear()
 
     player.setPlaybackState('paused')
     player.loadSceneBlob(sceneBlob)
 
-    expect(engineMocks.pause).toHaveBeenCalledTimes(2)
+    expect(engineMocks.start).toHaveBeenCalledTimes(1)
+    expect(engineMocks.pause).toHaveBeenCalledTimes(1)
     expect(engineMocks.play).not.toHaveBeenCalled()
+  })
+
+  it('surfaces the underlying engine error text when scene loading throws', async () => {
+    const { createMagePlayer } = await import('./magePlayerAdapter')
+    const canvas = document.createElement('canvas')
+    const sceneBlob = {
+      visualizer: {
+        shader: 'test',
+      },
+    }
+
+    engineMocks.loadPreset.mockImplementation(() => {
+      throw new ReferenceError('setStepSize is not defined')
+    })
+
+    const player = await createMagePlayer(canvas)
+
+    expect(() => player.loadSceneBlob(sceneBlob)).toThrowError(
+      'Scene data could not be rendered by the MAGE engine. ReferenceError: setStepSize is not defined',
+    )
   })
 
   it('disables native engine controls so only shared playback chrome is shown', async () => {

--- a/src/lib/magePlayerAdapter.test.ts
+++ b/src/lib/magePlayerAdapter.test.ts
@@ -34,7 +34,7 @@ describe('createMagePlayer', () => {
     engineMocks.loadPreset.mockReturnValue({ visualizer: { shader: 'test' } })
   })
 
-  it('primes engine time and restarts the engine after loading a scene blob', async () => {
+  it('primes engine time and resumes playback after loading a scene blob', async () => {
     const { createMagePlayer } = await import('./magePlayerAdapter')
     const canvas = document.createElement('canvas')
     const sceneBlob = {
@@ -60,8 +60,8 @@ describe('createMagePlayer', () => {
 
     expect(engineMocks.loadPreset).toHaveBeenCalledWith(sceneBlob)
     expect(engineMocks.setEngineTime).toHaveBeenCalledWith(1 / 60)
-    expect(engineMocks.start).toHaveBeenCalledTimes(2)
-    expect(engineMocks.play).not.toHaveBeenCalled()
+    expect(engineMocks.start).toHaveBeenCalledTimes(1)
+    expect(engineMocks.play).toHaveBeenCalledTimes(1)
   })
 
   it('does not reset engine time when it is already past zero', async () => {
@@ -80,8 +80,8 @@ describe('createMagePlayer', () => {
     player.loadSceneBlob(sceneBlob)
 
     expect(engineMocks.setEngineTime).not.toHaveBeenCalled()
-    expect(engineMocks.start).toHaveBeenCalledTimes(2)
-    expect(engineMocks.play).not.toHaveBeenCalled()
+    expect(engineMocks.start).toHaveBeenCalledTimes(1)
+    expect(engineMocks.play).toHaveBeenCalledTimes(1)
   })
 
   it('tracks playback state before the first scene load without touching the engine', async () => {
@@ -147,7 +147,7 @@ describe('createMagePlayer', () => {
     player.setPlaybackState('paused')
     player.loadSceneBlob(sceneBlob)
 
-    expect(engineMocks.start).toHaveBeenCalledTimes(1)
+    expect(engineMocks.start).not.toHaveBeenCalled()
     expect(engineMocks.pause).toHaveBeenCalledTimes(1)
     expect(engineMocks.play).not.toHaveBeenCalled()
   })

--- a/src/lib/magePlayerAdapter.ts
+++ b/src/lib/magePlayerAdapter.ts
@@ -16,6 +16,7 @@ const DEFAULT_ENGINE_CONTROLS = {
   active: false,
   integrated: false,
 } as const
+const GENERIC_RENDER_ERROR_MESSAGE = 'Scene data could not be rendered by the MAGE engine.'
 
 type MageEngineBridge = {
   dispose: MAGEEngineAPI['dispose']
@@ -50,7 +51,15 @@ export type MagePlayerController = {
   setPlaybackState: (playbackState: MagePlayerPlaybackState) => MagePlayerPlaybackState
 }
 
-export class MagePlayerAdapterError extends Error {}
+export class MagePlayerAdapterError extends Error {
+  override cause: unknown
+
+  constructor(message: string, options: { cause?: unknown } = {}) {
+    super(message)
+    this.name = 'MagePlayerAdapterError'
+    this.cause = options.cause
+  }
+}
 
 let mageEngineModulePromise: Promise<MageEngineModule> | null = null
 
@@ -66,11 +75,41 @@ function isMageSceneBlob(value: unknown): value is MageSceneBlob {
   return SCENE_BLOB_KEYS.some((key) => Object.hasOwn(value, key))
 }
 
+function readErrorDetails(error: unknown) {
+  if (error instanceof Error) {
+    const message = error.message.trim()
+
+    if (!message) {
+      return error.name !== 'Error' ? error.name : null
+    }
+
+    return error.name !== 'Error' && !message.startsWith(`${error.name}:`)
+      ? `${error.name}: ${message}`
+      : message
+  }
+
+  if (typeof error === 'string' && error.trim()) {
+    return error.trim()
+  }
+
+  return null
+}
+
+function createSceneRenderError(cause?: unknown) {
+  const details = readErrorDetails(cause)
+
+  if (!details || details === GENERIC_RENDER_ERROR_MESSAGE) {
+    return new MagePlayerAdapterError(GENERIC_RENDER_ERROR_MESSAGE, { cause })
+  }
+
+  return new MagePlayerAdapterError(`${GENERIC_RENDER_ERROR_MESSAGE} ${details}`, { cause })
+}
+
 function loadSceneIntoEngine(engine: MageEngineBridge, sceneBlob: MageSceneBlob) {
   const loadedScene = engine.loadPreset(sceneBlob)
 
   if (!loadedScene) {
-    throw new MagePlayerAdapterError('Scene data could not be rendered by the MAGE engine.')
+    throw createSceneRenderError()
   }
 }
 
@@ -100,6 +139,23 @@ function applyPlaybackState(
   return playbackState
 }
 
+function restartLoadedScene(
+  engine: MageEngineBridge,
+  playbackState: MagePlayerPlaybackState,
+) {
+  // Scene reloads were stable when the shared player restarted the engine
+  // directly after loadPreset(). Preserve that behavior and then re-apply
+  // paused state if the UI requested it.
+  primeEngineTime(engine)
+  engine.start()
+
+  if (playbackState === 'paused') {
+    engine.pause()
+  }
+
+  return playbackState
+}
+
 async function loadMageEngineModule() {
   if (!mageEngineModulePromise) {
     mageEngineModulePromise = (import('@notrac/mage') as Promise<MageEngineModule>).catch((error) => {
@@ -124,9 +180,16 @@ export async function createMagePlayer(
   })
 
   engine.start()
+  let hasLoadedScene = false
   let playbackState: MagePlayerPlaybackState = 'playing'
 
   function setPlaybackState(nextPlaybackState: MagePlayerPlaybackState) {
+    playbackState = nextPlaybackState
+
+    if (!hasLoadedScene) {
+      return playbackState
+    }
+
     playbackState = applyPlaybackState(engine, nextPlaybackState)
     return playbackState
   }
@@ -142,13 +205,14 @@ export async function createMagePlayer(
 
       try {
         loadSceneIntoEngine(engine, sceneBlob)
-        setPlaybackState(playbackState)
+        hasLoadedScene = true
+        playbackState = restartLoadedScene(engine, playbackState)
       } catch (error) {
         if (error instanceof MagePlayerAdapterError) {
           throw error
         }
 
-        throw new MagePlayerAdapterError('Scene data could not be rendered by the MAGE engine.')
+        throw createSceneRenderError(error)
       }
     },
     setPlaybackState,

--- a/src/lib/magePlayerAdapter.ts
+++ b/src/lib/magePlayerAdapter.ts
@@ -139,23 +139,6 @@ function applyPlaybackState(
   return playbackState
 }
 
-function restartLoadedScene(
-  engine: MageEngineBridge,
-  playbackState: MagePlayerPlaybackState,
-) {
-  // Scene reloads were stable when the shared player restarted the engine
-  // directly after loadPreset(). Preserve that behavior and then re-apply
-  // paused state if the UI requested it.
-  primeEngineTime(engine)
-  engine.start()
-
-  if (playbackState === 'paused') {
-    engine.pause()
-  }
-
-  return playbackState
-}
-
 async function loadMageEngineModule() {
   if (!mageEngineModulePromise) {
     mageEngineModulePromise = (import('@notrac/mage') as Promise<MageEngineModule>).catch((error) => {
@@ -206,7 +189,7 @@ export async function createMagePlayer(
       try {
         loadSceneIntoEngine(engine, sceneBlob)
         hasLoadedScene = true
-        playbackState = restartLoadedScene(engine, playbackState)
+        playbackState = applyPlaybackState(engine, playbackState)
       } catch (error) {
         if (error instanceof MagePlayerAdapterError) {
           throw error


### PR DESCRIPTION
## Summary

This PR patches the published `@notrac/mage` package from the frontend repo so embedded scene previews can access the Shader Park helpers they expect at runtime.

It also improves the shared `MagePlayer` adapter so requested playback state is tracked cleanly before the first scene load and scene load failures surface the underlying engine error text instead of collapsing everything into one generic message.

## What Changed

- reintroduced `patch-package` in the frontend repo
- added a checked-in patch for `@notrac/mage@1.0.1`
- exposed `setStepSize`, `torus`, and `cylinder` through the engine compiler eval globals
- kept requested playback state local until a scene is actually loaded
- preserved underlying engine exception text in player-facing errors for easier debugging
- updated adapter tests to cover the patched runtime assumptions and improved error reporting

## Why

The published engine bundle includes these Shader Park helpers, but they were not all being exposed consistently into the runtime eval scope used for embedded scene preview compilation. That caused preview failures with errors such as `setStepSize is not defined`, `torus is not defined`, and `cylinder is not defined`.

The shared player was also flattening scene-load failures into a generic message, which made it harder to see what the engine was actually throwing.

## Testing

Ran:

- `npm test -- --run src/lib/magePlayerAdapter.test.ts`
- `npm test -- --run src/components/MagePlayer.test.tsx`
- `npm run build`

## Notes

- the patch is applied automatically during `postinstall` and `prebuild`
- this PR patches the compiled published engine bundle, so it is intentionally pinned to `@notrac/mage@1.0.1`
