### PR TITLE
36 add basic audio playback controls to the player UI

### DIFF
--- a/docs/engine-integration.md
+++ b/docs/engine-integration.md
@@ -14,7 +14,7 @@ That keeps engine-specific startup, loading, and disposal logic in one place.
 
 ## Current Integration
 
-The adapter loads the engine dynamically, creates it for a canvas, loads a scene blob, leaves the package's native control system enabled, exposes shared play/pause controls, and disposes it on unmount.
+The adapter loads the engine dynamically, creates it for a canvas, loads a scene blob, keeps the package's native control system disabled, exposes shared playback and audio controls, and disposes it on unmount.
 
 Relevant files:
 
@@ -40,7 +40,8 @@ The adapter is doing more than forwarding calls:
 - it keeps engine imports out of route components
 - it validates scene blobs before loading
 - it applies the current startup workaround for the published engine so scenes do not stall at time `0`
-- it centralizes pause/resume behavior so every embedded `MagePlayer` uses the same playback model
+- it centralizes scene pause/resume plus audio load/reset behavior so every embedded `MagePlayer` uses the same playback model
+- it explicitly loads saved `audioPath` metadata on demand because the published engine does not auto-load preset audio sources
 - it starts the engine without the package's built-in controls bootstrap, so embedded player UI stays frontend-owned
 
 ## Current Caveats

--- a/docs/player-component.md
+++ b/docs/player-component.md
@@ -67,7 +67,11 @@ Pages should pass the raw `sceneData` object returned by the backend instead of 
 - `initialPlayback="playing"` keeps the scene running and shows a `Pause` control instead
 - when the player is ready, hover or keyboard focus reveals a playback bar at the bottom of the viewport
 - on touch devices the playback bar stays visible so the control is not hover-only
-- the playback button toggles shared pause/resume state without remounting the engine instance
+- when `audioPath` or compatible root-level audio metadata is present, the playback bar shows the saved audio file name
+- `Load` pulls the saved audio source into the engine on demand instead of auto-loading it on scene mount
+- when a scene has no saved audio source, `Load` opens a device file picker so the user can choose local audio manually
+- the shared play/pause button drives both scene playback state and loaded audio playback
+- `Reset` returns the scene and any loaded audio to the beginning in a paused state
 - the app's custom playback bar is the only player UI shown by default
 - invalid scene data produces a recoverable error overlay instead of crashing the page
 - the engine instance is disposed on unmount

--- a/patches/@notrac+mage+1.0.1.patch
+++ b/patches/@notrac+mage+1.0.1.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@notrac/mage/dist/mage-engine.js b/node_modules/@notrac/mage/dist/mage-engine.js
-index 13dcc32..3331322 100644
+index 13dcc32..6285874 100644
 --- a/node_modules/@notrac/mage/dist/mage-engine.js
 +++ b/node_modules/@notrac/mage/dist/mage-engine.js
 @@ -71848,6 +71848,7 @@ var require_shader_park_core_umd = /* @__PURE__ */ __commonJSMin(((exports, modu
@@ -19,3 +19,78 @@ index 13dcc32..3331322 100644
  				grid,
  				repeatLinear,
  				repeatRadial,
+@@ -112922,9 +112925,31 @@ var MAGEEngine = class MAGEEngine {
+ 	* @returns {number} Current playback time of the audio in seconds, or 0 if no audio is loaded.
+ 	*/
+ 	getAudioTime() {
++		const duration = this.getAudioDuration();
++		if (duration <= 0) return 0;
++		const resolveAudioTime = (audio, reverse = false) => {
++			if (!audio?.buffer) return null;
++			const offset = Number.isFinite(audio.offset) ? audio.offset : 0;
++			const progress = Number.isFinite(audio._progress) ? audio._progress : 0;
++			const playbackRate = Number.isFinite(audio.playbackRate) ? audio.playbackRate : 1;
++			const startedAt = Number.isFinite(audio._startedAt) ? audio._startedAt : audio.context?.currentTime ?? 0;
++			const liveProgress = audio.isPlaying && audio.context ? Math.max(audio.context.currentTime - startedAt, 0) * playbackRate : 0;
++			const clampedTime = Math.max(0, Math.min(offset + progress + liveProgress, duration));
++			return reverse ? Math.max(duration - clampedTime, 0) : clampedTime;
++		};
++		const nextTime = this.#isReversed ? resolveAudioTime(this.#reversedAudio, true) ?? resolveAudioTime(this.#audio, false) : resolveAudioTime(this.#audio, false) ?? resolveAudioTime(this.#reversedAudio, true);
++		this.#playbackTime = nextTime ?? this.#playbackTime;
+ 		return this.#playbackTime;
+ 	}
+ 	/**
++	* Returns the current master volume for the active audio sources.
++	* @returns {number} Current audio volume between 0 and 1.
++	*/
++	getAudioVolume() {
++		const volume = this.#audio?.getVolume?.() ?? this.#reversedAudio?.getVolume?.() ?? 1;
++		return Number.isFinite(volume) ? Math.min(Math.max(volume, 0), 1) : 1;
++	}
++	/**
+ 	* Seeks to a specific time in the audio.
+ 	* @param {number} time - The time to seek to, in seconds.
+ 	* @returns {boolean} True if the seek was successful, false otherwise.
+@@ -112958,10 +112983,22 @@ var MAGEEngine = class MAGEEngine {
+ 		return this.seek(time);
+ 	}
+ 	/**
++	* Sets the audio volume for the forward and reversed audio sources.
++	* @param {number} volume - The volume to set, clamped between 0 and 1.
++	* @returns {number} The applied volume.
++	*/
++	setAudioVolume(volume) {
++		const nextVolume = Number.isFinite(volume) ? Math.min(Math.max(volume, 0), 1) : 1;
++		if (this.#audio) this.#audio.setVolume(nextVolume);
++		if (this.#reversedAudio) this.#reversedAudio.setVolume(nextVolume);
++		return nextVolume;
++	}
++	/**
+ 	* Plays the currently loaded audio if it is not already playing. If no audio is loaded, this method does nothing.
+ 	* @returns {void}
+ 	*/
+ 	play() {
++		if (!this.#isRunning) this.start();
+ 		if (!this.isAudioLoaded()) return;
+ 		if (this.#audio && !this.#audio.isPlaying) this.#audio.play();
+ 	}
+@@ -112972,6 +113009,11 @@ var MAGEEngine = class MAGEEngine {
+ 	pause() {
+ 		if (this.#audio?.isPlaying) this.#audio.pause();
+ 		if (this.#reversedAudio?.isPlaying) this.#reversedAudio.pause();
++		this.#isRunning = false;
++		if (this.#animationFrameId !== null) {
++			cancelAnimationFrame(this.#animationFrameId);
++			this.#animationFrameId = null;
++		}
+ 	}
+ 	/**
+ 	* Returns whether audio is currently loaded in the engine. This checks for the presence of an audio buffer in either the forward or reversed audio sources, 
+@@ -113310,7 +113352,6 @@ var MAGEEngine = class MAGEEngine {
+ 	*/
+ 	dispose() {
+ 		if (this.#isDisposed) return;
+-		if (!this.#isRunning) return;
+ 		this.#isDisposed = true;
+ 		this.#isRunning = false;
+ 		if (this.#animationFrameId !== null) {

--- a/patches/@notrac+mage+1.0.1.patch
+++ b/patches/@notrac+mage+1.0.1.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@notrac/mage/dist/mage-engine.js b/node_modules/@notrac/mage/dist/mage-engine.js
-index 13dcc32..6285874 100644
+index 13dcc32..0204f23 100644
 --- a/node_modules/@notrac/mage/dist/mage-engine.js
 +++ b/node_modules/@notrac/mage/dist/mage-engine.js
 @@ -71848,6 +71848,7 @@ var require_shader_park_core_umd = /* @__PURE__ */ __commonJSMin(((exports, modu
@@ -86,7 +86,32 @@ index 13dcc32..6285874 100644
  	}
  	/**
  	* Returns whether audio is currently loaded in the engine. This checks for the presence of an audio buffer in either the forward or reversed audio sources, 
-@@ -113310,7 +113352,6 @@ var MAGEEngine = class MAGEEngine {
+@@ -113025,6 +113067,24 @@ var MAGEEngine = class MAGEEngine {
+ 		});
+ 	}
+ 	/**
++	* Unloads the currently loaded audio and clears any playback state.
++	* @returns {void}
++	*/
++	unloadAudio() {
++		if (this.#audio?.isPlaying) this.#audio.stop();
++		else this.#audio?.pause?.();
++		if (this.#reversedAudio?.isPlaying) this.#reversedAudio.stop();
++		else this.#reversedAudio?.pause?.();
++		if (this.#audio) this.#audio.setBuffer(null);
++		if (this.#reversedAudio) this.#reversedAudio.setBuffer(null);
++		this.#audio = null;
++		this.#reversedAudio = null;
++		this.#audioAnalyser = null;
++		this.#audioBuffer = null;
++		this.#audioFile = null;
++		this.#playbackTime = 0;
++	}
++	/**
+ 	* Loads a preset into the engine.
+ 	* @param {MAGEPreset} presetInput - The preset input to load.
+ 	* @returns {MAGEPreset} The loaded preset.
+@@ -113310,7 +113370,6 @@ var MAGEEngine = class MAGEEngine {
  	*/
  	dispose() {
  		if (this.#isDisposed) return;

--- a/src/App.css
+++ b/src/App.css
@@ -463,154 +463,6 @@
   margin-top: 32px;
 }
 
-.mage-player {
-  width: 50%;
-}
-
-.mage-player__viewport {
-  position: relative;
-  overflow: hidden;
-  aspect-ratio: 1 / 1;
-  border-radius: 28px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background:
-    radial-gradient(
-      circle at 24% 18%,
-      rgba(99, 240, 214, 0.16),
-      transparent 28%
-    ),
-    radial-gradient(
-      circle at 78% 74%,
-      rgba(118, 196, 255, 0.16),
-      transparent 30%
-    ),
-    linear-gradient(180deg, rgba(2, 8, 11, 0.42), rgba(2, 8, 11, 0.82));
-  box-shadow:
-    inset 0 0 0 1px rgba(255, 255, 255, 0.03),
-    0 24px 70px rgba(0, 0, 0, 0.34);
-}
-
-.mage-player__viewport::after {
-  content: "";
-  position: absolute;
-  inset: 14px;
-  border-radius: 20px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  pointer-events: none;
-}
-
-.mage-player__canvas {
-  display: block;
-  width: 100%;
-  height: 100%;
-}
-
-.mage-player__controls {
-  position: absolute;
-  inset: auto 0 0 0;
-  display: flex;
-  align-items: flex-end;
-  justify-content: flex-start;
-  padding: 44px 18px 18px;
-  border-bottom-left-radius: inherit;
-  border-bottom-right-radius: inherit;
-  background: linear-gradient(
-    180deg,
-    rgba(6, 13, 16, 0),
-    rgba(6, 13, 16, 0.12) 20%,
-    rgba(6, 13, 16, 0.7) 74%,
-    rgba(6, 13, 16, 0.92)
-  );
-  opacity: 0;
-  transform: translateY(14px);
-  pointer-events: none;
-  transition:
-    opacity 180ms ease,
-    transform 180ms ease;
-  z-index: 1;
-}
-
-.mage-player__control-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 48px;
-  height: 48px;
-  padding: 0;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.12);
-  color: var(--text);
-  font: inherit;
-  cursor: pointer;
-  transition:
-    background-color 160ms ease,
-    color 160ms ease,
-    transform 160ms ease,
-    border-color 160ms ease;
-}
-
-.mage-player__control-button:hover,
-.mage-player__control-button:focus-visible {
-  background: rgba(99, 240, 214, 0.22);
-  border-color: rgba(99, 240, 214, 0.34);
-  color: var(--accent);
-  outline: none;
-}
-
-.mage-player__control-button:active {
-  transform: translateY(1px);
-}
-
-.mage-player__control-icon {
-  display: inline-flex;
-  width: 1rem;
-  height: 1rem;
-}
-
-.mage-player__control-icon svg {
-  width: 100%;
-  height: 100%;
-}
-
-.mage-player[data-state="ready"] .mage-player__viewport:hover .mage-player__controls,
-.mage-player[data-state="ready"] .mage-player__viewport:focus-within .mage-player__controls {
-  opacity: 1;
-  transform: translateY(0);
-  pointer-events: auto;
-}
-
-.mage-player__overlay {
-  position: absolute;
-  inset: 0;
-  display: grid;
-  place-items: center;
-  padding: 28px;
-  background: linear-gradient(
-    180deg,
-    rgba(4, 12, 14, 0.78),
-    rgba(4, 12, 14, 0.92)
-  );
-  text-align: center;
-}
-
-.mage-player__overlay-copy {
-  display: grid;
-  gap: 10px;
-  max-width: 26rem;
-}
-
-.mage-player__overlay-copy strong {
-  font-size: 1.05rem;
-  letter-spacing: -0.02em;
-}
-
-.mage-player__overlay-copy p {
-  margin: 0;
-  color: var(--muted);
-  line-height: 1.6;
-}
-
 .secondary-link {
   color: var(--text);
   text-decoration: none;
@@ -3525,24 +3377,6 @@
     border-radius: 22px;
   }
 
-  .mage-player__viewport {
-    min-height: 260px;
-    border-radius: 22px;
-  }
-
-  .mage-player__overlay {
-    padding: 22px;
-  }
-
-  .mage-player__controls {
-    padding: 34px 14px 14px;
-  }
-
-  .mage-player__control-button {
-    width: 44px;
-    height: 44px;
-  }
-
   .scene-detail-description-card,
   .scene-detail-comments-panel {
     padding: 16px;
@@ -4037,13 +3871,5 @@
   .scene-grid {
     grid-template-columns: 1fr;
     gap: 16px;
-  }
-}
-
-@media (hover: none), (pointer: coarse) {
-  .mage-player[data-state="ready"] .mage-player__controls {
-    opacity: 1;
-    transform: translateY(0);
-    pointer-events: auto;
   }
 }

--- a/src/components/MagePlayer.test.tsx
+++ b/src/components/MagePlayer.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { MagePlayer } from './MagePlayer'
 import {
   createMagePlayer,
+  type MagePlayerAudioState,
   type MagePlayerController,
   type MagePlayerPlaybackState,
 } from '../lib/magePlayerAdapter'
@@ -14,11 +15,94 @@ vi.mock('../lib/magePlayerAdapter', () => ({
 
 function createController(overrides: Partial<MagePlayerController> = {}): MagePlayerController {
   let playbackState: MagePlayerPlaybackState = 'playing'
+  let audioState: MagePlayerAudioState = {
+    currentTime: 0,
+    duration: 0,
+    hasSource: false,
+    isLoaded: false,
+    sourcePath: null,
+    volume: 1,
+  }
 
   return {
+    clearAudio: vi.fn(() => {
+      audioState = {
+        currentTime: 0,
+        duration: 0,
+        hasSource: false,
+        isLoaded: false,
+        sourcePath: null,
+        volume: audioState.volume,
+      }
+
+      return audioState
+    }),
     dispose: vi.fn(),
+    getAudioState: vi.fn(() => audioState),
     getPlaybackState: vi.fn(() => playbackState),
-    loadSceneBlob: vi.fn(),
+    loadAudio: vi.fn(async (options?: { sourceLabel?: string; sourcePath?: string }) => {
+      audioState = {
+        ...audioState,
+        currentTime: 0,
+        duration: 185,
+        hasSource: true,
+        isLoaded: true,
+        sourcePath: options?.sourceLabel ?? audioState.sourcePath,
+      }
+
+      return audioState
+    }),
+    loadSceneBlob: vi.fn((sceneBlob: unknown) => {
+      if (typeof sceneBlob === 'object' && sceneBlob !== null) {
+        const nextSceneBlob = sceneBlob as Record<string, unknown>
+        const audioValue = nextSceneBlob.audio
+        const sourcePath =
+          typeof nextSceneBlob.audioPath === 'string'
+            ? nextSceneBlob.audioPath
+            : typeof audioValue === 'string'
+              ? audioValue
+              : audioValue && typeof audioValue === 'object'
+                ? typeof (audioValue as Record<string, unknown>).path === 'string'
+                  ? ((audioValue as Record<string, unknown>).path as string)
+                  : typeof (audioValue as Record<string, unknown>).url === 'string'
+                    ? ((audioValue as Record<string, unknown>).url as string)
+                    : null
+                : null
+
+        audioState = {
+          currentTime: 0,
+          duration: 0,
+          hasSource: Boolean(sourcePath),
+          isLoaded: false,
+          sourcePath,
+          volume: 1,
+        }
+      }
+    }),
+    resetPlayback: vi.fn(() => {
+      audioState = {
+        ...audioState,
+        currentTime: 0,
+      }
+      playbackState = 'paused'
+      return playbackState
+    }),
+    seekAudio: vi.fn((time: number) => {
+      audioState = {
+        ...audioState,
+        currentTime: time,
+      }
+
+      return audioState
+    }),
+    setAudioVolume: vi.fn((volume: number) => {
+      audioState = {
+        ...audioState,
+        volume,
+      }
+
+      return audioState
+    }),
     setPlaybackState: vi.fn((nextPlaybackState: MagePlayerPlaybackState) => {
       playbackState = nextPlaybackState
       return playbackState
@@ -53,9 +137,14 @@ describe('MagePlayer', () => {
     })
 
     expect(screen.queryByText('Loading scene preview.')).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /pause scene playback/i })).toHaveAccessibleName(
-      'Pause scene playback',
+    expect(screen.getByRole('button', { name: /pause scene and audio playback/i })).toHaveAccessibleName(
+      'Pause scene and audio playback',
     )
+    expect(screen.getByRole('button', { name: /add audio tracks/i })).toBeEnabled()
+    expect(screen.queryByRole('button', { name: /shuffle playback/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /repeat playback/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /reset scene and audio playback/i })).not.toBeInTheDocument()
+    expect(screen.getByText('Track 0/0: No track selected')).toBeInTheDocument()
 
     unmount()
 
@@ -97,11 +186,7 @@ describe('MagePlayer', () => {
   it('shows a recoverable error state when the scene is invalid', async () => {
     const controller = createController({
       loadSceneBlob: vi.fn((sceneBlob: unknown) => {
-        if (
-          typeof sceneBlob === 'object' &&
-          sceneBlob !== null &&
-          'invalid' in sceneBlob
-        ) {
+        if (typeof sceneBlob === 'object' && sceneBlob !== null && 'invalid' in sceneBlob) {
           throw new Error('Scene data is missing required MAGE fields.')
         }
       }),
@@ -141,7 +226,6 @@ describe('MagePlayer', () => {
     const controller = createController()
     vi.mocked(createMagePlayer).mockResolvedValue(controller)
 
-    const user = userEvent.setup()
     const sceneBlob = {
       visualizer: {
         skyboxPreset: 6,
@@ -157,18 +241,490 @@ describe('MagePlayer', () => {
       expect(controller.setPlaybackState).toHaveBeenLastCalledWith('paused')
     })
 
-    const playbackButton = screen.getByRole('button', { name: /play scene playback/i })
+    const playbackButton = screen.getByRole('button', { name: /play scene and audio playback/i })
     expect(playbackButton).toHaveAttribute('aria-pressed', 'false')
-    expect(playbackButton).toHaveAccessibleName('Play scene playback')
+    expect(playbackButton).toHaveAccessibleName('Play scene and audio playback')
 
-    await user.click(playbackButton)
+    fireEvent.click(playbackButton)
 
     expect(controller.setPlaybackState).toHaveBeenLastCalledWith('playing')
     expect(playbackButton).toHaveAttribute('aria-pressed', 'true')
-    expect(playbackButton).toHaveAccessibleName('Pause scene playback')
+    expect(playbackButton).toHaveAccessibleName('Pause scene and audio playback')
     await waitFor(() => {
       expect(playbackButton).not.toHaveFocus()
     })
+  })
+
+  it('auto-loads saved scene audio into the playlist and exposes a clickable track summary', async () => {
+    const controller = createController()
+    vi.mocked(createMagePlayer).mockResolvedValue(controller)
+
+    const onRequestPlaylistOpen = vi.fn()
+    const sceneBlob = {
+      audioPath: '/audio/crimson-reactor.mp3',
+      visualizer: {
+        skyboxPreset: 6,
+      },
+    }
+
+    render(<MagePlayer onRequestPlaylistOpen={onRequestPlaylistOpen} sceneBlob={sceneBlob} />)
+
+    await waitFor(() => {
+      expect(controller.loadAudio).toHaveBeenLastCalledWith({
+        sourceLabel: 'crimson-reactor.mp3',
+        sourcePath: '/audio/crimson-reactor.mp3',
+      })
+    })
+
+    const trackSummaryButton = screen.getByRole('button', {
+      name: /track 1\/1: crimson-reactor\.mp3/i,
+    })
+
+    expect(trackSummaryButton).toBeInTheDocument()
+    expect(screen.getByText('3:05')).toBeInTheDocument()
+
+    fireEvent.click(trackSummaryButton)
+
+    expect(onRequestPlaylistOpen).toHaveBeenCalledTimes(1)
+  })
+
+  it('adds local audio tracks to the playlist and auto-loads the first added track', async () => {
+    const controller = createController()
+    vi.mocked(createMagePlayer).mockResolvedValue(controller)
+
+    const user = userEvent.setup()
+    const onPlaylistChange = vi.fn()
+    const sceneBlob = {
+      visualizer: {
+        skyboxPreset: 6,
+      },
+    }
+
+    const { container } = render(<MagePlayer onPlaylistChange={onPlaylistChange} sceneBlob={sceneBlob} />)
+
+    const addButton = await screen.findByRole('button', { name: /add audio tracks/i })
+    const audioInput = container.querySelector('.mage-player__audio-input') as HTMLInputElement
+    const localAudioFile = new File(['audio'], 'device-track.mp3', { type: 'audio/mpeg' })
+
+    fireEvent.click(addButton)
+    await user.upload(audioInput, localAudioFile)
+
+    await waitFor(() => {
+      expect(controller.loadAudio).toHaveBeenLastCalledWith({
+        sourceLabel: 'device-track.mp3',
+        sourcePath: expect.stringMatching(/^blob:/),
+      })
+    })
+
+    expect(onPlaylistChange).toHaveBeenCalledTimes(1)
+    expect(onPlaylistChange).toHaveBeenLastCalledWith([
+      expect.objectContaining({
+        duration: expect.any(Number),
+        name: 'device-track.mp3',
+        sourcePath: expect.stringMatching(/^blob:/),
+        sourceType: 'device',
+      }),
+    ])
+    expect(screen.getByRole('button', { name: /track 1\/1: device-track\.mp3/i })).toBeInTheDocument()
+  })
+
+  it('supports audio scrubbing and volume control from the shared hover bar', async () => {
+    const controller = createController()
+    vi.mocked(createMagePlayer).mockResolvedValue(controller)
+
+    const sceneBlob = {
+      audioPath: '/audio/crimson-reactor.mp3',
+      visualizer: {
+        skyboxPreset: 6,
+      },
+    }
+
+    render(<MagePlayer sceneBlob={sceneBlob} />)
+
+    await waitFor(() => {
+      expect(controller.loadAudio).toHaveBeenCalled()
+    })
+
+    const scrubber = screen.getByRole('slider', { name: /seek scene audio/i })
+    fireEvent.change(scrubber, { target: { value: '42' } })
+
+    expect(controller.seekAudio).toHaveBeenLastCalledWith(42)
+    expect(screen.getByText('0:42')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /adjust audio volume/i }))
+
+    const volumeSlider = screen.getByRole('slider', { name: /audio volume/i })
+    fireEvent.change(volumeSlider, { target: { value: '0.4' } })
+
+    expect(controller.setAudioVolume).toHaveBeenLastCalledWith(0.4)
+    expect(screen.getByText('40%')).toBeInTheDocument()
+  })
+
+  it('advances to the next playlist track when the current track finishes', async () => {
+    let playbackState: MagePlayerPlaybackState = 'playing'
+    let audioState: MagePlayerAudioState = {
+      currentTime: 0,
+      duration: 0,
+      hasSource: false,
+      isLoaded: false,
+      sourcePath: null,
+      volume: 1,
+    }
+
+    const controller: MagePlayerController = {
+      clearAudio: vi.fn(() => {
+        audioState = {
+          currentTime: 0,
+          duration: 0,
+          hasSource: false,
+          isLoaded: false,
+          sourcePath: null,
+          volume: audioState.volume,
+        }
+
+        return audioState
+      }),
+      dispose: vi.fn(),
+      getAudioState: vi.fn(() => audioState),
+      getPlaybackState: vi.fn(() => playbackState),
+      loadAudio: vi.fn(async (options?: { sourceLabel?: string; sourcePath?: string }) => {
+        audioState = {
+          currentTime: 0,
+          duration: options?.sourceLabel === 'track-two.mp3' ? 120 : 185,
+          hasSource: true,
+          isLoaded: true,
+          sourcePath: options?.sourceLabel ?? null,
+          volume: 1,
+        }
+
+        return audioState
+      }),
+      loadSceneBlob: vi.fn(() => {
+        audioState = {
+          currentTime: 0,
+          duration: 0,
+          hasSource: false,
+          isLoaded: false,
+          sourcePath: null,
+          volume: 1,
+        }
+      }),
+      resetPlayback: vi.fn(() => playbackState),
+      seekAudio: vi.fn((time: number) => {
+        audioState = {
+          ...audioState,
+          currentTime: time,
+        }
+
+        return audioState
+      }),
+      setAudioVolume: vi.fn((volume: number) => {
+        audioState = {
+          ...audioState,
+          volume,
+        }
+
+        return audioState
+      }),
+      setPlaybackState: vi.fn((nextPlaybackState: MagePlayerPlaybackState) => {
+        playbackState = nextPlaybackState
+        return playbackState
+      }),
+    }
+
+    vi.mocked(createMagePlayer).mockResolvedValue(controller)
+
+    const firstTrack = {
+      duration: 185,
+      id: 'track-1',
+      name: 'track-one.mp3',
+      sourcePath: 'blob:track-one',
+      sourceType: 'device' as const,
+    }
+    const secondTrack = {
+      duration: 120,
+      id: 'track-2',
+      name: 'track-two.mp3',
+      sourcePath: 'blob:track-two',
+      sourceType: 'device' as const,
+    }
+    const onSelectedTrackChange = vi.fn()
+    const sceneBlob = {
+      visualizer: {
+        skyboxPreset: 6,
+      },
+    }
+
+    render(
+      <MagePlayer
+        onSelectedTrackChange={onSelectedTrackChange}
+        playlistTracks={[firstTrack, secondTrack]}
+        sceneBlob={sceneBlob}
+        selectedTrackId={firstTrack.id}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(controller.loadAudio).toHaveBeenLastCalledWith({
+        sourceLabel: 'track-one.mp3',
+        sourcePath: 'blob:track-one',
+      })
+    })
+
+    audioState = {
+      ...audioState,
+      currentTime: 184.9,
+      duration: 185,
+      hasSource: true,
+      isLoaded: true,
+    }
+
+    await waitFor(() => {
+      expect(onSelectedTrackChange).toHaveBeenCalledWith(secondTrack.id)
+    })
+  })
+
+  it('wraps back to the first playlist track when repeat is enabled', async () => {
+    let playbackState: MagePlayerPlaybackState = 'playing'
+    let audioState: MagePlayerAudioState = {
+      currentTime: 0,
+      duration: 0,
+      hasSource: false,
+      isLoaded: false,
+      sourcePath: null,
+      volume: 1,
+    }
+
+    const controller: MagePlayerController = {
+      clearAudio: vi.fn(() => audioState),
+      dispose: vi.fn(),
+      getAudioState: vi.fn(() => audioState),
+      getPlaybackState: vi.fn(() => playbackState),
+      loadAudio: vi.fn(async (options?: { sourceLabel?: string; sourcePath?: string }) => {
+        audioState = {
+          currentTime: 0,
+          duration: options?.sourceLabel === 'track-two.mp3' ? 120 : 185,
+          hasSource: true,
+          isLoaded: true,
+          sourcePath: options?.sourceLabel ?? null,
+          volume: 1,
+        }
+
+        return audioState
+      }),
+      loadSceneBlob: vi.fn(() => {
+        audioState = {
+          currentTime: 0,
+          duration: 0,
+          hasSource: false,
+          isLoaded: false,
+          sourcePath: null,
+          volume: 1,
+        }
+      }),
+      resetPlayback: vi.fn(() => playbackState),
+      seekAudio: vi.fn((time: number) => {
+        audioState = { ...audioState, currentTime: time }
+        return audioState
+      }),
+      setAudioVolume: vi.fn((volume: number) => {
+        audioState = { ...audioState, volume }
+        return audioState
+      }),
+      setPlaybackState: vi.fn((nextPlaybackState: MagePlayerPlaybackState) => {
+        playbackState = nextPlaybackState
+        return playbackState
+      }),
+    }
+
+    vi.mocked(createMagePlayer).mockResolvedValue(controller)
+
+    const firstTrack = {
+      duration: 185,
+      id: 'track-1',
+      name: 'track-one.mp3',
+      sourcePath: 'blob:track-one',
+      sourceType: 'device' as const,
+    }
+    const secondTrack = {
+      duration: 120,
+      id: 'track-2',
+      name: 'track-two.mp3',
+      sourcePath: 'blob:track-two',
+      sourceType: 'device' as const,
+    }
+    const onSelectedTrackChange = vi.fn()
+    const sceneBlob = {
+      visualizer: {
+        skyboxPreset: 6,
+      },
+    }
+
+    render(
+      <MagePlayer
+        onSelectedTrackChange={onSelectedTrackChange}
+        playlistTracks={[firstTrack, secondTrack]}
+        repeatEnabled
+        sceneBlob={sceneBlob}
+        selectedTrackId={secondTrack.id}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(controller.loadAudio).toHaveBeenLastCalledWith({
+        sourceLabel: 'track-two.mp3',
+        sourcePath: 'blob:track-two',
+      })
+    })
+
+    audioState = {
+      ...audioState,
+      currentTime: 119.9,
+      duration: 120,
+      hasSource: true,
+      isLoaded: true,
+    }
+
+    await waitFor(() => {
+      expect(onSelectedTrackChange).toHaveBeenCalledWith(firstTrack.id)
+    })
+  })
+
+  it('continues through the supplied playlist order even when shuffle is enabled', async () => {
+    let playbackState: MagePlayerPlaybackState = 'playing'
+    let audioState: MagePlayerAudioState = {
+      currentTime: 0,
+      duration: 0,
+      hasSource: false,
+      isLoaded: false,
+      sourcePath: null,
+      volume: 1,
+    }
+
+    const controller: MagePlayerController = {
+      clearAudio: vi.fn(() => audioState),
+      dispose: vi.fn(),
+      getAudioState: vi.fn(() => audioState),
+      getPlaybackState: vi.fn(() => playbackState),
+      loadAudio: vi.fn(async (options?: { sourceLabel?: string; sourcePath?: string }) => {
+        audioState = {
+          currentTime: 0,
+          duration: 185,
+          hasSource: true,
+          isLoaded: true,
+          sourcePath: options?.sourceLabel ?? null,
+          volume: 1,
+        }
+
+        return audioState
+      }),
+      loadSceneBlob: vi.fn(() => {
+        audioState = {
+          currentTime: 0,
+          duration: 0,
+          hasSource: false,
+          isLoaded: false,
+          sourcePath: null,
+          volume: 1,
+        }
+      }),
+      resetPlayback: vi.fn(() => playbackState),
+      seekAudio: vi.fn((time: number) => {
+        audioState = { ...audioState, currentTime: time }
+        return audioState
+      }),
+      setAudioVolume: vi.fn((volume: number) => {
+        audioState = { ...audioState, volume }
+        return audioState
+      }),
+      setPlaybackState: vi.fn((nextPlaybackState: MagePlayerPlaybackState) => {
+        playbackState = nextPlaybackState
+        return playbackState
+      }),
+    }
+
+    vi.mocked(createMagePlayer).mockResolvedValue(controller)
+
+    const firstTrack = {
+      duration: 185,
+      id: 'track-1',
+      name: 'track-one.mp3',
+      sourcePath: 'blob:track-one',
+      sourceType: 'device' as const,
+    }
+    const secondTrack = {
+      duration: 120,
+      id: 'track-2',
+      name: 'track-two.mp3',
+      sourcePath: 'blob:track-two',
+      sourceType: 'device' as const,
+    }
+    const thirdTrack = {
+      duration: 95,
+      id: 'track-3',
+      name: 'track-three.mp3',
+      sourcePath: 'blob:track-three',
+      sourceType: 'device' as const,
+    }
+    const onSelectedTrackChange = vi.fn()
+    const sceneBlob = {
+      visualizer: {
+        skyboxPreset: 6,
+      },
+    }
+
+    render(
+      <MagePlayer
+        onSelectedTrackChange={onSelectedTrackChange}
+        playlistTracks={[firstTrack, secondTrack, thirdTrack]}
+        sceneBlob={sceneBlob}
+        selectedTrackId={firstTrack.id}
+        shuffleEnabled
+      />,
+    )
+
+    await waitFor(() => {
+      expect(controller.loadAudio).toHaveBeenLastCalledWith({
+        sourceLabel: 'track-one.mp3',
+        sourcePath: 'blob:track-one',
+      })
+    })
+
+    audioState = {
+      ...audioState,
+      currentTime: 184.9,
+      duration: 185,
+      hasSource: true,
+      isLoaded: true,
+    }
+
+    await waitFor(() => {
+      expect(onSelectedTrackChange).toHaveBeenCalledWith(secondTrack.id)
+    })
+
+  })
+
+  it('shows a recoverable audio error when the selected playlist track fails to load', async () => {
+    const controller = createController({
+      loadAudio: vi.fn(async () => {
+        throw new Error('Audio could not be loaded from the configured source.')
+      }),
+    })
+
+    vi.mocked(createMagePlayer).mockResolvedValue(controller)
+
+    const sceneBlob = {
+      audioPath: '/audio/crimson-reactor.mp3',
+      visualizer: {
+        skyboxPreset: 6,
+      },
+    }
+
+    render(<MagePlayer sceneBlob={sceneBlob} />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Audio could not be loaded from the configured source.',
+    )
   })
 
   it('suppresses playback controls while the player is empty', async () => {

--- a/src/components/MagePlayer.test.tsx
+++ b/src/components/MagePlayer.test.tsx
@@ -360,6 +360,51 @@ describe('MagePlayer', () => {
     expect(screen.getByText('40%')).toBeInTheDocument()
   })
 
+  it('pauses playback and clears audio when the last playlist track is removed', async () => {
+    const controller = createController()
+    vi.mocked(createMagePlayer).mockResolvedValue(controller)
+
+    const onlyTrack = {
+      duration: 185,
+      id: 'track-1',
+      name: 'track-one.mp3',
+      sourcePath: 'blob:track-one',
+      sourceType: 'device' as const,
+    }
+    const sceneBlob = {
+      visualizer: {
+        skyboxPreset: 6,
+      },
+    }
+
+    const { rerender } = render(
+      <MagePlayer
+        playlistTracks={[onlyTrack]}
+        sceneBlob={sceneBlob}
+        selectedTrackId={onlyTrack.id}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(controller.loadAudio).toHaveBeenLastCalledWith({
+        sourceLabel: 'track-one.mp3',
+        sourcePath: 'blob:track-one',
+      })
+    })
+
+    vi.mocked(controller.clearAudio).mockClear()
+    vi.mocked(controller.setPlaybackState).mockClear()
+
+    rerender(<MagePlayer playlistTracks={[]} sceneBlob={sceneBlob} selectedTrackId={null} />)
+
+    await waitFor(() => {
+      expect(controller.setPlaybackState).toHaveBeenLastCalledWith('paused')
+      expect(controller.clearAudio).toHaveBeenCalledTimes(1)
+    })
+
+    expect(screen.getByRole('button', { name: /play scene and audio playback/i })).toBeInTheDocument()
+  })
+
   it('advances to the next playlist track when the current track finishes', async () => {
     let playbackState: MagePlayerPlaybackState = 'playing'
     let audioState: MagePlayerAudioState = {

--- a/src/components/MagePlayer.tsx
+++ b/src/components/MagePlayer.tsx
@@ -309,6 +309,11 @@ export function MagePlayer({
 
     if (tracks.length === 0) {
       try {
+        if (loadedTrackIdRef.current !== null && player.getPlaybackState() !== 'paused') {
+          requestedPlaybackRef.current = 'paused'
+          setPlaybackState(player.setPlaybackState('paused'))
+        }
+
         loadedTrackIdRef.current = null
         setAudioState(player.clearAudio())
         setAudioError(null)

--- a/src/components/MagePlayer.tsx
+++ b/src/components/MagePlayer.tsx
@@ -1,47 +1,51 @@
-import { useEffect, useRef, useState, type MouseEvent as ReactMouseEvent } from 'react'
+import { useEffect, useRef, useState, type ChangeEvent, type MouseEvent as ReactMouseEvent } from 'react'
+import { type MagePlayerPlaylistTrack } from '../lib/magePlayerPlaylist'
 import {
   createMagePlayer,
+  type MagePlayerAudioState,
   type MagePlayerController,
   type MagePlayerPlaybackState,
   type MageSceneBlob,
 } from '../lib/magePlayerAdapter'
-
-type MagePlayerStatus = 'empty' | 'loading' | 'ready' | 'error'
+import { MagePlayerControls } from './mage-player/MagePlayerControls'
+import './mage-player/magePlayer.css'
+import {
+  audioStatesMatch,
+  buildMagePlayerClassName,
+  createPlaylistTrackId,
+  EMPTY_AUDIO_STATE,
+  readAudioFileDuration,
+  readMagePlayerErrorMessage,
+  type MagePlayerStatus,
+} from './mage-player/magePlayerUtils'
+import { useMagePlayerPlaylist } from './mage-player/useMagePlayerPlaylist'
 
 type MagePlayerProps = {
   ariaLabel?: string
   className?: string
   initialPlayback?: MagePlayerPlaybackState
   log?: boolean
+  onPlaylistChange?: (tracks: MagePlayerPlaylistTrack[]) => void
+  onRequestPlaylistOpen?: () => void
+  onSelectedTrackChange?: (trackId: string | null) => void
+  onTrackDurationChange?: (trackId: string, duration: number) => void
+  playlistTracks?: MagePlayerPlaylistTrack[]
+  repeatEnabled?: boolean
   sceneBlob: MageSceneBlob | null | undefined
+  selectedTrackId?: string | null
+  shuffleEnabled?: boolean
 }
 
-function buildClassName(baseClassName: string, nextClassName?: string) {
-  return nextClassName ? `${baseClassName} ${nextClassName}` : baseClassName
-}
-
-function readErrorMessage(error: unknown) {
-  if (error instanceof Error && error.message.trim()) {
-    return error.message
+function blurMouseActivatedControl(control: HTMLButtonElement, clickCount: number) {
+  if (clickCount <= 0) {
+    return
   }
 
-  return 'MAGE could not render this scene.'
-}
-
-function PauseIcon() {
-  return (
-    <svg aria-hidden="true" viewBox="0 0 24 24">
-      <path d="M7 5h4v14H7zm6 0h4v14h-4z" fill="currentColor" />
-    </svg>
-  )
-}
-
-function PlayIcon() {
-  return (
-    <svg aria-hidden="true" viewBox="0 0 24 24">
-      <path d="M8 5.5v13L18.5 12 8 5.5Z" fill="currentColor" />
-    </svg>
-  )
+  window.requestAnimationFrame(() => {
+    if (control.isConnected) {
+      control.blur()
+    }
+  })
 }
 
 export function MagePlayer({
@@ -49,22 +53,71 @@ export function MagePlayer({
   className,
   initialPlayback = 'playing',
   log = false,
+  onPlaylistChange,
+  onRequestPlaylistOpen,
+  onSelectedTrackChange,
+  onTrackDurationChange,
+  playlistTracks,
+  repeatEnabled = false,
   sceneBlob,
+  selectedTrackId,
+  shuffleEnabled = false,
 }: MagePlayerProps) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const audioInputRef = useRef<HTMLInputElement | null>(null)
+  const volumeControlRef = useRef<HTMLDivElement | null>(null)
   const playerRef = useRef<MagePlayerController | null>(null)
   const latestSceneBlobRef = useRef<MageSceneBlob | null | undefined>(sceneBlob)
   const requestedPlaybackRef = useRef<MagePlayerPlaybackState>(initialPlayback)
+  const loadedTrackIdRef = useRef<string | null>(null)
+  const completedTrackIdRef = useRef<string | null>(null)
+
+  const {
+    commitPlaylistTracks,
+    commitSelectedTrackId,
+    commitTrackDuration,
+    currentTrack,
+    currentTrackIndex,
+    tracks,
+  } = useMagePlayerPlaylist({
+    onPlaylistChange,
+    onSelectedTrackChange,
+    onTrackDurationChange,
+    playlistTracks,
+    sceneBlob,
+    selectedTrackId,
+  })
 
   const [loadedSceneBlob, setLoadedSceneBlob] = useState<MageSceneBlob | null>(null)
   const [playerVersion, setPlayerVersion] = useState(0)
   const [playbackState, setPlaybackState] = useState<MagePlayerPlaybackState>(initialPlayback)
+  const [audioState, setAudioState] = useState<MagePlayerAudioState>(EMPTY_AUDIO_STATE)
+  const [audioError, setAudioError] = useState<string | null>(null)
+  const [activeAudioAction, setActiveAudioAction] = useState<'add' | 'load' | null>(null)
+  const [isVolumeOpen, setIsVolumeOpen] = useState(false)
+  const [trackLoadVersion, setTrackLoadVersion] = useState(0)
   const [loadError, setLoadError] = useState<{ message: string; sceneBlob: MageSceneBlob } | null>(
     null,
   )
 
   useEffect(() => {
     latestSceneBlobRef.current = sceneBlob
+  }, [sceneBlob])
+
+  useEffect(() => {
+    loadedTrackIdRef.current = null
+    completedTrackIdRef.current = null
+  }, [sceneBlob])
+
+  useEffect(() => {
+    if (sceneBlob) {
+      return
+    }
+
+    setAudioState(EMPTY_AUDIO_STATE)
+    setAudioError(null)
+    setActiveAudioAction(null)
+    setIsVolumeOpen(false)
   }, [sceneBlob])
 
   useEffect(() => {
@@ -78,6 +131,7 @@ export function MagePlayer({
     }
 
     setPlaybackState(player.setPlaybackState(initialPlayback))
+    setAudioState(player.getAudioState())
   }, [initialPlayback])
 
   useEffect(() => {
@@ -103,6 +157,7 @@ export function MagePlayer({
 
           playerRef.current = nextPlayer
           setPlaybackState(nextPlayer.setPlaybackState(requestedPlaybackRef.current))
+          setAudioState(nextPlayer.getAudioState())
           setPlayerVersion((currentVersion) => currentVersion + 1)
         } catch (error) {
           nextPlayer?.dispose()
@@ -112,7 +167,7 @@ export function MagePlayer({
 
             if (currentSceneBlob) {
               setLoadError({
-                message: readErrorMessage(error),
+                message: readMagePlayerErrorMessage(error),
                 sceneBlob: currentSceneBlob,
               })
             }
@@ -144,16 +199,21 @@ export function MagePlayer({
 
     try {
       player.loadSceneBlob(sceneBlob)
-      const nextPlaybackState = player.setPlaybackState(requestedPlaybackRef.current)
+      const nextPlaybackState = player.getPlaybackState()
 
       queueMicrotask(() => {
         if (isCancelled) {
           return
         }
 
+        requestedPlaybackRef.current = nextPlaybackState
+        loadedTrackIdRef.current = null
         setLoadError(null)
         setLoadedSceneBlob(sceneBlob)
         setPlaybackState(nextPlaybackState)
+        setAudioState(player.getAudioState())
+        setAudioError(null)
+        setActiveAudioAction(null)
       })
     } catch (error) {
       queueMicrotask(() => {
@@ -161,8 +221,9 @@ export function MagePlayer({
           return
         }
 
+        setAudioState(EMPTY_AUDIO_STATE)
         setLoadError({
-          message: readErrorMessage(error),
+          message: readMagePlayerErrorMessage(error),
           sceneBlob,
         })
       })
@@ -182,6 +243,311 @@ export function MagePlayer({
           ? 'ready'
           : 'loading'
 
+  useEffect(() => {
+    const player = playerRef.current
+
+    if (!player || status !== 'ready') {
+      return
+    }
+
+    const intervalId = window.setInterval(() => {
+      setAudioState((currentAudioState) => {
+        const nextAudioState = player.getAudioState()
+        return audioStatesMatch(currentAudioState, nextAudioState) ? currentAudioState : nextAudioState
+      })
+    }, 250)
+
+    return () => {
+      window.clearInterval(intervalId)
+    }
+  }, [playerVersion, status])
+
+  useEffect(() => {
+    if (!isVolumeOpen) {
+      return
+    }
+
+    function handlePointerDown(event: MouseEvent) {
+      if (
+        volumeControlRef.current &&
+        event.target instanceof Node &&
+        !volumeControlRef.current.contains(event.target)
+      ) {
+        setIsVolumeOpen(false)
+      }
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setIsVolumeOpen(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [isVolumeOpen])
+
+  useEffect(() => {
+    if (status !== 'ready' || !audioState.isLoaded) {
+      setIsVolumeOpen(false)
+    }
+  }, [audioState.isLoaded, status])
+
+  useEffect(() => {
+    const player = playerRef.current
+
+    if (!player || status !== 'ready') {
+      return
+    }
+
+    let isCancelled = false
+
+    if (tracks.length === 0) {
+      try {
+        loadedTrackIdRef.current = null
+        setAudioState(player.clearAudio())
+        setAudioError(null)
+      } catch (error) {
+        setAudioError(readMagePlayerErrorMessage(error))
+      }
+
+      return
+    }
+
+    if (!currentTrack || loadedTrackIdRef.current === currentTrack.id) {
+      return
+    }
+
+    setActiveAudioAction('load')
+    setAudioError(null)
+
+    void (async () => {
+      try {
+        const nextAudioState = await player.loadAudio({
+          sourceLabel: currentTrack.title?.trim() || currentTrack.name,
+          sourcePath: currentTrack.sourcePath,
+        })
+
+        if (isCancelled) {
+          return
+        }
+
+        loadedTrackIdRef.current = currentTrack.id
+        setAudioState(nextAudioState)
+        commitTrackDuration(currentTrack.id, nextAudioState.duration)
+      } catch (error) {
+        if (!isCancelled) {
+          loadedTrackIdRef.current = null
+          setAudioError(readMagePlayerErrorMessage(error))
+        }
+      } finally {
+        if (!isCancelled) {
+          setActiveAudioAction(null)
+        }
+      }
+    })()
+
+    return () => {
+      isCancelled = true
+    }
+  }, [commitTrackDuration, currentTrack, playerVersion, status, trackLoadVersion, tracks.length])
+
+  useEffect(() => {
+    if (!currentTrack) {
+      completedTrackIdRef.current = null
+      return
+    }
+
+    if (completedTrackIdRef.current && completedTrackIdRef.current !== currentTrack.id) {
+      completedTrackIdRef.current = null
+    }
+
+    if (
+      playbackState !== 'playing' ||
+      !audioState.isLoaded ||
+      audioState.duration <= 0 ||
+      loadedTrackIdRef.current !== currentTrack.id
+    ) {
+      return
+    }
+
+    const completionThreshold = Math.max(audioState.duration - 0.35, 0)
+
+    if (audioState.currentTime < completionThreshold) {
+      if (completedTrackIdRef.current === currentTrack.id) {
+        completedTrackIdRef.current = null
+      }
+
+      return
+    }
+
+    if (completedTrackIdRef.current === currentTrack.id) {
+      return
+    }
+
+    completedTrackIdRef.current = currentTrack.id
+
+    let nextTrack: MagePlayerPlaylistTrack | null = tracks[currentTrackIndex] ?? null
+
+    if (!nextTrack && repeatEnabled) {
+      nextTrack = tracks[0] ?? null
+    }
+
+    if (!nextTrack) {
+      return
+    }
+
+    if (nextTrack.id === currentTrack.id) {
+      completedTrackIdRef.current = null
+      loadedTrackIdRef.current = null
+      setTrackLoadVersion((currentVersion) => currentVersion + 1)
+      return
+    }
+
+    commitSelectedTrackId(nextTrack.id)
+  }, [
+    audioState.currentTime,
+    audioState.duration,
+    audioState.isLoaded,
+    commitSelectedTrackId,
+    currentTrack,
+    currentTrackIndex,
+    playbackState,
+    repeatEnabled,
+    shuffleEnabled,
+    tracks,
+  ])
+
+  const controlsBusy = activeAudioAction !== null
+  const addButtonLabel = activeAudioAction === 'add' ? 'Adding' : 'Add'
+  const audioProgressPercent =
+    audioState.duration > 0
+      ? `${Math.min((audioState.currentTime / audioState.duration) * 100, 100)}%`
+      : '0%'
+
+  function handleTogglePlayback(event: ReactMouseEvent<HTMLButtonElement>) {
+    const player = playerRef.current
+
+    if (!player || status !== 'ready' || controlsBusy) {
+      return
+    }
+
+    const nextPlaybackState = playbackState === 'playing' ? 'paused' : 'playing'
+    requestedPlaybackRef.current = nextPlaybackState
+    setPlaybackState(player.setPlaybackState(nextPlaybackState))
+    setAudioState(player.getAudioState())
+    setAudioError(null)
+    blurMouseActivatedControl(event.currentTarget, event.detail)
+  }
+
+  function handleOpenAudioPicker(event: ReactMouseEvent<HTMLButtonElement>) {
+    const audioInput = audioInputRef.current
+
+    if (!audioInput || controlsBusy || status !== 'ready') {
+      return
+    }
+
+    audioInput.value = ''
+    audioInput.click()
+    blurMouseActivatedControl(event.currentTarget, event.detail)
+  }
+
+  async function handleAudioSelection() {
+    const audioInput = audioInputRef.current
+
+    if (!audioInput) {
+      return
+    }
+
+    const selectedFiles = Array.from(audioInput.files ?? [])
+
+    if (selectedFiles.length === 0) {
+      return
+    }
+
+    setActiveAudioAction('add')
+    setAudioError(null)
+
+    try {
+      const nextTracks = await Promise.all(
+        selectedFiles.map(async (selectedFile) => {
+          const sourcePath = URL.createObjectURL(selectedFile)
+          const duration = await readAudioFileDuration(sourcePath)
+
+          return {
+            duration,
+            id: createPlaylistTrackId(),
+            name: selectedFile.name,
+            sourcePath,
+            sourceType: 'device' as const,
+          }
+        }),
+      )
+
+      const nextPlaylist = [...tracks, ...nextTracks]
+      commitPlaylistTracks(nextPlaylist)
+
+      if (!currentTrack && nextTracks[0]) {
+        commitSelectedTrackId(nextTracks[0].id)
+      }
+
+      onRequestPlaylistOpen?.()
+    } catch (error) {
+      setAudioError(readMagePlayerErrorMessage(error))
+    } finally {
+      setActiveAudioAction(null)
+      audioInput.value = ''
+    }
+  }
+
+  function handleSeekAudio(event: ChangeEvent<HTMLInputElement>) {
+    const player = playerRef.current
+
+    if (!player || status !== 'ready' || controlsBusy || !audioState.isLoaded) {
+      return
+    }
+
+    try {
+      setAudioState(player.seekAudio(Number(event.currentTarget.value)))
+      setAudioError(null)
+    } catch (error) {
+      setAudioError(readMagePlayerErrorMessage(error))
+    }
+  }
+
+  function handleToggleVolumePanel() {
+    if (!audioState.isLoaded || controlsBusy) {
+      return
+    }
+
+    setIsVolumeOpen((currentState) => !currentState)
+  }
+
+  function handleVolumeChange(event: ChangeEvent<HTMLInputElement>) {
+    const player = playerRef.current
+
+    if (!player || status !== 'ready' || controlsBusy) {
+      return
+    }
+
+    try {
+      setAudioState(player.setAudioVolume(Number(event.currentTarget.value)))
+      setAudioError(null)
+    } catch (error) {
+      setAudioError(readMagePlayerErrorMessage(error))
+    }
+  }
+
+  function handleTrackSummaryClick(event: ReactMouseEvent<HTMLButtonElement>) {
+    onRequestPlaylistOpen?.()
+    blurMouseActivatedControl(event.currentTarget, event.detail)
+  }
+
   let title = 'No scene selected.'
   let message = 'Pass a scene blob into this player to render it in the browser.'
   let role: 'alert' | 'status' = 'status'
@@ -195,48 +561,41 @@ export function MagePlayer({
     role = 'alert'
   }
 
-  const playbackLabel = playbackState === 'playing' ? 'Pause' : 'Play'
-
-  function handleTogglePlayback(event: ReactMouseEvent<HTMLButtonElement>) {
-    const player = playerRef.current
-
-    if (!player || status !== 'ready') {
-      return
-    }
-
-    const nextPlaybackState = playbackState === 'playing' ? 'paused' : 'playing'
-    setPlaybackState(player.setPlaybackState(nextPlaybackState))
-
-    // Mouse clicks should not leave the hover bar pinned open via :focus-within.
-    // Keep keyboard-triggered activation focused so keyboard users can continue interacting.
-    if (event.detail > 0) {
-      const controlButton = event.currentTarget
-
-      window.requestAnimationFrame(() => {
-        controlButton.blur()
-      })
-    }
-  }
-
   return (
-    <section className={buildClassName('mage-player', className)} data-state={status}>
+    <section className={buildMagePlayerClassName('mage-player', className)} data-state={status}>
       <div className="mage-player__viewport" aria-busy={status === 'loading'}>
         <canvas aria-label={ariaLabel} className="mage-player__canvas" ref={canvasRef} />
+        <input
+          accept="audio/*"
+          className="mage-player__audio-input"
+          hidden
+          multiple
+          onChange={() => {
+            void handleAudioSelection()
+          }}
+          ref={audioInputRef}
+          type="file"
+        />
         {status === 'ready' ? (
-          <div className="mage-player__controls">
-            <button
-              aria-label={`${playbackLabel} scene playback`}
-              aria-pressed={playbackState === 'playing'}
-              className="mage-player__control-button"
-              onClick={handleTogglePlayback}
-              title={`${playbackLabel} scene playback`}
-              type="button"
-            >
-              <span className="mage-player__control-icon">
-                {playbackState === 'playing' ? <PauseIcon /> : <PlayIcon />}
-              </span>
-            </button>
-          </div>
+          <MagePlayerControls
+            addButtonLabel={addButtonLabel}
+            audioError={audioError}
+            audioProgressPercent={audioProgressPercent}
+            audioState={audioState}
+            controlsBusy={controlsBusy}
+            currentTrack={currentTrack}
+            currentTrackIndex={currentTrackIndex}
+            isVolumeOpen={isVolumeOpen}
+            onOpenAudioPicker={handleOpenAudioPicker}
+            onSeekAudio={handleSeekAudio}
+            onTogglePlayback={handleTogglePlayback}
+            onToggleVolumePanel={handleToggleVolumePanel}
+            onTrackSummaryClick={handleTrackSummaryClick}
+            onVolumeChange={handleVolumeChange}
+            playbackState={playbackState}
+            tracksCount={tracks.length}
+            volumeControlRef={volumeControlRef}
+          />
         ) : null}
         {status !== 'ready' ? (
           <div className="mage-player__overlay" role={role} aria-live="polite">

--- a/src/components/mage-player/MagePlayerControls.tsx
+++ b/src/components/mage-player/MagePlayerControls.tsx
@@ -1,0 +1,195 @@
+import { type ChangeEvent, type CSSProperties, type MouseEvent as ReactMouseEvent, type RefObject } from 'react'
+import {
+  readPlaylistTrackSummaryName,
+  type MagePlayerPlaylistTrack,
+} from '../../lib/magePlayerPlaylist'
+import {
+  type MagePlayerAudioState,
+  type MagePlayerPlaybackState,
+} from '../../lib/magePlayerAdapter'
+import { formatAudioTime } from './magePlayerUtils'
+
+type MagePlayerControlsProps = {
+  addButtonLabel: string
+  audioError: string | null
+  audioProgressPercent: string
+  audioState: MagePlayerAudioState
+  controlsBusy: boolean
+  currentTrack: MagePlayerPlaylistTrack | null
+  currentTrackIndex: number
+  isVolumeOpen: boolean
+  onOpenAudioPicker: (event: ReactMouseEvent<HTMLButtonElement>) => void
+  onSeekAudio: (event: ChangeEvent<HTMLInputElement>) => void
+  onTogglePlayback: (event: ReactMouseEvent<HTMLButtonElement>) => void
+  onToggleVolumePanel: () => void
+  onTrackSummaryClick: (event: ReactMouseEvent<HTMLButtonElement>) => void
+  onVolumeChange: (event: ChangeEvent<HTMLInputElement>) => void
+  playbackState: MagePlayerPlaybackState
+  tracksCount: number
+  volumeControlRef: RefObject<HTMLDivElement | null>
+}
+
+function PauseIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24">
+      <path d="M7 5h4v14H7zm6 0h4v14h-4z" fill="currentColor" />
+    </svg>
+  )
+}
+
+function PlayIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24">
+      <path d="M8 5.5v13L18.5 12 8 5.5Z" fill="currentColor" />
+    </svg>
+  )
+}
+
+function VolumeIcon({ muted }: { muted: boolean }) {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24">
+      {muted ? (
+        <path
+          d="M15.3 8.7a1 1 0 0 1 1.4 0L19 11l2.3-2.3a1 1 0 1 1 1.4 1.4L20.4 12l2.3 2.3a1 1 0 0 1-1.4 1.4L19 13.4l-2.3 2.3a1 1 0 1 1-1.4-1.4l2.3-2.3-2.3-2.3a1 1 0 0 1 0-1.4ZM4 9h3.2l4-3.6A1 1 0 0 1 13 6.1v11.8a1 1 0 0 1-1.8.7l-4-3.6H4a1 1 0 0 1-1-1v-4a1 1 0 0 1 1-1Z"
+          fill="currentColor"
+        />
+      ) : (
+        <path
+          d="M4 9h3.2l4-3.6A1 1 0 0 1 13 6.1v11.8a1 1 0 0 1-1.8.7l-4-3.6H4a1 1 0 0 1-1-1v-4a1 1 0 0 1 1-1Zm12.5-1.2a1 1 0 0 1 1.4 0 6 6 0 0 1 0 8.5 1 1 0 1 1-1.4-1.4 4 4 0 0 0 0-5.7 1 1 0 0 1 0-1.4Zm2.8-2.8a1 1 0 0 1 1.4 0 10 10 0 0 1 0 14.1 1 1 0 0 1-1.4-1.4 8 8 0 0 0 0-11.3 1 1 0 0 1 0-1.4Z"
+          fill="currentColor"
+        />
+      )}
+    </svg>
+  )
+}
+
+export function MagePlayerControls({
+  addButtonLabel,
+  audioError,
+  audioProgressPercent,
+  audioState,
+  controlsBusy,
+  currentTrack,
+  currentTrackIndex,
+  isVolumeOpen,
+  onOpenAudioPicker,
+  onSeekAudio,
+  onTogglePlayback,
+  onToggleVolumePanel,
+  onTrackSummaryClick,
+  onVolumeChange,
+  playbackState,
+  tracksCount,
+  volumeControlRef,
+}: MagePlayerControlsProps) {
+  const playbackLabel = playbackState === 'playing' ? 'Pause' : 'Play'
+  const trackSummaryLabel = currentTrack
+    ? `Track ${currentTrackIndex}/${tracksCount}: ${readPlaylistTrackSummaryName(currentTrack)}`
+    : 'Track 0/0: No track selected'
+
+  return (
+    <div className="mage-player__controls">
+      <div className="mage-player__controls-main">
+        <div className="mage-player__control-meta">
+          {tracksCount > 0 ? (
+            <button className="mage-player__track-summary" onClick={onTrackSummaryClick} type="button">
+              {trackSummaryLabel}
+            </button>
+          ) : (
+            <span className="mage-player__audio-label">{trackSummaryLabel}</span>
+          )}
+          {audioError ? (
+            <span className="mage-player__control-feedback" role="alert">
+              {audioError}
+            </span>
+          ) : null}
+        </div>
+        <div className="mage-player__timeline">
+          <span className="mage-player__time-label">{formatAudioTime(audioState.currentTime)}</span>
+          <input
+            aria-label="Seek scene audio"
+            className="mage-player__timeline-slider"
+            disabled={!audioState.isLoaded || audioState.duration <= 0 || controlsBusy}
+            max={audioState.duration > 0 ? audioState.duration : 0}
+            min={0}
+            onChange={onSeekAudio}
+            step={0.01}
+            style={{ '--mage-player-progress': audioProgressPercent } as CSSProperties}
+            title={
+              audioState.isLoaded
+                ? 'Seek through the loaded audio.'
+                : 'Add audio to enable scrubbing.'
+            }
+            type="range"
+            value={Math.min(audioState.currentTime, audioState.duration)}
+          />
+          <span className="mage-player__time-label">{formatAudioTime(audioState.duration)}</span>
+        </div>
+      </div>
+      <div className="mage-player__control-actions">
+        <button
+          aria-label="Add audio tracks"
+          className="mage-player__control-button mage-player__control-button--text"
+          disabled={controlsBusy}
+          onClick={onOpenAudioPicker}
+          title="Add audio tracks from your device."
+          type="button"
+        >
+          {addButtonLabel}
+        </button>
+        <div className="mage-player__volume-control" ref={volumeControlRef}>
+          <button
+            aria-controls="mage-player-volume-panel"
+            aria-expanded={isVolumeOpen}
+            aria-label="Adjust audio volume"
+            className="mage-player__control-button"
+            disabled={!audioState.isLoaded || controlsBusy}
+            onClick={onToggleVolumePanel}
+            title={
+              audioState.isLoaded
+                ? 'Adjust audio volume'
+                : 'Add audio to enable volume controls'
+            }
+            type="button"
+          >
+            <span className="mage-player__control-icon">
+              <VolumeIcon muted={audioState.volume <= 0.001} />
+            </span>
+          </button>
+          {isVolumeOpen ? (
+            <div className="mage-player__volume-panel" id="mage-player-volume-panel">
+              <label className="mage-player__volume-label" htmlFor="mage-player-volume-slider">
+                Volume
+              </label>
+              <input
+                aria-label="Audio volume"
+                className="mage-player__volume-slider"
+                id="mage-player-volume-slider"
+                max={1}
+                min={0}
+                onChange={onVolumeChange}
+                step={0.01}
+                type="range"
+                value={audioState.volume}
+              />
+              <span className="mage-player__volume-value">{Math.round(audioState.volume * 100)}%</span>
+            </div>
+          ) : null}
+        </div>
+        <button
+          aria-label={`${playbackLabel} scene and audio playback`}
+          aria-pressed={playbackState === 'playing'}
+          className="mage-player__control-button"
+          disabled={controlsBusy}
+          onClick={onTogglePlayback}
+          title={`${playbackLabel} scene and audio playback`}
+          type="button"
+        >
+          <span className="mage-player__control-icon">
+            {playbackState === 'playing' ? <PauseIcon /> : <PlayIcon />}
+          </span>
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/mage-player/magePlayer.css
+++ b/src/components/mage-player/magePlayer.css
@@ -1,0 +1,394 @@
+.mage-player {
+  width: 50%;
+}
+
+.mage-player__viewport {
+  position: relative;
+  overflow: hidden;
+  aspect-ratio: 1 / 1;
+  border-radius: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background:
+    radial-gradient(circle at 24% 18%, rgba(99, 240, 214, 0.16), transparent 28%),
+    radial-gradient(circle at 78% 74%, rgba(118, 196, 255, 0.16), transparent 30%),
+    linear-gradient(180deg, rgba(2, 8, 11, 0.42), rgba(2, 8, 11, 0.82));
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.03),
+    0 24px 70px rgba(0, 0, 0, 0.34);
+}
+
+.mage-player__viewport::after {
+  content: "";
+  position: absolute;
+  inset: 14px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  pointer-events: none;
+}
+
+.mage-player__canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.mage-player__controls {
+  position: absolute;
+  inset: auto 0 0 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 18px;
+  padding: 44px 18px 18px;
+  border-bottom-left-radius: inherit;
+  border-bottom-right-radius: inherit;
+  background: linear-gradient(
+    180deg,
+    rgba(6, 13, 16, 0),
+    rgba(6, 13, 16, 0.12) 20%,
+    rgba(6, 13, 16, 0.7) 74%,
+    rgba(6, 13, 16, 0.92)
+  );
+  opacity: 0;
+  transform: translateY(14px);
+  pointer-events: none;
+  transition:
+    opacity 180ms ease,
+    transform 180ms ease;
+  z-index: 1;
+}
+
+.mage-player__controls-main {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+}
+
+.mage-player__control-meta {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.mage-player__timeline {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+}
+
+.mage-player__time-label {
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 0.79rem;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+}
+
+.mage-player__audio-label,
+.mage-player__track-summary,
+.mage-player__control-feedback {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mage-player__audio-label,
+.mage-player__track-summary {
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 0.77rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mage-player__track-summary {
+  justify-self: start;
+  max-width: 100%;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  font-size: 0.82rem;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  transition: color 160ms ease;
+}
+
+.mage-player__track-summary:hover,
+.mage-player__track-summary:focus-visible {
+  color: #f2fffd;
+  outline: none;
+}
+
+.mage-player__control-feedback {
+  color: #ffc4b9;
+  font-size: 0.83rem;
+  line-height: 1.3;
+}
+
+.mage-player__timeline-slider,
+.mage-player__volume-slider {
+  appearance: none;
+  width: 100%;
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+  cursor: pointer;
+}
+
+.mage-player__timeline-slider {
+  background:
+    linear-gradient(
+      90deg,
+      rgba(99, 240, 214, 0.95) 0,
+      rgba(99, 240, 214, 0.95) var(--mage-player-progress, 0%),
+      rgba(255, 255, 255, 0.2) var(--mage-player-progress, 0%),
+      rgba(255, 255, 255, 0.2) 100%
+    );
+}
+
+.mage-player__timeline-slider:disabled,
+.mage-player__volume-slider:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.mage-player__timeline-slider::-webkit-slider-runnable-track,
+.mage-player__volume-slider::-webkit-slider-runnable-track {
+  height: 4px;
+  border-radius: 999px;
+  background: transparent;
+}
+
+.mage-player__timeline-slider::-moz-range-track,
+.mage-player__volume-slider::-moz-range-track {
+  height: 4px;
+  border-radius: 999px;
+  background: transparent;
+}
+
+.mage-player__timeline-slider::-webkit-slider-thumb,
+.mage-player__volume-slider::-webkit-slider-thumb {
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  margin-top: -5px;
+  border: 0;
+  border-radius: 50%;
+  background: #f4fffd;
+  box-shadow: 0 0 0 4px rgba(99, 240, 214, 0.14);
+}
+
+.mage-player__timeline-slider::-moz-range-thumb,
+.mage-player__volume-slider::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border: 0;
+  border-radius: 50%;
+  background: #f4fffd;
+  box-shadow: 0 0 0 4px rgba(99, 240, 214, 0.14);
+}
+
+.mage-player__control-actions {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.mage-player__control-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  padding: 0;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--text);
+  font: inherit;
+  cursor: pointer;
+  transition:
+    background-color 160ms ease,
+    color 160ms ease,
+    transform 160ms ease,
+    border-color 160ms ease,
+    opacity 160ms ease;
+}
+
+.mage-player__control-button:hover,
+.mage-player__control-button:focus-visible {
+  background: rgba(99, 240, 214, 0.22);
+  border-color: rgba(99, 240, 214, 0.34);
+  color: var(--accent);
+  outline: none;
+}
+
+.mage-player__control-button[aria-pressed="true"] {
+  background: rgba(99, 240, 214, 0.2);
+  border-color: rgba(99, 240, 214, 0.34);
+  color: var(--accent);
+}
+
+.mage-player__control-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.mage-player__control-button:disabled:hover,
+.mage-player__control-button:disabled:focus-visible {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.1);
+  color: var(--text);
+}
+
+.mage-player__control-button:active {
+  transform: translateY(1px);
+}
+
+.mage-player__control-button--text {
+  width: auto;
+  min-width: 70px;
+  padding: 0 16px;
+  font-size: 0.83rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.mage-player__control-icon {
+  display: inline-flex;
+  width: 1rem;
+  height: 1rem;
+}
+
+.mage-player__control-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.mage-player__volume-control {
+  position: relative;
+}
+
+.mage-player__volume-panel {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 10px);
+  display: grid;
+  gap: 10px;
+  width: 170px;
+  padding: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  background: rgba(8, 16, 20, 0.95);
+  box-shadow: 0 18px 34px rgba(0, 0, 0, 0.34);
+}
+
+.mage-player__volume-label,
+.mage-player__volume-value {
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 0.77rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mage-player__volume-value {
+  justify-self: end;
+}
+
+.mage-player[data-state="ready"] .mage-player__viewport:hover .mage-player__controls,
+.mage-player[data-state="ready"] .mage-player__viewport:focus-within .mage-player__controls {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.mage-player__overlay {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 28px;
+  background: linear-gradient(
+    180deg,
+    rgba(4, 12, 14, 0.78),
+    rgba(4, 12, 14, 0.92)
+  );
+  text-align: center;
+}
+
+.mage-player__overlay-copy {
+  display: grid;
+  gap: 10px;
+  max-width: 26rem;
+}
+
+.mage-player__overlay-copy strong {
+  font-size: 1.05rem;
+  letter-spacing: -0.02em;
+}
+
+.mage-player__overlay-copy p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+@media (max-width: 560px) {
+  .mage-player__viewport {
+    min-height: 260px;
+    border-radius: 22px;
+  }
+
+  .mage-player__overlay {
+    padding: 22px;
+  }
+
+  .mage-player__controls {
+    grid-template-columns: minmax(0, 1fr);
+    padding: 34px 14px 14px;
+  }
+
+  .mage-player__controls-main,
+  .mage-player__control-meta,
+  .mage-player__control-actions {
+    width: 100%;
+  }
+
+  .mage-player__control-actions {
+    justify-content: flex-start;
+  }
+
+  .mage-player__timeline {
+    gap: 10px;
+  }
+
+  .mage-player__volume-panel {
+    left: 0;
+    right: auto;
+  }
+
+  .mage-player__control-button {
+    width: 44px;
+    height: 44px;
+  }
+
+  .mage-player__control-button--text {
+    width: auto;
+    min-width: 68px;
+    padding: 0 14px;
+  }
+}
+
+@media (hover: none), (pointer: coarse) {
+  .mage-player[data-state="ready"] .mage-player__controls {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+}

--- a/src/components/mage-player/magePlayerUtils.ts
+++ b/src/components/mage-player/magePlayerUtils.ts
@@ -1,0 +1,88 @@
+import type { MagePlayerAudioState } from '../../lib/magePlayerAdapter'
+
+export type MagePlayerStatus = 'empty' | 'loading' | 'ready' | 'error'
+
+export const EMPTY_AUDIO_STATE: MagePlayerAudioState = {
+  currentTime: 0,
+  duration: 0,
+  hasSource: false,
+  isLoaded: false,
+  sourcePath: null,
+  volume: 1,
+}
+
+export function buildMagePlayerClassName(baseClassName: string, nextClassName?: string) {
+  return nextClassName ? `${baseClassName} ${nextClassName}` : baseClassName
+}
+
+export function readMagePlayerErrorMessage(error: unknown) {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message
+  }
+
+  return 'MAGE could not render this scene.'
+}
+
+export function audioStatesMatch(currentState: MagePlayerAudioState, nextState: MagePlayerAudioState) {
+  return (
+    currentState.currentTime === nextState.currentTime &&
+    currentState.duration === nextState.duration &&
+    currentState.hasSource === nextState.hasSource &&
+    currentState.isLoaded === nextState.isLoaded &&
+    currentState.sourcePath === nextState.sourcePath &&
+    currentState.volume === nextState.volume
+  )
+}
+
+export function formatAudioTime(seconds: number | null) {
+  const safeSeconds = Number.isFinite(seconds) ? Math.max(seconds ?? 0, 0) : 0
+  const roundedSeconds = Math.floor(safeSeconds)
+  const hours = Math.floor(roundedSeconds / 3600)
+  const minutes = Math.floor((roundedSeconds % 3600) / 60)
+  const remainingSeconds = roundedSeconds % 60
+
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(remainingSeconds).padStart(2, '0')}`
+  }
+
+  return `${minutes}:${String(remainingSeconds).padStart(2, '0')}`
+}
+
+export function createPlaylistTrackId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+
+  return `track-${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
+export function readAudioFileDuration(sourcePath: string) {
+  return new Promise<number>((resolve) => {
+    const probe = document.createElement('audio')
+    let timeoutId = 0
+
+    function cleanup() {
+      window.clearTimeout(timeoutId)
+      probe.removeEventListener('loadedmetadata', handleLoadedMetadata)
+      probe.removeEventListener('error', handleError)
+      probe.src = ''
+    }
+
+    function handleLoadedMetadata() {
+      const duration = Number.isFinite(probe.duration) ? Math.max(probe.duration, 0) : 0
+      cleanup()
+      resolve(duration)
+    }
+
+    function handleError() {
+      cleanup()
+      resolve(0)
+    }
+
+    probe.preload = 'metadata'
+    probe.addEventListener('loadedmetadata', handleLoadedMetadata)
+    probe.addEventListener('error', handleError)
+    timeoutId = window.setTimeout(handleError, 300)
+    probe.src = sourcePath
+  })
+}

--- a/src/components/mage-player/useMagePlayerPlaylist.ts
+++ b/src/components/mage-player/useMagePlayerPlaylist.ts
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  buildScenePlaylistTrack,
+  revokePlaylistTrackSources,
+  type MagePlayerPlaylistTrack,
+} from '../../lib/magePlayerPlaylist'
+import type { MageSceneBlob } from '../../lib/magePlayerAdapter'
+
+type UseMagePlayerPlaylistArgs = {
+  onPlaylistChange?: (tracks: MagePlayerPlaylistTrack[]) => void
+  onSelectedTrackChange?: (trackId: string | null) => void
+  onTrackDurationChange?: (trackId: string, duration: number) => void
+  playlistTracks?: MagePlayerPlaylistTrack[]
+  sceneBlob: MageSceneBlob | null | undefined
+  selectedTrackId?: string | null
+}
+
+export function useMagePlayerPlaylist({
+  onPlaylistChange,
+  onSelectedTrackChange,
+  onTrackDurationChange,
+  playlistTracks,
+  sceneBlob,
+  selectedTrackId,
+}: UseMagePlayerPlaylistArgs) {
+  const isPlaylistControlled = playlistTracks !== undefined
+  const isSelectionControlled = selectedTrackId !== undefined
+  const [internalPlaylistTracks, setInternalPlaylistTracks] = useState<MagePlayerPlaylistTrack[]>(() => {
+    const sceneTrack = buildScenePlaylistTrack(sceneBlob)
+    return sceneTrack ? [sceneTrack] : []
+  })
+  const [internalSelectedTrackId, setInternalSelectedTrackId] = useState<string | null>(() => {
+    const sceneTrack = buildScenePlaylistTrack(sceneBlob)
+    return sceneTrack?.id ?? null
+  })
+  const internalPlaylistTracksRef = useRef<MagePlayerPlaylistTrack[]>(internalPlaylistTracks)
+
+  const tracks = playlistTracks ?? internalPlaylistTracks
+  const activeSelectedTrackId = selectedTrackId ?? internalSelectedTrackId
+  const currentTrack = tracks.find((track) => track.id === activeSelectedTrackId) ?? null
+  const currentTrackIndex = currentTrack ? tracks.findIndex((track) => track.id === currentTrack.id) + 1 : 0
+
+  const commitPlaylistTracks = useCallback((nextTracks: MagePlayerPlaylistTrack[]) => {
+    if (!isPlaylistControlled) {
+      setInternalPlaylistTracks(nextTracks)
+    }
+
+    onPlaylistChange?.(nextTracks)
+  }, [isPlaylistControlled, onPlaylistChange])
+
+  const commitSelectedTrackId = useCallback((nextTrackId: string | null) => {
+    if (!isSelectionControlled) {
+      setInternalSelectedTrackId(nextTrackId)
+    }
+
+    onSelectedTrackChange?.(nextTrackId)
+  }, [isSelectionControlled, onSelectedTrackChange])
+
+  const commitTrackDuration = useCallback((trackId: string, duration: number) => {
+    if (!Number.isFinite(duration) || duration <= 0) {
+      return
+    }
+
+    if (!isPlaylistControlled) {
+      setInternalPlaylistTracks((currentTracks) =>
+        currentTracks.map((track) => (track.id === trackId ? { ...track, duration } : track)),
+      )
+    }
+
+    onTrackDurationChange?.(trackId, duration)
+  }, [isPlaylistControlled, onTrackDurationChange])
+
+  useEffect(() => {
+    internalPlaylistTracksRef.current = internalPlaylistTracks
+  }, [internalPlaylistTracks])
+
+  useEffect(() => {
+    return () => {
+      revokePlaylistTrackSources(internalPlaylistTracksRef.current)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (isPlaylistControlled) {
+      return
+    }
+
+    setInternalPlaylistTracks((currentTracks) => {
+      revokePlaylistTrackSources(currentTracks)
+
+      const sceneTrack = buildScenePlaylistTrack(sceneBlob)
+      return sceneTrack ? [sceneTrack] : []
+    })
+
+    setInternalSelectedTrackId(() => {
+      const sceneTrack = buildScenePlaylistTrack(sceneBlob)
+      return sceneTrack?.id ?? null
+    })
+  }, [isPlaylistControlled, sceneBlob])
+
+  useEffect(() => {
+    if (isPlaylistControlled || !sceneBlob || tracks.length > 0) {
+      return
+    }
+
+    const sceneTrack = buildScenePlaylistTrack(sceneBlob)
+
+    if (!sceneTrack) {
+      return
+    }
+
+    commitPlaylistTracks([sceneTrack])
+    commitSelectedTrackId(sceneTrack.id)
+  }, [isPlaylistControlled, sceneBlob, tracks.length])
+
+  useEffect(() => {
+    if (tracks.length === 0) {
+      if (activeSelectedTrackId !== null) {
+        commitSelectedTrackId(null)
+      }
+
+      return
+    }
+
+    if (!currentTrack) {
+      commitSelectedTrackId(tracks[0].id)
+    }
+  }, [activeSelectedTrackId, currentTrack, tracks])
+
+  return {
+    activeSelectedTrackId,
+    commitPlaylistTracks,
+    commitSelectedTrackId,
+    commitTrackDuration,
+    currentTrack,
+    currentTrackIndex,
+    tracks,
+  }
+}

--- a/src/components/scene-detail/PlaylistPanel.tsx
+++ b/src/components/scene-detail/PlaylistPanel.tsx
@@ -1,0 +1,344 @@
+import { useEffect, useState, type ChangeEvent, type DragEvent, type KeyboardEvent } from 'react'
+import type { MagePlayerPlaylistTrack } from '../../lib/magePlayerPlaylist'
+import { PlaylistTrackRow } from './PlaylistTrackRow'
+import { EditIcon, RepeatIcon, ShuffleIcon } from './playlistPanelIcons'
+import './playlistPanel.css'
+
+type PlaylistDropIndicator = {
+  position: 'after' | 'before'
+  trackId: string
+}
+
+type PlaylistPanelProps = {
+  isOpen: boolean
+  onClose: () => void
+  onPlaylistNameChange: (name: string) => void
+  onRemoveTrack: (trackId: string) => void
+  onReorderTracks: (tracks: MagePlayerPlaylistTrack[]) => void
+  onSelectTrack: (trackId: string | null) => void
+  onToggleRepeat: () => void
+  onToggleShuffle: () => void
+  onUpdateTrack: (
+    trackId: string,
+    nextDetails: Partial<Pick<MagePlayerPlaylistTrack, 'album' | 'artist' | 'title'>>,
+  ) => void
+  playlistName: string
+  playlistTracks: MagePlayerPlaylistTrack[]
+  repeatEnabled: boolean
+  selectedTrackId: string | null
+  shuffleEnabled: boolean
+}
+
+function buildTrackCountLabel(trackCount: number) {
+  return `${trackCount} track${trackCount === 1 ? '' : 's'}`
+}
+
+export function PlaylistPanel({
+  isOpen,
+  onClose,
+  onPlaylistNameChange,
+  onRemoveTrack,
+  onReorderTracks,
+  onSelectTrack,
+  onToggleRepeat,
+  onToggleShuffle,
+  onUpdateTrack,
+  playlistName,
+  playlistTracks,
+  repeatEnabled,
+  selectedTrackId,
+  shuffleEnabled,
+}: PlaylistPanelProps) {
+  const [isEditingPlaylist, setIsEditingPlaylist] = useState(false)
+  const [editingTrackId, setEditingTrackId] = useState<string | null>(null)
+  const [draggedTrackId, setDraggedTrackId] = useState<string | null>(null)
+  const [dropIndicator, setDropIndicator] = useState<PlaylistDropIndicator | null>(null)
+  const [isRenamingPlaylist, setIsRenamingPlaylist] = useState(false)
+  const [playlistNameDraft, setPlaylistNameDraft] = useState(playlistName)
+
+  useEffect(() => {
+    if (!isOpen || playlistTracks.length === 0) {
+      setIsEditingPlaylist(false)
+    }
+  }, [isOpen, playlistTracks.length])
+
+  useEffect(() => {
+    if (!isEditingPlaylist || !isOpen || playlistTracks.length <= 1) {
+      setDraggedTrackId(null)
+      setDropIndicator(null)
+    }
+  }, [isEditingPlaylist, isOpen, playlistTracks.length])
+
+  useEffect(() => {
+    if (!isEditingPlaylist || !isOpen) {
+      setEditingTrackId(null)
+      setIsRenamingPlaylist(false)
+    }
+  }, [isEditingPlaylist, isOpen])
+
+  useEffect(() => {
+    if (editingTrackId && !playlistTracks.some((track) => track.id === editingTrackId)) {
+      setEditingTrackId(null)
+    }
+  }, [editingTrackId, playlistTracks])
+
+  useEffect(() => {
+    setPlaylistNameDraft(playlistName)
+  }, [playlistName])
+
+  function commitPlaylistName() {
+    onPlaylistNameChange(playlistNameDraft.trim() || 'Playlist')
+    setIsRenamingPlaylist(false)
+  }
+
+  function handlePlaylistNameKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      commitPlaylistName()
+    }
+
+    if (event.key === 'Escape') {
+      setPlaylistNameDraft(playlistName)
+      setIsRenamingPlaylist(false)
+    }
+  }
+
+  function readDropPosition(event: DragEvent<HTMLDivElement>) {
+    const { height, top } = event.currentTarget.getBoundingClientRect()
+    return event.clientY >= top + height / 2 ? 'after' : 'before'
+  }
+
+  function reorderTracks(
+    sourceTrackId: string,
+    targetTrackId: string,
+    position: PlaylistDropIndicator['position'],
+  ) {
+    if (sourceTrackId === targetTrackId) {
+      return null
+    }
+
+    const sourceIndex = playlistTracks.findIndex((track) => track.id === sourceTrackId)
+    const targetIndex = playlistTracks.findIndex((track) => track.id === targetTrackId)
+
+    if (sourceIndex === -1 || targetIndex === -1) {
+      return null
+    }
+
+    const nextTracks = [...playlistTracks]
+    const [movedTrack] = nextTracks.splice(sourceIndex, 1)
+    let insertionIndex = targetIndex
+
+    if (sourceIndex < targetIndex) {
+      insertionIndex -= 1
+    }
+
+    if (position === 'after') {
+      insertionIndex += 1
+    }
+
+    insertionIndex = Math.max(0, Math.min(insertionIndex, nextTracks.length))
+    nextTracks.splice(insertionIndex, 0, movedTrack)
+
+    const didOrderChange = nextTracks.some((track, index) => track.id !== playlistTracks[index]?.id)
+    return didOrderChange ? nextTracks : null
+  }
+
+  function handleTrackDragStart(event: DragEvent<HTMLDivElement>, trackId: string) {
+    if (!isEditingPlaylist || playlistTracks.length <= 1) {
+      return
+    }
+
+    setEditingTrackId(null)
+    setDraggedTrackId(trackId)
+    setDropIndicator(null)
+    event.dataTransfer.effectAllowed = 'move'
+    event.dataTransfer.setData('text/plain', trackId)
+  }
+
+  function handleTrackDragOver(event: DragEvent<HTMLDivElement>, targetTrackId: string) {
+    if (!isEditingPlaylist || playlistTracks.length <= 1) {
+      return
+    }
+
+    const sourceTrackId = draggedTrackId ?? event.dataTransfer.getData('text/plain')
+
+    if (!sourceTrackId || sourceTrackId === targetTrackId) {
+      return
+    }
+
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'move'
+
+    const nextDropIndicator = {
+      position: readDropPosition(event),
+      trackId: targetTrackId,
+    } satisfies PlaylistDropIndicator
+
+    setDropIndicator((currentIndicator) => {
+      if (
+        currentIndicator?.trackId === nextDropIndicator.trackId &&
+        currentIndicator.position === nextDropIndicator.position
+      ) {
+        return currentIndicator
+      }
+
+      return nextDropIndicator
+    })
+  }
+
+  function handleTrackDrop(event: DragEvent<HTMLDivElement>, targetTrackId: string) {
+    if (!isEditingPlaylist || playlistTracks.length <= 1) {
+      return
+    }
+
+    event.preventDefault()
+
+    const sourceTrackId = draggedTrackId ?? event.dataTransfer.getData('text/plain')
+    const nextTracks = sourceTrackId
+      ? reorderTracks(sourceTrackId, targetTrackId, readDropPosition(event))
+      : null
+
+    if (nextTracks) {
+      onReorderTracks(nextTracks)
+    }
+
+    setDraggedTrackId(null)
+    setDropIndicator(null)
+  }
+
+  function handleTrackEditorChange(
+    trackId: string,
+    key: 'album' | 'artist' | 'title',
+    event: ChangeEvent<HTMLInputElement>,
+  ) {
+    onUpdateTrack(trackId, {
+      [key]: event.currentTarget.value,
+    })
+  }
+
+  if (!isOpen) {
+    return null
+  }
+
+  return (
+    <section className="mage-watch__playlist-panel">
+      <header className="mage-watch__playlist-header">
+        <div className="mage-watch__playlist-heading">
+          {isEditingPlaylist ? (
+            isRenamingPlaylist ? (
+              <input
+                aria-label="Playlist name"
+                autoFocus
+                className="mage-watch__playlist-name-input"
+                onBlur={commitPlaylistName}
+                onChange={(event) => {
+                  setPlaylistNameDraft(event.currentTarget.value)
+                }}
+                onKeyDown={handlePlaylistNameKeyDown}
+                type="text"
+                value={playlistNameDraft}
+              />
+            ) : (
+              <button
+                aria-label="Rename playlist"
+                className="mage-watch__playlist-name-button"
+                onClick={() => {
+                  setPlaylistNameDraft(playlistName)
+                  setIsRenamingPlaylist(true)
+                }}
+                title="Rename playlist"
+                type="button"
+              >
+                <strong>{playlistName}</strong>
+              </button>
+            )
+          ) : (
+            <strong>{playlistName}</strong>
+          )}
+          <span>{buildTrackCountLabel(playlistTracks.length)}</span>
+        </div>
+        <div className="mage-watch__playlist-actions">
+          <button
+            aria-label={`${shuffleEnabled ? 'Disable' : 'Enable'} shuffle playback`}
+            aria-pressed={shuffleEnabled}
+            className="mage-watch__playlist-action mage-watch__playlist-action--icon"
+            disabled={playlistTracks.length <= 1}
+            onClick={onToggleShuffle}
+            title="Shuffle"
+            type="button"
+          >
+            <ShuffleIcon />
+          </button>
+          <button
+            aria-label={`${repeatEnabled ? 'Disable' : 'Enable'} repeat playback`}
+            aria-pressed={repeatEnabled}
+            className="mage-watch__playlist-action mage-watch__playlist-action--icon"
+            disabled={playlistTracks.length === 0}
+            onClick={onToggleRepeat}
+            title="Repeat"
+            type="button"
+          >
+            <RepeatIcon />
+          </button>
+          {playlistTracks.length > 0 ? (
+            <button
+              aria-label={`${isEditingPlaylist ? 'Finish' : 'Edit'} playlist`}
+              aria-pressed={isEditingPlaylist}
+              className="mage-watch__playlist-action mage-watch__playlist-action--icon"
+              onClick={() => {
+                setIsEditingPlaylist((currentValue) => !currentValue)
+              }}
+              title={isEditingPlaylist ? 'Done editing' : 'Edit playlist'}
+              type="button"
+            >
+              <EditIcon />
+            </button>
+          ) : null}
+          <button
+            aria-label="Close playlist"
+            className="mage-watch__playlist-action mage-watch__playlist-action--close"
+            onClick={onClose}
+            type="button"
+          >
+            Close
+          </button>
+        </div>
+      </header>
+      {playlistTracks.length === 0 ? (
+        <p className="mage-watch__playlist-empty">Add tracks from the player to build a playlist.</p>
+      ) : (
+        <div className="mage-watch__playlist-list">
+          {playlistTracks.map((track, index) => (
+            <PlaylistTrackRow
+              dropPosition={dropIndicator?.trackId === track.id ? dropIndicator.position : undefined}
+              editingTrackId={editingTrackId}
+              draggedTrackId={draggedTrackId}
+              index={index}
+              isDropTarget={dropIndicator?.trackId === track.id}
+              isEditingPlaylist={isEditingPlaylist}
+              key={track.id}
+              onCloseEditor={() => {
+                setEditingTrackId(null)
+              }}
+              onDrop={handleTrackDrop}
+              onDragEnd={() => {
+                setDraggedTrackId(null)
+                setDropIndicator(null)
+              }}
+              onDragOver={handleTrackDragOver}
+              onDragStart={handleTrackDragStart}
+              onFieldChange={handleTrackEditorChange}
+              onRemoveTrack={onRemoveTrack}
+              onSelectTrack={onSelectTrack}
+              onToggleEditor={(trackId) => {
+                setEditingTrackId((currentTrackId) => (currentTrackId === trackId ? null : trackId))
+              }}
+              selectedTrackId={selectedTrackId}
+              track={track}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/scene-detail/PlaylistTrackEditor.tsx
+++ b/src/components/scene-detail/PlaylistTrackEditor.tsx
@@ -1,0 +1,71 @@
+import { type ChangeEvent } from 'react'
+import { readPlaylistTrackSummaryName, type MagePlayerPlaylistTrack } from '../../lib/magePlayerPlaylist'
+import { CloseIcon } from './playlistPanelIcons'
+
+type PlaylistTrackEditorProps = {
+  onClose: () => void
+  onFieldChange: (
+    trackId: string,
+    key: 'album' | 'artist' | 'title',
+    event: ChangeEvent<HTMLInputElement>,
+  ) => void
+  track: MagePlayerPlaylistTrack
+}
+
+export function PlaylistTrackEditor({ onClose, onFieldChange, track }: PlaylistTrackEditorProps) {
+  return (
+    <div
+      aria-label={`Edit ${readPlaylistTrackSummaryName(track)}`}
+      className="mage-watch__playlist-track-editor"
+      role="dialog"
+    >
+      <div className="mage-watch__playlist-track-editor-header">
+        <strong>Edit track</strong>
+        <button
+          aria-label={`Close track details for ${readPlaylistTrackSummaryName(track)}`}
+          className="mage-watch__playlist-track-editor-close"
+          onClick={onClose}
+          type="button"
+        >
+          <CloseIcon />
+        </button>
+      </div>
+      <label className="mage-watch__playlist-track-editor-field">
+        <span>Song name</span>
+        <input
+          onChange={(event) => {
+            onFieldChange(track.id, 'title', event)
+          }}
+          placeholder={track.name}
+          type="text"
+          value={track.title ?? ''}
+        />
+      </label>
+      <label className="mage-watch__playlist-track-editor-field">
+        <span>Artist</span>
+        <input
+          onChange={(event) => {
+            onFieldChange(track.id, 'artist', event)
+          }}
+          placeholder="Add artist"
+          type="text"
+          value={track.artist ?? ''}
+        />
+      </label>
+      <label className="mage-watch__playlist-track-editor-field">
+        <span>Album</span>
+        <input
+          onChange={(event) => {
+            onFieldChange(track.id, 'album', event)
+          }}
+          placeholder="Add album"
+          type="text"
+          value={track.album ?? ''}
+        />
+      </label>
+      <p className="mage-watch__playlist-track-editor-source" title={track.name}>
+        Source file: {track.name}
+      </p>
+    </div>
+  )
+}

--- a/src/components/scene-detail/PlaylistTrackRow.tsx
+++ b/src/components/scene-detail/PlaylistTrackRow.tsx
@@ -1,0 +1,130 @@
+import { type ChangeEvent, type DragEvent } from 'react'
+import {
+  readPlaylistTrackDisplayName,
+  readPlaylistTrackMetaLine,
+  readPlaylistTrackSummaryName,
+  type MagePlayerPlaylistTrack,
+} from '../../lib/magePlayerPlaylist'
+import { PlaylistTrackEditor } from './PlaylistTrackEditor'
+import { CloseIcon } from './playlistPanelIcons'
+
+type PlaylistTrackRowProps = {
+  dropPosition: 'after' | 'before' | undefined
+  editingTrackId: string | null
+  draggedTrackId: string | null
+  index: number
+  isDropTarget: boolean
+  isEditingPlaylist: boolean
+  onCloseEditor: () => void
+  onDrop: (event: DragEvent<HTMLDivElement>, trackId: string) => void
+  onDragEnd: () => void
+  onDragOver: (event: DragEvent<HTMLDivElement>, trackId: string) => void
+  onDragStart: (event: DragEvent<HTMLDivElement>, trackId: string) => void
+  onFieldChange: (
+    trackId: string,
+    key: 'album' | 'artist' | 'title',
+    event: ChangeEvent<HTMLInputElement>,
+  ) => void
+  onRemoveTrack: (trackId: string) => void
+  onSelectTrack: (trackId: string | null) => void
+  onToggleEditor: (trackId: string) => void
+  selectedTrackId: string | null
+  track: MagePlayerPlaylistTrack
+}
+
+function formatTrackDuration(seconds: number | null) {
+  if (!Number.isFinite(seconds) || seconds === null || seconds <= 0) {
+    return '--:--'
+  }
+
+  const roundedSeconds = Math.floor(seconds)
+  const hours = Math.floor(roundedSeconds / 3600)
+  const minutes = Math.floor((roundedSeconds % 3600) / 60)
+  const remainingSeconds = roundedSeconds % 60
+
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(remainingSeconds).padStart(2, '0')}`
+  }
+
+  return `${minutes}:${String(remainingSeconds).padStart(2, '0')}`
+}
+
+export function PlaylistTrackRow({
+  dropPosition,
+  editingTrackId,
+  draggedTrackId,
+  index,
+  isDropTarget,
+  isEditingPlaylist,
+  onCloseEditor,
+  onDrop,
+  onDragEnd,
+  onDragOver,
+  onDragStart,
+  onFieldChange,
+  onRemoveTrack,
+  onSelectTrack,
+  onToggleEditor,
+  selectedTrackId,
+  track,
+}: PlaylistTrackRowProps) {
+  const isDetailsOpen = isEditingPlaylist && editingTrackId === track.id
+  const isDragging = draggedTrackId === track.id
+  const trackMeta = readPlaylistTrackMetaLine(track)
+
+  return (
+    <div className={`mage-watch__playlist-track-shell${isDetailsOpen ? ' is-details-open' : ''}`}>
+      <div
+        className={`mage-watch__playlist-track${selectedTrackId === track.id ? ' is-active' : ''}${isEditingPlaylist ? ' is-editing' : ''}${isDragging ? ' is-dragging' : ''}${isDropTarget && !isDragging ? ' is-drop-target' : ''}${isDetailsOpen ? ' is-details-open' : ''}`}
+        data-drop-position={isDropTarget ? dropPosition : undefined}
+        draggable={isEditingPlaylist && !isDetailsOpen}
+        onDragEnd={onDragEnd}
+        onDragOver={(event) => {
+          onDragOver(event, track.id)
+        }}
+        onDragStart={(event) => {
+          onDragStart(event, track.id)
+        }}
+        onDrop={(event) => {
+          onDrop(event, track.id)
+        }}
+      >
+        <button
+          className="mage-watch__playlist-track-button"
+          onClick={() => {
+            if (isEditingPlaylist) {
+              onToggleEditor(track.id)
+              return
+            }
+
+            onSelectTrack(track.id)
+          }}
+          title={readPlaylistTrackSummaryName(track)}
+          type="button"
+        >
+          <span className="mage-watch__playlist-track-index">{index + 1}</span>
+          <span className="mage-watch__playlist-track-copy">
+            <strong>{readPlaylistTrackDisplayName(track)}</strong>
+            <span>{trackMeta ? `${trackMeta} - ${formatTrackDuration(track.duration)}` : formatTrackDuration(track.duration)}</span>
+          </span>
+        </button>
+        {isEditingPlaylist ? (
+          <button
+            aria-label={`Remove ${readPlaylistTrackSummaryName(track)}`}
+            className="mage-watch__playlist-remove"
+            onClick={() => {
+              onRemoveTrack(track.id)
+            }}
+            title={`Remove ${readPlaylistTrackSummaryName(track)}`}
+            type="button"
+          >
+            <CloseIcon />
+          </button>
+        ) : null}
+      </div>
+      {isDetailsOpen ? (
+        <PlaylistTrackEditor onClose={onCloseEditor} onFieldChange={onFieldChange} track={track} />
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/scene-detail/SceneRecommendationRail.tsx
+++ b/src/components/scene-detail/SceneRecommendationRail.tsx
@@ -1,5 +1,6 @@
-import type { CSSProperties } from 'react'
+import { type CSSProperties } from 'react'
 import { Link } from 'react-router-dom'
+import type { MagePlayerPlaylistTrack } from '../../lib/magePlayerPlaylist'
 import {
   buildTagRecommendationFilter,
   readRecommendationFilterTag,
@@ -7,50 +8,122 @@ import {
   type RecommendationFilter,
 } from '../../lib/sceneDetail'
 import { ScrollableTagBar } from '../ScrollableTagBar'
+import { PlaylistPanel } from './PlaylistPanel'
 
 type SceneRecommendationRailProps = {
   creatorDisplayName: string
   currentSceneTags: string[]
   isLoading: boolean
+  isPlaylistOpen: boolean
+  onClosePlaylist: () => void
+  onPlaylistNameChange: (name: string) => void
+  onReorderTracks: (tracks: MagePlayerPlaylistTrack[]) => void
+  onRemoveTrack: (trackId: string) => void
+  onSelectFilter: (filter: RecommendationFilter) => void
+  onSelectTrack: (trackId: string | null) => void
+  onToggleRepeat: () => void
+  onToggleShuffle: () => void
+  onUpdateTrack: (
+    trackId: string,
+    nextDetails: Partial<Pick<MagePlayerPlaylistTrack, 'album' | 'artist' | 'title'>>,
+  ) => void
+  playlistName: string
+  playlistTracks: MagePlayerPlaylistTrack[]
   recommendedScenes: RecommendedSceneCard[]
   recommendationFilter: RecommendationFilter
-  onSelectFilter: (filter: RecommendationFilter) => void
+  repeatEnabled: boolean
+  selectedTrackId: string | null
+  shuffleEnabled: boolean
+}
+
+function buildLoadingCopy(
+  activeRecommendationTag: string | null,
+  creatorDisplayName: string,
+  recommendationFilter: RecommendationFilter,
+) {
+  if (activeRecommendationTag !== null) {
+    return `Loading scenes tagged "${activeRecommendationTag}"...`
+  }
+
+  if (recommendationFilter === 'creator') {
+    return `Loading scenes from ${creatorDisplayName}...`
+  }
+
+  return 'Loading related scenes...'
+}
+
+function buildEmptyCopy(
+  activeRecommendationTag: string | null,
+  creatorDisplayName: string,
+  recommendationFilter: RecommendationFilter,
+) {
+  if (activeRecommendationTag !== null) {
+    return `No other scenes tagged "${activeRecommendationTag}" yet.`
+  }
+
+  if (recommendationFilter === 'creator') {
+    return `No other scenes from ${creatorDisplayName} yet.`
+  }
+
+  return `No related scenes from ${creatorDisplayName} or this scene's tags yet.`
 }
 
 export function SceneRecommendationRail({
   creatorDisplayName,
   currentSceneTags,
   isLoading,
+  isPlaylistOpen,
+  onClosePlaylist,
+  onPlaylistNameChange,
+  onReorderTracks,
+  onRemoveTrack,
+  onSelectFilter,
+  onSelectTrack,
+  onToggleRepeat,
+  onToggleShuffle,
+  onUpdateTrack,
+  playlistName,
+  playlistTracks,
   recommendedScenes,
   recommendationFilter,
-  onSelectFilter,
+  repeatEnabled,
+  selectedTrackId,
+  shuffleEnabled,
 }: SceneRecommendationRailProps) {
   const activeRecommendationTag = readRecommendationFilterTag(recommendationFilter)
-
-  const loadingCopy =
-    activeRecommendationTag !== null
-      ? `Loading scenes tagged "${activeRecommendationTag}"...`
-      : recommendationFilter === 'creator'
-        ? `Loading scenes from ${creatorDisplayName}...`
-        : 'Loading related scenes...'
-
-  const emptyCopy =
-    activeRecommendationTag !== null
-      ? `No other scenes tagged "${activeRecommendationTag}" yet.`
-      : recommendationFilter === 'creator'
-        ? `No other scenes from ${creatorDisplayName} yet.`
-        : `No related scenes from ${creatorDisplayName} or this scene's tags yet.`
+  const loadingCopy = buildLoadingCopy(
+    activeRecommendationTag,
+    creatorDisplayName,
+    recommendationFilter,
+  )
+  const emptyCopy = buildEmptyCopy(activeRecommendationTag, creatorDisplayName, recommendationFilter)
 
   return (
     <aside className="mage-watch__rail">
+      <PlaylistPanel
+        isOpen={isPlaylistOpen}
+        onClose={onClosePlaylist}
+        onPlaylistNameChange={onPlaylistNameChange}
+        onRemoveTrack={onRemoveTrack}
+        onReorderTracks={onReorderTracks}
+        onSelectTrack={onSelectTrack}
+        onToggleRepeat={onToggleRepeat}
+        onToggleShuffle={onToggleShuffle}
+        onUpdateTrack={onUpdateTrack}
+        playlistName={playlistName}
+        playlistTracks={playlistTracks}
+        repeatEnabled={repeatEnabled}
+        selectedTrackId={selectedTrackId}
+        shuffleEnabled={shuffleEnabled}
+      />
       <ScrollableTagBar
         ariaLabel="Filter recommended scenes"
         barClassName="scene-detail-recommendation-filters"
         role="toolbar"
       >
         <button
-          className={`tag-pill${recommendationFilter === 'all' ? ' tag-pill--active' : ''}`}
           aria-pressed={recommendationFilter === 'all'}
+          className={`tag-pill${recommendationFilter === 'all' ? ' tag-pill--active' : ''}`}
           onClick={() => {
             onSelectFilter('all')
           }}
@@ -59,8 +132,8 @@ export function SceneRecommendationRail({
           All
         </button>
         <button
-          className={`tag-pill${recommendationFilter === 'creator' ? ' tag-pill--active' : ''}`}
           aria-pressed={recommendationFilter === 'creator'}
+          className={`tag-pill${recommendationFilter === 'creator' ? ' tag-pill--active' : ''}`}
           onClick={() => {
             onSelectFilter('creator')
           }}
@@ -74,8 +147,8 @@ export function SceneRecommendationRail({
           return (
             <button
               key={tag}
-              className={`tag-pill${recommendationFilter === tagFilter ? ' tag-pill--active' : ''}`}
               aria-pressed={recommendationFilter === tagFilter}
+              className={`tag-pill${recommendationFilter === tagFilter ? ' tag-pill--active' : ''}`}
               onClick={() => {
                 onSelectFilter(tagFilter)
               }}
@@ -94,22 +167,18 @@ export function SceneRecommendationRail({
       ) : (
         <div className="mage-watch__rail-list">
           {recommendedScenes.map((recommendedScene) => (
-            <Link
-              key={recommendedScene.id}
-              className="mage-scene-card"
-              to={`/scenes/${recommendedScene.id}`}
-            >
+            <Link className="mage-scene-card" key={recommendedScene.id} to={`/scenes/${recommendedScene.id}`}>
               {recommendedScene.thumbnailRef ? (
                 <img
+                  alt={`${recommendedScene.title} thumbnail`}
                   className="mage-scene-card__thumb mage-scene-card__thumb-image"
                   src={recommendedScene.thumbnailRef}
-                  alt={`${recommendedScene.title} thumbnail`}
                 />
               ) : (
                 <div
+                  aria-hidden="true"
                   className="mage-scene-card__thumb"
                   style={{ '--scene-accent': recommendedScene.accent } as CSSProperties}
-                  aria-hidden="true"
                 />
               )}
               <div className="mage-scene-card__body">

--- a/src/components/scene-detail/playlistPanel.css
+++ b/src/components/scene-detail/playlistPanel.css
@@ -1,0 +1,391 @@
+.mage-watch__playlist-panel {
+  display: grid;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  background: rgba(14, 22, 26, 0.92);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.24);
+}
+
+.mage-watch__playlist-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.mage-watch__playlist-heading {
+  min-width: 0;
+}
+
+.mage-watch__playlist-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mage-watch__playlist-header strong {
+  display: block;
+  font-size: 1rem;
+}
+
+.mage-watch__playlist-name-button {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.mage-watch__playlist-name-button:hover,
+.mage-watch__playlist-name-button:focus-visible {
+  color: var(--accent);
+  outline: none;
+}
+
+.mage-watch__playlist-name-input {
+  width: min(100%, 220px);
+  min-height: 34px;
+  padding: 0 12px;
+  border: 1px solid rgba(99, 240, 214, 0.22);
+  border-radius: 12px;
+  background: rgba(5, 12, 15, 0.8);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.mage-watch__playlist-name-input:focus {
+  outline: none;
+  border-color: rgba(99, 240, 214, 0.38);
+  box-shadow: 0 0 0 3px rgba(99, 240, 214, 0.1);
+}
+
+.mage-watch__playlist-header span {
+  display: block;
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.mage-watch__playlist-action,
+.mage-watch__playlist-remove {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  color: rgba(255, 255, 255, 0.78);
+  font: inherit;
+  cursor: pointer;
+  transition:
+    color 0.18s ease,
+    background-color 0.18s ease,
+    border-color 0.18s ease;
+}
+
+.mage-watch__playlist-action {
+  min-height: 32px;
+  padding: 0 12px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.mage-watch__playlist-action--icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  min-width: 34px;
+  min-height: 34px;
+  padding: 0;
+}
+
+.mage-watch__playlist-action--icon svg {
+  width: 18px;
+  height: 18px;
+}
+
+.mage-watch__playlist-action[aria-pressed="true"] {
+  background: rgba(99, 240, 214, 0.16);
+  border-color: rgba(99, 240, 214, 0.28);
+  color: var(--accent);
+}
+
+.mage-watch__playlist-action:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.mage-watch__playlist-action:hover,
+.mage-watch__playlist-action:focus-visible,
+.mage-watch__playlist-remove:hover,
+.mage-watch__playlist-remove:focus-visible {
+  background: rgba(99, 240, 214, 0.12);
+  border-color: rgba(99, 240, 214, 0.24);
+  color: var(--accent);
+  outline: none;
+}
+
+.mage-watch__playlist-empty {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.mage-watch__playlist-list {
+  display: grid;
+  gap: 8px;
+  overflow: visible;
+}
+
+.mage-watch__playlist-track-shell {
+  position: relative;
+  overflow: visible;
+}
+
+.mage-watch__playlist-track-shell.is-details-open {
+  z-index: 3;
+}
+
+.mage-watch__playlist-track {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.03);
+  transition: background-color 0.18s ease;
+}
+
+.mage-watch__playlist-track::before,
+.mage-watch__playlist-track::after {
+  content: "";
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: rgba(99, 240, 214, 0.94);
+  box-shadow: 0 0 0 3px rgba(99, 240, 214, 0.14);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.mage-watch__playlist-track::before {
+  top: -4px;
+}
+
+.mage-watch__playlist-track::after {
+  bottom: -4px;
+}
+
+.mage-watch__playlist-track.is-active {
+  background: rgba(99, 240, 214, 0.12);
+}
+
+.mage-watch__playlist-track.is-editing {
+  cursor: grab;
+}
+
+.mage-watch__playlist-track.is-editing .mage-watch__playlist-track-button {
+  cursor: inherit;
+}
+
+.mage-watch__playlist-track.is-dragging {
+  opacity: 0.52;
+}
+
+.mage-watch__playlist-track.is-drop-target {
+  background: rgba(99, 240, 214, 0.08);
+}
+
+.mage-watch__playlist-track.is-drop-target[data-drop-position="before"]::before {
+  opacity: 1;
+}
+
+.mage-watch__playlist-track.is-drop-target[data-drop-position="after"]::after {
+  opacity: 1;
+}
+
+.mage-watch__playlist-track-button {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 12px;
+  align-items: center;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.mage-watch__playlist-track-button:focus-visible {
+  outline: none;
+}
+
+.mage-watch__playlist-track-index {
+  width: 1.4rem;
+  color: rgba(255, 255, 255, 0.58);
+  font-size: 0.82rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.mage-watch__playlist-track-copy {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.mage-watch__playlist-track-copy strong,
+.mage-watch__playlist-track-copy span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mage-watch__playlist-track-copy strong {
+  font-size: 0.9rem;
+  line-height: 1.35;
+}
+
+.mage-watch__playlist-track-copy span {
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.mage-watch__playlist-track.is-details-open {
+  background: rgba(99, 240, 214, 0.1);
+}
+
+.mage-watch__playlist-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  min-height: 32px;
+  min-width: 32px;
+  padding: 0;
+}
+
+.mage-watch__playlist-remove svg {
+  width: 14px;
+  height: 14px;
+}
+
+.mage-watch__playlist-track-editor {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 28px;
+  right: 8px;
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  background: rgba(6, 13, 16, 0.92);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(14px);
+  z-index: 5;
+}
+
+.mage-watch__playlist-track-editor::before {
+  content: "";
+  position: absolute;
+  top: -7px;
+  left: 26px;
+  width: 14px;
+  height: 14px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-left: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(6, 13, 16, 0.92);
+  transform: rotate(45deg);
+}
+
+.mage-watch__playlist-track-editor-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.mage-watch__playlist-track-editor-header strong {
+  font-size: 0.86rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.mage-watch__playlist-track-editor-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  color: rgba(255, 255, 255, 0.78);
+  cursor: pointer;
+}
+
+.mage-watch__playlist-track-editor-close:hover,
+.mage-watch__playlist-track-editor-close:focus-visible {
+  background: rgba(99, 240, 214, 0.12);
+  border-color: rgba(99, 240, 214, 0.24);
+  color: var(--accent);
+  outline: none;
+}
+
+.mage-watch__playlist-track-editor-close svg {
+  width: 14px;
+  height: 14px;
+}
+
+.mage-watch__playlist-track-editor-field {
+  display: grid;
+  gap: 6px;
+}
+
+.mage-watch__playlist-track-editor-field span {
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.mage-watch__playlist-track-editor-field input {
+  min-height: 38px;
+  padding: 0 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text);
+  font: inherit;
+}
+
+.mage-watch__playlist-track-editor-field input:focus {
+  outline: none;
+  border-color: rgba(99, 240, 214, 0.3);
+  box-shadow: 0 0 0 3px rgba(99, 240, 214, 0.1);
+}
+
+.mage-watch__playlist-track-editor-source {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.8rem;
+  line-height: 1.45;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/components/scene-detail/playlistPanelIcons.tsx
+++ b/src/components/scene-detail/playlistPanelIcons.tsx
@@ -1,0 +1,146 @@
+export function ShuffleIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24">
+      <polyline
+        fill="none"
+        points="16 3 21 3 21 8"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.9"
+      />
+      <line
+        x1="4"
+        x2="21"
+        y1="20"
+        y2="3"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.9"
+      />
+      <polyline
+        fill="none"
+        points="21 16 21 21 16 21"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.9"
+      />
+      <line
+        x1="15"
+        x2="21"
+        y1="15"
+        y2="21"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.9"
+      />
+      <line
+        x1="4"
+        x2="9"
+        y1="4"
+        y2="9"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.9"
+      />
+    </svg>
+  )
+}
+
+export function RepeatIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24">
+      <polyline
+        fill="none"
+        points="17 1 21 5 17 9"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.9"
+      />
+      <path
+        d="M3 11V9a4 4 0 0 1 4-4h14"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.9"
+      />
+      <polyline
+        fill="none"
+        points="7 23 3 19 7 15"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.9"
+      />
+      <path
+        d="M21 13v2a4 4 0 0 1-4 4H3"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.9"
+      />
+    </svg>
+  )
+}
+
+export function EditIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24">
+      <path
+        d="M12 20h9"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.9"
+      />
+      <path
+        d="M16.5 3.5a2.12 2.12 0 1 1 3 3L7 19l-4 1 1-4 12.5-12.5Z"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.9"
+      />
+    </svg>
+  )
+}
+
+export function CloseIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24">
+      <line
+        x1="6"
+        x2="18"
+        y1="6"
+        y2="18"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.9"
+      />
+      <line
+        x1="18"
+        x2="6"
+        y1="6"
+        y2="18"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.9"
+      />
+    </svg>
+  )
+}

--- a/src/components/scene-detail/useScenePlaylistState.ts
+++ b/src/components/scene-detail/useScenePlaylistState.ts
@@ -1,0 +1,151 @@
+import { useEffect, useRef, useState } from 'react'
+import {
+  buildScenePlaylistTrack,
+  mergePlaylistTrackCollections,
+  revokePlaylistTrackSource,
+  revokePlaylistTrackSources,
+  shufflePlaylistTracks,
+  type MagePlayerPlaylistTrack,
+} from '../../lib/magePlayerPlaylist'
+import type { MageSceneBlob } from '../../lib/magePlayerAdapter'
+
+export function useScenePlaylistState(sceneBlob: MageSceneBlob | null | undefined) {
+  const [basePlaylistTracks, setBasePlaylistTracks] = useState<MagePlayerPlaylistTrack[]>([])
+  const [playlistTracks, setPlaylistTracks] = useState<MagePlayerPlaylistTrack[]>([])
+  const [playlistName, setPlaylistName] = useState('Playlist')
+  const [selectedTrackId, setSelectedTrackId] = useState<string | null>(null)
+  const [isPlaylistOpen, setIsPlaylistOpen] = useState(false)
+  const [isRepeatEnabled, setIsRepeatEnabled] = useState(false)
+  const [isShuffleEnabled, setIsShuffleEnabled] = useState(false)
+  const basePlaylistTracksRef = useRef<MagePlayerPlaylistTrack[]>([])
+
+  useEffect(() => {
+    basePlaylistTracksRef.current = basePlaylistTracks
+  }, [basePlaylistTracks])
+
+  useEffect(() => {
+    return () => {
+      revokePlaylistTrackSources(basePlaylistTracksRef.current)
+    }
+  }, [])
+
+  useEffect(() => {
+    const sceneTrack = buildScenePlaylistTrack(sceneBlob)
+    const nextTracks = sceneTrack ? [sceneTrack] : []
+
+    setBasePlaylistTracks((currentTracks) => {
+      revokePlaylistTrackSources(currentTracks)
+      return nextTracks
+    })
+    setPlaylistTracks(nextTracks)
+    setSelectedTrackId(sceneTrack?.id ?? null)
+    setPlaylistName('Playlist')
+    setIsPlaylistOpen(false)
+    setIsRepeatEnabled(false)
+    setIsShuffleEnabled(false)
+  }, [sceneBlob])
+
+  function handlePlaylistChange(nextTracks: MagePlayerPlaylistTrack[]) {
+    setBasePlaylistTracks((currentBaseTracks) => mergePlaylistTrackCollections(currentBaseTracks, nextTracks))
+    setPlaylistTracks((currentTracks) => {
+      const retainedTrackIds = new Set(nextTracks.map((track) => track.id))
+
+      currentTracks.forEach((track) => {
+        if (!retainedTrackIds.has(track.id)) {
+          revokePlaylistTrackSource(track)
+        }
+      })
+
+      return nextTracks
+    })
+  }
+
+  function handleTrackDurationChange(trackId: string, duration: number) {
+    setBasePlaylistTracks((currentTracks) =>
+      currentTracks.map((track) => (track.id === trackId ? { ...track, duration } : track)),
+    )
+    setPlaylistTracks((currentTracks) =>
+      currentTracks.map((track) => (track.id === trackId ? { ...track, duration } : track)),
+    )
+  }
+
+  function handleReorderTracks(nextTracks: MagePlayerPlaylistTrack[]) {
+    if (!isShuffleEnabled) {
+      setBasePlaylistTracks(nextTracks)
+    }
+
+    setPlaylistTracks(nextTracks)
+  }
+
+  function handleUpdateTrack(
+    trackId: string,
+    nextDetails: Partial<Pick<MagePlayerPlaylistTrack, 'album' | 'artist' | 'title'>>,
+  ) {
+    setBasePlaylistTracks((currentTracks) =>
+      currentTracks.map((track) => (track.id === trackId ? { ...track, ...nextDetails } : track)),
+    )
+    setPlaylistTracks((currentTracks) =>
+      currentTracks.map((track) => (track.id === trackId ? { ...track, ...nextDetails } : track)),
+    )
+  }
+
+  function handleRemoveTrack(trackId: string) {
+    setBasePlaylistTracks((currentTracks) => currentTracks.filter((track) => track.id !== trackId))
+    setPlaylistTracks((currentTracks) => {
+      const nextTracks = currentTracks.filter((track) => track.id !== trackId)
+      const removedTrack = currentTracks.find((track) => track.id === trackId)
+      const removedTrackIndex = currentTracks.findIndex((track) => track.id === trackId)
+
+      if (removedTrack) {
+        revokePlaylistTrackSource(removedTrack)
+      }
+
+      if (selectedTrackId === trackId) {
+        const nextSelectedTrack =
+          nextTracks[removedTrackIndex] ?? nextTracks[Math.max(removedTrackIndex - 1, 0)] ?? null
+        setSelectedTrackId(nextSelectedTrack?.id ?? null)
+      }
+
+      if (nextTracks.length === 0) {
+        setIsPlaylistOpen(false)
+      }
+
+      return nextTracks
+    })
+  }
+
+  function toggleRepeat() {
+    setIsRepeatEnabled((currentValue) => !currentValue)
+  }
+
+  function toggleShuffle() {
+    setIsShuffleEnabled((currentValue) => {
+      const nextValue = !currentValue
+
+      setPlaylistTracks(() =>
+        nextValue ? shufflePlaylistTracks(basePlaylistTracks, selectedTrackId) : basePlaylistTracks,
+      )
+
+      return nextValue
+    })
+  }
+
+  return {
+    handlePlaylistChange,
+    handleRemoveTrack,
+    handleReorderTracks,
+    handleTrackDurationChange,
+    handleUpdateTrack,
+    isPlaylistOpen,
+    isRepeatEnabled,
+    isShuffleEnabled,
+    playlistName,
+    playlistTracks,
+    selectedTrackId,
+    setIsPlaylistOpen,
+    setPlaylistName,
+    setSelectedTrackId,
+    toggleRepeat,
+    toggleShuffle,
+  }
+}

--- a/src/lib/magePlayerAdapter.test.ts
+++ b/src/lib/magePlayerAdapter.test.ts
@@ -2,13 +2,21 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const engineMocks = vi.hoisted(() => ({
   dispose: vi.fn(),
+  getAudioDuration: vi.fn(),
+  getAudioTime: vi.fn(),
+  getAudioVolume: vi.fn(),
   getEngineTime: vi.fn(),
   initMAGE: vi.fn(),
+  isAudioLoaded: vi.fn(),
+  loadAudio: vi.fn(),
   loadPreset: vi.fn(),
   pause: vi.fn(),
   play: vi.fn(),
+  seek: vi.fn(),
+  setAudioVolume: vi.fn(),
   setEngineTime: vi.fn(),
   start: vi.fn(),
+  unloadAudio: vi.fn(),
 }))
 
 vi.mock('@notrac/mage', () => ({
@@ -17,21 +25,51 @@ vi.mock('@notrac/mage', () => ({
 
 describe('createMagePlayer', () => {
   beforeEach(() => {
+    let audioLoaded = false
+    let audioVolume = 1
+    let engineTime = 0
+
     vi.resetModules()
     vi.clearAllMocks()
     document.body.innerHTML = ''
 
     engineMocks.initMAGE.mockReturnValue({
       dispose: engineMocks.dispose,
+      getAudioDuration: engineMocks.getAudioDuration,
+      getAudioTime: engineMocks.getAudioTime,
+      getAudioVolume: engineMocks.getAudioVolume,
       getEngineTime: engineMocks.getEngineTime,
+      isAudioLoaded: engineMocks.isAudioLoaded,
+      loadAudio: engineMocks.loadAudio,
       loadPreset: engineMocks.loadPreset,
       pause: engineMocks.pause,
       play: engineMocks.play,
+      seek: engineMocks.seek,
+      setAudioVolume: engineMocks.setAudioVolume,
       setEngineTime: engineMocks.setEngineTime,
       start: engineMocks.start,
+      unloadAudio: engineMocks.unloadAudio,
     })
-    engineMocks.getEngineTime.mockReturnValue(0)
+    engineMocks.getAudioDuration.mockReturnValue(0)
+    engineMocks.getAudioTime.mockReturnValue(0)
+    engineMocks.getAudioVolume.mockImplementation(() => audioVolume)
+    engineMocks.getEngineTime.mockImplementation(() => engineTime)
+    engineMocks.isAudioLoaded.mockImplementation(() => audioLoaded)
+    engineMocks.loadAudio.mockImplementation(() => {
+      audioLoaded = true
+    })
     engineMocks.loadPreset.mockReturnValue({ visualizer: { shader: 'test' } })
+    engineMocks.unloadAudio.mockImplementation(() => {
+      audioLoaded = false
+    })
+    engineMocks.setAudioVolume.mockImplementation((volume: number) => {
+      audioVolume = volume
+      return audioVolume
+    })
+    engineMocks.setEngineTime.mockImplementation((time: number) => {
+      engineTime = time
+      return true
+    })
   })
 
   it('primes engine time and resumes playback after loading a scene blob', async () => {
@@ -82,6 +120,7 @@ describe('createMagePlayer', () => {
     expect(engineMocks.setEngineTime).not.toHaveBeenCalled()
     expect(engineMocks.start).toHaveBeenCalledTimes(1)
     expect(engineMocks.play).toHaveBeenCalledTimes(1)
+    expect(engineMocks.loadPreset).toHaveBeenCalledWith(sceneBlob)
   })
 
   it('tracks playback state before the first scene load without touching the engine', async () => {
@@ -127,6 +166,7 @@ describe('createMagePlayer', () => {
 
     expect(player.getPlaybackState()).toBe('playing')
     expect(engineMocks.play).toHaveBeenCalledTimes(1)
+    expect(engineMocks.loadPreset).toHaveBeenCalledTimes(1)
   })
 
   it('keeps a paused scene paused when a new scene blob loads', async () => {
@@ -150,6 +190,7 @@ describe('createMagePlayer', () => {
     expect(engineMocks.start).not.toHaveBeenCalled()
     expect(engineMocks.pause).toHaveBeenCalledTimes(1)
     expect(engineMocks.play).not.toHaveBeenCalled()
+    expect(engineMocks.loadPreset).toHaveBeenCalledWith(sceneBlob)
   })
 
   it('surfaces the underlying engine error text when scene loading throws', async () => {
@@ -170,6 +211,148 @@ describe('createMagePlayer', () => {
     expect(() => player.loadSceneBlob(sceneBlob)).toThrowError(
       'Scene data could not be rendered by the MAGE engine. ReferenceError: setStepSize is not defined',
     )
+  })
+
+  it('loads configured audio and syncs it to the current scene time', async () => {
+    const { createMagePlayer } = await import('./magePlayerAdapter')
+    const canvas = document.createElement('canvas')
+    const sceneBlob = {
+      audioPath: '/audio/crimson-reactor.mp3',
+      visualizer: {
+        shader: 'test',
+      },
+    }
+
+    const player = await createMagePlayer(canvas)
+
+    player.loadSceneBlob(sceneBlob)
+    engineMocks.play.mockClear()
+    engineMocks.seek.mockClear()
+    engineMocks.getEngineTime.mockReturnValue(2.5)
+
+    await expect(player.loadAudio()).resolves.toMatchObject({
+      hasSource: true,
+      isLoaded: true,
+      sourcePath: '/audio/crimson-reactor.mp3',
+    })
+
+    expect(engineMocks.loadAudio).toHaveBeenCalledWith('/audio/crimson-reactor.mp3')
+    expect(engineMocks.seek).toHaveBeenCalledWith(2.5)
+    expect(engineMocks.setAudioVolume).toHaveBeenCalledWith(1)
+    expect(engineMocks.play).toHaveBeenCalledTimes(1)
+    const audioState = player.getAudioState()
+
+    expect(audioState.hasSource).toBe(true)
+    expect(audioState.isLoaded).toBe(true)
+    expect(audioState.sourcePath).toBe('/audio/crimson-reactor.mp3')
+    expect(audioState.volume).toBe(1)
+    expect(audioState.currentTime).toBeGreaterThanOrEqual(2.5)
+  })
+
+  it('allows audio loading from a local device when the frontend passes a source path directly', async () => {
+    const { createMagePlayer } = await import('./magePlayerAdapter')
+    const canvas = document.createElement('canvas')
+    const sceneBlob = {
+      visualizer: {
+        shader: 'test',
+      },
+    }
+
+    const player = await createMagePlayer(canvas)
+
+    player.loadSceneBlob(sceneBlob)
+    engineMocks.play.mockClear()
+    engineMocks.seek.mockClear()
+
+    await expect(
+      player.loadAudio({
+        sourceLabel: 'device-track.mp3',
+        sourcePath: 'blob:device-track',
+      }),
+    ).resolves.toMatchObject({
+      hasSource: true,
+      isLoaded: true,
+      sourcePath: 'device-track.mp3',
+    })
+
+    expect(engineMocks.loadAudio).toHaveBeenCalledWith('blob:device-track')
+    expect(engineMocks.setAudioVolume).toHaveBeenCalledWith(1)
+    expect(engineMocks.play).toHaveBeenCalledTimes(1)
+    const audioState = player.getAudioState()
+
+    expect(audioState.hasSource).toBe(true)
+    expect(audioState.isLoaded).toBe(true)
+    expect(audioState.sourcePath).toBe('device-track.mp3')
+    expect(audioState.volume).toBe(1)
+    expect(audioState.currentTime).toBeGreaterThanOrEqual(0)
+  })
+
+  it('seeks loaded audio and syncs engine time for the shared scrubber', async () => {
+    const { createMagePlayer } = await import('./magePlayerAdapter')
+    const canvas = document.createElement('canvas')
+    const sceneBlob = {
+      audioPath: '/audio/crimson-reactor.mp3',
+      visualizer: {
+        shader: 'test',
+      },
+    }
+
+    engineMocks.getAudioDuration.mockReturnValue(185)
+    engineMocks.getAudioTime.mockReturnValue(42)
+
+    const player = await createMagePlayer(canvas)
+
+    player.loadSceneBlob(sceneBlob)
+    await player.loadAudio()
+
+    const audioState = player.seekAudio(42)
+
+    expect(audioState.duration).toBe(185)
+    expect(audioState.currentTime).toBeGreaterThanOrEqual(42)
+    expect(audioState.currentTime).toBeLessThan(43)
+    expect(engineMocks.seek).toHaveBeenLastCalledWith(42)
+  })
+
+  it('updates audio volume through the shared player bridge', async () => {
+    const { createMagePlayer } = await import('./magePlayerAdapter')
+    const canvas = document.createElement('canvas')
+
+    const player = await createMagePlayer(canvas)
+
+    expect(player.setAudioVolume(0.4)).toMatchObject({
+      volume: 0.4,
+    })
+    expect(engineMocks.setAudioVolume).toHaveBeenLastCalledWith(0.4)
+  })
+
+  it('resets scene and audio playback back to the beginning', async () => {
+    const { createMagePlayer } = await import('./magePlayerAdapter')
+    const canvas = document.createElement('canvas')
+    const sceneBlob = {
+      audioPath: '/audio/crimson-reactor.mp3',
+      intent: {
+        time_multiplier: 1.5,
+      },
+      visualizer: {
+        shader: 'test',
+      },
+    }
+
+    const player = await createMagePlayer(canvas)
+
+    player.loadSceneBlob(sceneBlob)
+    await player.loadAudio()
+
+    engineMocks.loadPreset.mockClear()
+    engineMocks.pause.mockClear()
+    engineMocks.seek.mockClear()
+
+    expect(player.resetPlayback()).toBe('paused')
+    expect(player.getPlaybackState()).toBe('paused')
+    expect(engineMocks.loadPreset).toHaveBeenCalledWith(sceneBlob)
+    expect(engineMocks.seek).toHaveBeenCalledWith(0)
+    expect(engineMocks.start).toHaveBeenCalledTimes(2)
+    expect(engineMocks.pause).toHaveBeenCalledTimes(1)
   })
 
   it('disables native engine controls so only shared playback chrome is shown', async () => {

--- a/src/lib/magePlayerAdapter.test.ts
+++ b/src/lib/magePlayerAdapter.test.ts
@@ -156,6 +156,7 @@ describe('createMagePlayer', () => {
 
     engineMocks.pause.mockClear()
     engineMocks.play.mockClear()
+    engineMocks.start.mockClear()
 
     player.setPlaybackState('paused')
 
@@ -165,7 +166,8 @@ describe('createMagePlayer', () => {
     player.setPlaybackState('playing')
 
     expect(player.getPlaybackState()).toBe('playing')
-    expect(engineMocks.play).toHaveBeenCalledTimes(1)
+    expect(engineMocks.start).toHaveBeenCalledTimes(1)
+    expect(engineMocks.play).not.toHaveBeenCalled()
     expect(engineMocks.loadPreset).toHaveBeenCalledTimes(1)
   })
 
@@ -285,6 +287,50 @@ describe('createMagePlayer', () => {
     expect(audioState.sourcePath).toBe('device-track.mp3')
     expect(audioState.volume).toBe(1)
     expect(audioState.currentTime).toBeGreaterThanOrEqual(0)
+  })
+
+  it('detaches cleared audio so resuming playback does not replay a removed track', async () => {
+    const { createMagePlayer } = await import('./magePlayerAdapter')
+    const canvas = document.createElement('canvas')
+    const sceneBlob = {
+      visualizer: {
+        shader: 'test',
+      },
+    }
+
+    const player = await createMagePlayer(canvas)
+
+    player.loadSceneBlob(sceneBlob)
+    await player.loadAudio({
+      sourceLabel: 'device-track.mp3',
+      sourcePath: 'blob:device-track',
+    })
+
+    engineMocks.play.mockClear()
+    engineMocks.start.mockClear()
+    engineMocks.unloadAudio.mockClear()
+
+    expect(player.clearAudio()).toMatchObject({
+      currentTime: 0,
+      duration: 0,
+      hasSource: false,
+      isLoaded: false,
+      sourcePath: null,
+    })
+
+    expect(engineMocks.unloadAudio).toHaveBeenCalledTimes(1)
+
+    player.setPlaybackState('playing')
+
+    expect(engineMocks.start).toHaveBeenCalledTimes(1)
+    expect(engineMocks.play).not.toHaveBeenCalled()
+    expect(player.getAudioState()).toMatchObject({
+      currentTime: 0,
+      duration: 0,
+      hasSource: false,
+      isLoaded: false,
+      sourcePath: null,
+    })
   })
 
   it('seeks loaded audio and syncs engine time for the shared scrubber', async () => {

--- a/src/lib/magePlayerAdapter.ts
+++ b/src/lib/magePlayerAdapter.ts
@@ -244,6 +244,7 @@ export async function createMagePlayer(
   engine.start()
   let hasLoadedScene = false
   let currentSceneBlob: MageSceneBlob | null = null
+  let hasAttachedAudio = false
   let currentAudioLabel: string | null = null
   let currentAudioTime = 0
   let currentAudioVolume = 1
@@ -287,8 +288,9 @@ export async function createMagePlayer(
   }
 
   function getAudioState(): MagePlayerAudioState {
-    const sourcePath = currentAudioLabel ?? (currentSceneBlob ? readSceneAudioSource(currentSceneBlob) : null)
-    const isLoaded = typeof engine.isAudioLoaded === 'function' ? engine.isAudioLoaded() : false
+    const sourcePath = hasAttachedAudio ? currentAudioLabel : null
+    const isLoaded =
+      hasAttachedAudio && typeof engine.isAudioLoaded === 'function' ? engine.isAudioLoaded() : false
     const duration = isLoaded ? getTrackedAudioDuration() : 0
 
     if (isLoaded) {
@@ -322,7 +324,15 @@ export async function createMagePlayer(
       return playbackState
     }
 
-    playbackState = applyPlaybackState(engine, nextPlaybackState)
+    if (nextPlaybackState === 'paused') {
+      playbackState = applyPlaybackState(engine, nextPlaybackState)
+    } else if (hasAttachedAudio) {
+      playbackState = applyPlaybackState(engine, nextPlaybackState)
+    } else {
+      primeEngineTime(engine)
+      engine.start()
+      playbackState = nextPlaybackState
+    }
 
     if (nextPlaybackState === 'paused') {
       pauseTrackedAudioTime()
@@ -339,11 +349,19 @@ export async function createMagePlayer(
         engine.unloadAudio()
       }
 
+      hasAttachedAudio = false
       currentAudioLabel = null
       currentAudioTime = 0
       trackedAudioStartedAtMs = null
 
-      return getAudioState()
+      return {
+        currentTime: 0,
+        duration: 0,
+        hasSource: false,
+        isLoaded: false,
+        sourcePath: null,
+        volume: currentAudioVolume,
+      }
     },
     getAudioState,
     getPlaybackState() {
@@ -371,6 +389,7 @@ export async function createMagePlayer(
       }
 
       try {
+        hasAttachedAudio = false
         currentAudioLabel = audioLabel
         engine.loadAudio(audioSource)
       } catch (error) {
@@ -406,6 +425,7 @@ export async function createMagePlayer(
         engine.seek(audioTime)
       }
 
+      hasAttachedAudio = true
       setTrackedAudioTime(audioTime)
 
       if (typeof engine.setAudioVolume === 'function') {
@@ -433,6 +453,7 @@ export async function createMagePlayer(
         }
 
         currentSceneBlob = sceneBlob
+        hasAttachedAudio = false
         currentAudioLabel = null
         currentAudioTime = 0
         trackedAudioStartedAtMs = null
@@ -441,6 +462,7 @@ export async function createMagePlayer(
         playbackState = applyPlaybackState(engine, playbackState)
       } catch (error) {
         currentSceneBlob = null
+        hasAttachedAudio = false
         currentAudioLabel = null
         hasLoadedScene = false
 

--- a/src/lib/magePlayerAdapter.ts
+++ b/src/lib/magePlayerAdapter.ts
@@ -20,12 +20,20 @@ const GENERIC_RENDER_ERROR_MESSAGE = 'Scene data could not be rendered by the MA
 
 type MageEngineBridge = {
   dispose: MAGEEngineAPI['dispose']
+  getAudioDuration?: MAGEEngineAPI['getAudioDuration']
+  getAudioTime?: MAGEEngineAPI['getAudioTime']
+  getAudioVolume?: () => number
   getEngineTime?: MAGEEngineAPI['getEngineTime']
+  isAudioLoaded?: MAGEEngineAPI['isAudioLoaded']
+  loadAudio?: MAGEEngineAPI['loadAudio']
   pause: MAGEEngineAPI['pause']
   play: MAGEEngineAPI['play']
   loadPreset: (scene: unknown) => unknown
+  seek?: MAGEEngineAPI['seek']
+  setAudioVolume?: (volume: number) => number
   setEngineTime?: (time: number) => boolean
   start: MAGEEngineAPI['start']
+  unloadAudio?: MAGEEngineAPI['unloadAudio']
 }
 
 type MageEngineModule = {
@@ -44,10 +52,25 @@ export type MageSceneBlob = Record<string, unknown>
 
 export type MagePlayerPlaybackState = 'paused' | 'playing'
 
+export type MagePlayerAudioState = {
+  currentTime: number
+  duration: number
+  hasSource: boolean
+  isLoaded: boolean
+  sourcePath: string | null
+  volume: number
+}
+
 export type MagePlayerController = {
+  clearAudio: () => MagePlayerAudioState
   dispose: () => void
+  getAudioState: () => MagePlayerAudioState
   getPlaybackState: () => MagePlayerPlaybackState
+  loadAudio: (options?: { sourceLabel?: string; sourcePath?: string }) => Promise<MagePlayerAudioState>
   loadSceneBlob: (sceneBlob: unknown) => void
+  resetPlayback: () => MagePlayerPlaybackState
+  seekAudio: (time: number) => MagePlayerAudioState
+  setAudioVolume: (volume: number) => MagePlayerAudioState
   setPlaybackState: (playbackState: MagePlayerPlaybackState) => MagePlayerPlaybackState
 }
 
@@ -105,12 +128,68 @@ function createSceneRenderError(cause?: unknown) {
   return new MagePlayerAdapterError(`${GENERIC_RENDER_ERROR_MESSAGE} ${details}`, { cause })
 }
 
+function createAudioError(message: string, cause?: unknown) {
+  return new MagePlayerAdapterError(message, { cause })
+}
+
 function loadSceneIntoEngine(engine: MageEngineBridge, sceneBlob: MageSceneBlob) {
   const loadedScene = engine.loadPreset(sceneBlob)
 
   if (!loadedScene) {
     throw createSceneRenderError()
   }
+}
+
+function readSceneAudioSource(sceneBlob: MageSceneBlob) {
+  const audioPath = sceneBlob.audioPath
+
+  if (typeof audioPath === 'string' && audioPath.trim()) {
+    return audioPath.trim()
+  }
+
+  const audio = sceneBlob.audio
+
+  if (typeof audio === 'string' && audio.trim()) {
+    return audio.trim()
+  }
+
+  if (isRecord(audio)) {
+    const audioSource = audio.path ?? audio.url
+
+    if (typeof audioSource === 'string' && audioSource.trim()) {
+      return audioSource.trim()
+    }
+  }
+
+  return null
+}
+
+function clampAudioTime(engine: MageEngineBridge, time: number) {
+  const normalizedTime = Number.isFinite(time) ? Math.max(time, 0) : 0
+
+  if (typeof engine.getAudioDuration !== 'function') {
+    return normalizedTime
+  }
+
+  const duration = engine.getAudioDuration()
+
+  if (!Number.isFinite(duration) || duration <= 0) {
+    return normalizedTime
+  }
+
+  return Math.min(normalizedTime, duration)
+}
+
+function clampAudioVolume(volume: number) {
+  if (!Number.isFinite(volume)) {
+    return 1
+  }
+
+  return Math.min(Math.max(volume, 0), 1)
+}
+
+function nowMs() {
+  return typeof performance !== 'undefined' ? performance.now() : Date.now()
 }
 
 function primeEngineTime(engine: MageEngineBridge) {
@@ -164,22 +243,184 @@ export async function createMagePlayer(
 
   engine.start()
   let hasLoadedScene = false
+  let currentSceneBlob: MageSceneBlob | null = null
+  let currentAudioLabel: string | null = null
+  let currentAudioTime = 0
+  let currentAudioVolume = 1
+  let trackedAudioStartedAtMs: number | null = null
   let playbackState: MagePlayerPlaybackState = 'playing'
+
+  function getTrackedAudioDuration() {
+    return typeof engine.getAudioDuration === 'function' ? clampAudioTime(engine, engine.getAudioDuration()) : 0
+  }
+
+  function syncTrackedAudioTime() {
+    if (trackedAudioStartedAtMs === null) {
+      return
+    }
+
+    const elapsedSeconds = Math.max((nowMs() - trackedAudioStartedAtMs) / 1000, 0)
+    const duration = getTrackedAudioDuration()
+
+    currentAudioTime =
+      duration > 0 ? Math.min(currentAudioTime + elapsedSeconds, duration) : currentAudioTime + elapsedSeconds
+    trackedAudioStartedAtMs = duration > 0 && currentAudioTime >= duration ? null : nowMs()
+  }
+
+  function setTrackedAudioTime(nextTime: number) {
+    currentAudioTime =
+      getTrackedAudioDuration() > 0 ? Math.min(clampAudioTime(engine, nextTime), getTrackedAudioDuration()) : Math.max(nextTime, 0)
+  }
+
+  function resumeTrackedAudioTime() {
+    if (typeof engine.isAudioLoaded === 'function' && !engine.isAudioLoaded()) {
+      trackedAudioStartedAtMs = null
+      return
+    }
+
+    trackedAudioStartedAtMs = nowMs()
+  }
+
+  function pauseTrackedAudioTime() {
+    syncTrackedAudioTime()
+    trackedAudioStartedAtMs = null
+  }
+
+  function getAudioState(): MagePlayerAudioState {
+    const sourcePath = currentAudioLabel ?? (currentSceneBlob ? readSceneAudioSource(currentSceneBlob) : null)
+    const isLoaded = typeof engine.isAudioLoaded === 'function' ? engine.isAudioLoaded() : false
+    const duration = isLoaded ? getTrackedAudioDuration() : 0
+
+    if (isLoaded) {
+      syncTrackedAudioTime()
+    } else {
+      currentAudioTime = 0
+      trackedAudioStartedAtMs = null
+    }
+
+    const volume =
+      typeof engine.getAudioVolume === 'function'
+        ? clampAudioVolume(engine.getAudioVolume())
+        : currentAudioVolume
+
+    currentAudioVolume = volume
+
+    return {
+      currentTime: duration > 0 ? Math.min(currentAudioTime, duration) : currentAudioTime,
+      duration,
+      hasSource: Boolean(sourcePath),
+      isLoaded,
+      sourcePath,
+      volume,
+    }
+  }
 
   function setPlaybackState(nextPlaybackState: MagePlayerPlaybackState) {
     playbackState = nextPlaybackState
 
-    if (!hasLoadedScene) {
+    if (!hasLoadedScene || !currentSceneBlob) {
       return playbackState
     }
 
     playbackState = applyPlaybackState(engine, nextPlaybackState)
+
+    if (nextPlaybackState === 'paused') {
+      pauseTrackedAudioTime()
+    } else {
+      resumeTrackedAudioTime()
+    }
+
     return playbackState
   }
 
   return {
+    clearAudio() {
+      if (typeof engine.unloadAudio === 'function') {
+        engine.unloadAudio()
+      }
+
+      currentAudioLabel = null
+      currentAudioTime = 0
+      trackedAudioStartedAtMs = null
+
+      return getAudioState()
+    },
+    getAudioState,
     getPlaybackState() {
       return playbackState
+    },
+    async loadAudio(options = {}) {
+      if (!hasLoadedScene || !currentSceneBlob) {
+        throw createAudioError('Load a scene before loading audio.')
+      }
+
+      const savedAudioSource = readSceneAudioSource(currentSceneBlob)
+      const audioSource = options.sourcePath ?? savedAudioSource
+      const audioLabel = options.sourceLabel ?? audioSource ?? null
+
+      if (typeof engine.loadAudio !== 'function') {
+        throw createAudioError('This MAGE engine build does not support audio loading.')
+      }
+
+      if (!audioSource) {
+        throw createAudioError('Choose an audio file or save an audioPath on the scene.')
+      }
+
+      if (typeof engine.unloadAudio === 'function') {
+        engine.unloadAudio()
+      }
+
+      try {
+        currentAudioLabel = audioLabel
+        engine.loadAudio(audioSource)
+      } catch (error) {
+        throw createAudioError('Audio could not be loaded from the configured source.', error)
+      }
+
+      await new Promise<void>((resolve, reject) => {
+        const startedAt = Date.now()
+
+        function poll() {
+          if (typeof engine.isAudioLoaded === 'function' && engine.isAudioLoaded()) {
+            resolve()
+            return
+          }
+
+          if (Date.now() - startedAt >= 5000) {
+            reject(createAudioError('Audio could not be loaded from the configured source.'))
+            return
+          }
+
+          window.setTimeout(poll, 50)
+        }
+
+        poll()
+      })
+
+      const audioTime =
+        typeof engine.getEngineTime === 'function'
+          ? clampAudioTime(engine, engine.getEngineTime())
+          : 0
+
+      if (typeof engine.seek === 'function') {
+        engine.seek(audioTime)
+      }
+
+      setTrackedAudioTime(audioTime)
+
+      if (typeof engine.setAudioVolume === 'function') {
+        currentAudioVolume = clampAudioVolume(engine.setAudioVolume(currentAudioVolume))
+      }
+
+      if (playbackState === 'paused') {
+        pauseTrackedAudioTime()
+        engine.pause()
+      } else {
+        resumeTrackedAudioTime()
+        engine.play()
+      }
+
+      return getAudioState()
     },
     loadSceneBlob(sceneBlob) {
       if (!isMageSceneBlob(sceneBlob)) {
@@ -187,16 +428,76 @@ export async function createMagePlayer(
       }
 
       try {
-        loadSceneIntoEngine(engine, sceneBlob)
+        if (typeof engine.unloadAudio === 'function') {
+          engine.unloadAudio()
+        }
+
+        currentSceneBlob = sceneBlob
+        currentAudioLabel = null
+        currentAudioTime = 0
+        trackedAudioStartedAtMs = null
         hasLoadedScene = true
+        loadSceneIntoEngine(engine, sceneBlob)
         playbackState = applyPlaybackState(engine, playbackState)
       } catch (error) {
+        currentSceneBlob = null
+        currentAudioLabel = null
+        hasLoadedScene = false
+
         if (error instanceof MagePlayerAdapterError) {
           throw error
         }
 
         throw createSceneRenderError(error)
       }
+    },
+    resetPlayback() {
+      if (!hasLoadedScene || !currentSceneBlob) {
+        throw new MagePlayerAdapterError('Load a scene before resetting playback.')
+      }
+
+      playbackState = 'paused'
+      currentAudioTime = 0
+      trackedAudioStartedAtMs = null
+      loadSceneIntoEngine(engine, currentSceneBlob)
+
+      if (typeof engine.seek === 'function') {
+        engine.seek(0)
+      }
+
+      engine.start()
+      engine.pause()
+      return playbackState
+    },
+    seekAudio(time) {
+      if (!hasLoadedScene || !currentSceneBlob) {
+        throw new MagePlayerAdapterError('Load a scene before seeking audio.')
+      }
+
+      const nextTime = clampAudioTime(engine, time)
+
+      if (typeof engine.seek === 'function') {
+        engine.seek(nextTime)
+      }
+
+      setTrackedAudioTime(nextTime)
+
+      if (playbackState === 'playing') {
+        resumeTrackedAudioTime()
+      } else {
+        trackedAudioStartedAtMs = null
+      }
+
+      return getAudioState()
+    },
+    setAudioVolume(volume) {
+      currentAudioVolume = clampAudioVolume(volume)
+
+      if (typeof engine.setAudioVolume === 'function') {
+        currentAudioVolume = clampAudioVolume(engine.setAudioVolume(currentAudioVolume))
+      }
+
+      return getAudioState()
     },
     setPlaybackState,
     dispose() {

--- a/src/lib/magePlayerPlaylist.test.ts
+++ b/src/lib/magePlayerPlaylist.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import {
+  mergePlaylistTrackCollections,
+  shufflePlaylistTracks,
+  type MagePlayerPlaylistTrack,
+} from './magePlayerPlaylist'
+
+function createTrack(id: string): MagePlayerPlaylistTrack {
+  return {
+    duration: 120,
+    id,
+    name: `${id}.mp3`,
+    sourcePath: `blob:${id}`,
+    sourceType: 'device',
+  }
+}
+
+describe('mergePlaylistTrackCollections', () => {
+  it('keeps the existing base order for retained tracks and appends new tracks', () => {
+    const baseTracks = [createTrack('track-1'), createTrack('track-2'), createTrack('track-3')]
+    const nextTracks = [createTrack('track-2'), createTrack('track-1'), createTrack('track-4')]
+
+    expect(mergePlaylistTrackCollections(baseTracks, nextTracks).map((track) => track.id)).toEqual([
+      'track-1',
+      'track-2',
+      'track-4',
+    ])
+  })
+})
+
+describe('shufflePlaylistTracks', () => {
+  it('keeps the anchored track first and shuffles the remaining tracks', () => {
+    const tracks = [
+      createTrack('track-1'),
+      createTrack('track-2'),
+      createTrack('track-3'),
+      createTrack('track-4'),
+    ]
+    const randomValues = [0.9, 0.3, 0.5]
+    let randomIndex = 0
+
+    const shuffledTracks = shufflePlaylistTracks(tracks, 'track-2', () => {
+      const nextValue = randomValues[randomIndex] ?? 0
+      randomIndex += 1
+      return nextValue
+    })
+
+    expect(shuffledTracks.map((track) => track.id)).toEqual([
+      'track-2',
+      'track-3',
+      'track-1',
+      'track-4',
+    ])
+  })
+
+  it('shuffles the whole list when there is no anchored track', () => {
+    const tracks = [createTrack('track-1'), createTrack('track-2'), createTrack('track-3')]
+    const randomValues = [0.1, 0.7]
+    let randomIndex = 0
+
+    const shuffledTracks = shufflePlaylistTracks(tracks, null, () => {
+      const nextValue = randomValues[randomIndex] ?? 0
+      randomIndex += 1
+      return nextValue
+    })
+
+    expect(shuffledTracks.map((track) => track.id)).toEqual(['track-3', 'track-2', 'track-1'])
+  })
+})

--- a/src/lib/magePlayerPlaylist.ts
+++ b/src/lib/magePlayerPlaylist.ts
@@ -1,0 +1,168 @@
+import type { MageSceneBlob } from './magePlayerAdapter'
+
+export type MagePlayerPlaylistTrack = {
+  album?: string
+  artist?: string
+  duration: number | null
+  id: string
+  name: string
+  sourcePath: string
+  sourceType: 'device' | 'scene'
+  title?: string
+}
+
+function readTrimmedMetadataValue(value: string | undefined) {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const trimmedValue = value.trim()
+  return trimmedValue ? trimmedValue : null
+}
+
+function readAudioSource(sceneBlob: MageSceneBlob | null | undefined) {
+  if (!sceneBlob) {
+    return null
+  }
+
+  const audioPath = sceneBlob.audioPath
+
+  if (typeof audioPath === 'string' && audioPath.trim()) {
+    return audioPath.trim()
+  }
+
+  const audio = sceneBlob.audio
+
+  if (typeof audio === 'string' && audio.trim()) {
+    return audio.trim()
+  }
+
+  if (audio && typeof audio === 'object') {
+    const audioRecord = audio as Record<string, unknown>
+    const audioSource = audioRecord.path ?? audioRecord.url
+
+    if (typeof audioSource === 'string' && audioSource.trim()) {
+      return audioSource.trim()
+    }
+  }
+
+  return null
+}
+
+export function formatPlaylistTrackName(sourcePath: string) {
+  const [normalizedPath] = sourcePath.split(/[?#]/, 1)
+  const pathSegments = normalizedPath.split(/[\\/]/).filter(Boolean)
+
+  return pathSegments.at(-1) ?? sourcePath
+}
+
+export function readPlaylistTrackDisplayName(track: MagePlayerPlaylistTrack) {
+  const title = readTrimmedMetadataValue(track.title)
+
+  return title ?? track.name
+}
+
+export function readPlaylistTrackSummaryName(track: MagePlayerPlaylistTrack) {
+  const title = readTrimmedMetadataValue(track.title)
+  const artist = readTrimmedMetadataValue(track.artist)
+
+  if (title && artist) {
+    return `${artist} - ${title}`
+  }
+
+  return title ?? track.name
+}
+
+export function readPlaylistTrackMetaLine(track: MagePlayerPlaylistTrack) {
+  const artist = readTrimmedMetadataValue(track.artist)
+  const album = readTrimmedMetadataValue(track.album)
+
+  if (artist && album) {
+    return `${artist} · ${album}`
+  }
+
+  return artist ?? album
+}
+
+export function mergePlaylistTrackCollections(
+  baseTracks: MagePlayerPlaylistTrack[],
+  nextTracks: MagePlayerPlaylistTrack[],
+) {
+  if (baseTracks.length === 0) {
+    return nextTracks
+  }
+
+  const nextTracksById = new Map(nextTracks.map((track) => [track.id, track]))
+  const baseTrackIds = new Set(baseTracks.map((track) => track.id))
+  const mergedTracks: MagePlayerPlaylistTrack[] = []
+
+  baseTracks.forEach((track) => {
+    const nextTrack = nextTracksById.get(track.id)
+
+    if (nextTrack) {
+      mergedTracks.push(nextTrack)
+    }
+  })
+
+  nextTracks.forEach((track) => {
+    if (!baseTrackIds.has(track.id)) {
+      mergedTracks.push(track)
+    }
+  })
+
+  return mergedTracks
+}
+
+export function shufflePlaylistTracks(
+  tracks: MagePlayerPlaylistTrack[],
+  anchoredTrackId: string | null,
+  randomFn: () => number = Math.random,
+) {
+  if (tracks.length <= 1) {
+    return [...tracks]
+  }
+
+  const anchoredTrackIndex =
+    anchoredTrackId === null ? -1 : tracks.findIndex((track) => track.id === anchoredTrackId)
+  const anchoredTrack = anchoredTrackIndex >= 0 ? tracks[anchoredTrackIndex] : null
+  const remainingTracks = anchoredTrack
+    ? tracks.filter((track) => track.id !== anchoredTrack.id)
+    : [...tracks]
+
+  for (let currentIndex = remainingTracks.length - 1; currentIndex > 0; currentIndex -= 1) {
+    const swapIndex = Math.floor(randomFn() * (currentIndex + 1))
+    const nextTrack = remainingTracks[currentIndex]
+    remainingTracks[currentIndex] = remainingTracks[swapIndex]
+    remainingTracks[swapIndex] = nextTrack
+  }
+
+  return anchoredTrack ? [anchoredTrack, ...remainingTracks] : remainingTracks
+}
+
+export function buildScenePlaylistTrack(
+  sceneBlob: MageSceneBlob | null | undefined,
+): MagePlayerPlaylistTrack | null {
+  const sourcePath = readAudioSource(sceneBlob)
+
+  if (!sourcePath) {
+    return null
+  }
+
+  return {
+    duration: null,
+    id: `scene:${sourcePath}`,
+    name: formatPlaylistTrackName(sourcePath),
+    sourcePath,
+    sourceType: 'scene',
+  }
+}
+
+export function revokePlaylistTrackSource(track: MagePlayerPlaylistTrack) {
+  if (track.sourceType === 'device' && track.sourcePath.startsWith('blob:')) {
+    URL.revokeObjectURL(track.sourcePath)
+  }
+}
+
+export function revokePlaylistTrackSources(tracks: MagePlayerPlaylistTrack[]) {
+  tracks.forEach(revokePlaylistTrackSource)
+}

--- a/src/pages/SceneDetailPage.tsx
+++ b/src/pages/SceneDetailPage.tsx
@@ -6,6 +6,7 @@ import { SceneCommentsPanel } from '../components/scene-detail/SceneCommentsPane
 import { SceneDescriptionCard } from '../components/scene-detail/SceneDescriptionCard'
 import { SceneRecommendationRail } from '../components/scene-detail/SceneRecommendationRail'
 import { SceneDetailState } from '../components/scene-detail/SceneDetailState'
+import { useScenePlaylistState } from '../components/scene-detail/useScenePlaylistState'
 import { VoteButton } from '../components/scene-detail/VoteButton'
 import {
   buildCreatorProfile,
@@ -38,8 +39,25 @@ export function SceneDetailPage() {
   const [isRecommendationsLoading, setIsRecommendationsLoading] = useState(false)
   const [recommendationFilter, setRecommendationFilter] = useState<RecommendationFilter>('all')
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
-
   const sceneId = readSceneId(id)
+  const {
+    handlePlaylistChange,
+    handleRemoveTrack,
+    handleReorderTracks,
+    handleTrackDurationChange,
+    handleUpdateTrack,
+    isPlaylistOpen,
+    isRepeatEnabled,
+    isShuffleEnabled,
+    playlistName,
+    playlistTracks,
+    selectedTrackId,
+    setIsPlaylistOpen,
+    setPlaylistName,
+    setSelectedTrackId,
+    toggleRepeat,
+    toggleShuffle,
+  } = useScenePlaylistState(scene?.sceneData)
 
   useEffect(() => {
     if (sceneId === null || isRestoringSession) {
@@ -226,7 +244,17 @@ export function SceneDetailPage() {
                 ariaLabel={`${scene.name} live render`}
                 className="scene-detail-player"
                 initialPlayback="playing"
+                onPlaylistChange={handlePlaylistChange}
+                onRequestPlaylistOpen={() => {
+                  setIsPlaylistOpen(true)
+                }}
+                onSelectedTrackChange={setSelectedTrackId}
+                onTrackDurationChange={handleTrackDurationChange}
+                playlistTracks={playlistTracks}
+                repeatEnabled={isRepeatEnabled}
                 sceneBlob={scene.sceneData}
+                selectedTrackId={selectedTrackId}
+                shuffleEnabled={isShuffleEnabled}
               />
             </div>
           </div>
@@ -295,8 +323,24 @@ export function SceneDetailPage() {
           creatorDisplayName={creatorProfile.displayName}
           currentSceneTags={scene.tags}
           isLoading={isRecommendationsLoading}
+          isPlaylistOpen={isPlaylistOpen}
+          onClosePlaylist={() => {
+            setIsPlaylistOpen(false)
+          }}
+          onPlaylistNameChange={setPlaylistName}
+          onReorderTracks={handleReorderTracks}
+          onRemoveTrack={handleRemoveTrack}
+          onSelectTrack={setSelectedTrackId}
+          onToggleRepeat={toggleRepeat}
+          onToggleShuffle={toggleShuffle}
+          onUpdateTrack={handleUpdateTrack}
+          playlistName={playlistName}
+          playlistTracks={playlistTracks}
           recommendedScenes={filteredRecommendedScenes}
           recommendationFilter={recommendationFilter}
+          repeatEnabled={isRepeatEnabled}
+          selectedTrackId={selectedTrackId}
+          shuffleEnabled={isShuffleEnabled}
           onSelectFilter={setRecommendationFilter}
         />
       </section>


### PR DESCRIPTION
## Summary

This PR adds playlist-driven audio controls to the shared `MagePlayer`, patches the published `@notrac/mage` bridge so audio playback state behaves correctly in the frontend, and refactors the new player and playlist UI into smaller modular components.

The result is a shared player that can load audio tracks, manage a playlist, scrub playback, control volume, and coordinate audio playback with scene playback while keeping the scene detail sidebar and player controls maintainable.

## What Changed

- added shared playlist utilities and tests for track normalization, ordering, and display helpers
- patched the published `@notrac/mage` package with `patch-package` so audio playback, timing, and exposed shader globals work correctly in the frontend
- expanded the shared player adapter to support audio loading, seeking, volume, errors, and synchronized playback state
- refactored `MagePlayer` into smaller player-focused modules
- added playlist-aware hover controls for playback, scrubbing, timing, and volume
- extracted scene-detail playlist state into a dedicated hook
- extracted the scene playlist sidebar into dedicated components for the panel, rows, icons, and track editor
- moved playlist panel styling into a component-scoped stylesheet
- updated player and engine integration docs to match the new behavior

## Commit Breakdown

1. `Add shared playlist utilities`
2. `Patch MAGE audio playback bridge`
3. `Refactor MagePlayer into modular components`
4. `Extract scene playlist sidebar components`
5. `Move playlist panel styles into component stylesheet`
6. `Update player and engine integration docs`

## Testing

Ran:

- `node .\\node_modules\\vitest\\vitest.mjs run src/lib/magePlayerAdapter.test.ts --reporter verbose`
- `node .\\node_modules\\vitest\\vitest.mjs run src/components/MagePlayer.test.tsx --reporter verbose`
- `npm run build`

## Notes

- the frontend now relies on a checked-in `patch-package` patch for `@notrac/mage@1.0.1`
- the large bundle and `eval` warnings still come from the published engine bundle and are unchanged by this PR
