### PR TITLE
refactor: add app layer architecture skeleton

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,9 @@ This directory holds focused implementation notes for the MAGE frontend. The rep
 - [engine-integration.md](./engine-integration.md)  
   Published engine bridge, frontend adapter responsibilities, and package caveats.
 
+- [frontend-architecture.md](./frontend-architecture.md)  
+  Initial modular-monolith folder conventions, ownership rules, and migration direction.
+
 - [login-page.md](./login-page.md)  
   Login flow behavior, session handling, and backend request shape.
 

--- a/docs/frontend-architecture.md
+++ b/docs/frontend-architecture.md
@@ -1,0 +1,62 @@
+# Frontend Architecture
+
+This document describes the initial modular-monolith direction for the frontend.
+
+## Top-Level Source Layout
+
+The frontend is moving toward this structure:
+
+```text
+src/
+  app/
+  modules/
+  shared/
+```
+
+## Ownership Rules
+
+### `app/`
+
+Use `app/` for application-wide composition:
+
+- provider composition
+- route composition
+- bootstrap-level wiring
+
+`app/` should not become a dumping ground for feature logic.
+
+### `modules/`
+
+Use `modules/` for vertical feature slices. A module should eventually own:
+
+- route-facing components
+- feature-specific UI
+- feature data access
+- internal selectors/helpers
+- feature tests and fixtures
+
+Examples of target modules include `player`, `scene-detail`, `scene-editor`, `discovery`, `my-scenes`, `auth`, `settings`, and `theme`.
+
+### `shared/`
+
+Use `shared/` only for cross-cutting concerns that are genuinely reused across multiple modules. Typical examples are:
+
+- UI primitives
+- generic formatting or storage helpers
+- app-wide style foundations
+- cross-cutting test utilities
+
+If code is mostly owned by one feature, it should stay with that feature.
+
+## Current State
+
+The repo is still in a hybrid state. Existing `pages/`, `components/`, and `lib/` directories remain in use while the modular-monolith structure is introduced. Issue `#83` establishes the skeleton and app-level composition move. Later stories will migrate feature code into modules incrementally rather than through a single rewrite.
+
+## Near-Term Refactor Sequence
+
+The intended sequence is:
+
+1. establish `app/`, `modules/`, and `shared/`
+2. move app-wide composition out of `App.tsx`
+3. formalize module entrypoints and boundaries
+4. migrate major surfaces into vertical slices over time

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,108 +1,13 @@
 import './App.css'
 import './theme/theme.css'
-import type { ReactElement } from 'react'
-import { Navigate, Route, Routes } from 'react-router-dom'
-import { AuthProvider, useAuth } from './auth/AuthContext'
-import { Layout } from './components/Layout'
-import { HomePage } from './pages/HomePage'
-import { LoginPage } from './pages/LoginPage'
-import { MyScenesPage } from './pages/MyScenesPage'
-import { SceneDetailPage } from './pages/SceneDetailPage'
-import { ScenesPage } from './pages/ScenesPage'
-import { RegisterPage } from './pages/RegisterPage'
-import { CreateScenePage } from './pages/CreateScenePage'
-import { SettingsPage } from './pages/SettingsPage'
-import { ThemeProvider } from './theme/ThemeProvider'
-
-type ProtectedRouteProps = {
-  children: ReactElement
-}
-
-function SessionRestoreState() {
-  return (
-    <main className="card">
-      <div className="eyebrow">Session</div>
-      <h1>Checking your login...</h1>
-      <p className="sub">MAGE is restoring your account before opening this page.</p>
-    </main>
-  )
-}
-
-function ProtectedRoute({ children }: ProtectedRouteProps) {
-  const { isAuthenticated, isRestoringSession } = useAuth()
-
-  if (isRestoringSession) {
-    return <SessionRestoreState />
-  }
-
-  if (!isAuthenticated) {
-    return <Navigate replace to="/login" />
-  }
-
-  return children
-}
-
-function GuestOnlyRoute({ children }: ProtectedRouteProps) {
-  const { isAuthenticated, isRestoringSession } = useAuth()
-
-  if (isRestoringSession) {
-    return <SessionRestoreState />
-  }
-
-  if (isAuthenticated) {
-    return <Navigate replace to="/" />
-  }
-
-  return children
-}
+import { AppProviders } from './app/providers'
+import { AppRoutes } from './app/routes'
 
 function App() {
   return (
-    <ThemeProvider>
-      <AuthProvider>
-        <Layout>
-          <Routes>
-            <Route path="/" element={<HomePage />} />
-            <Route path="/scenes" element={<ScenesPage />} />
-            <Route
-              path="/login"
-              element={
-                <GuestOnlyRoute>
-                  <LoginPage />
-                </GuestOnlyRoute>
-              }
-            />
-            <Route
-              path="/my-scenes"
-              element={
-                <ProtectedRoute>
-                  <MyScenesPage />
-                </ProtectedRoute>
-              }
-            />
-            <Route path="/scenes/:id" element={<SceneDetailPage />} />
-            <Route
-              path="/register"
-              element={
-                <GuestOnlyRoute>
-                  <RegisterPage />
-                </GuestOnlyRoute>
-              }
-            />
-            <Route path="/create-scene" element={<CreateScenePage />} />
-            <Route
-              path="/settings"
-              element={
-                <ProtectedRoute>
-                  <SettingsPage />
-                </ProtectedRoute>
-              }
-            />
-            <Route path="*" element={<Navigate replace to="/" />} />
-          </Routes>
-        </Layout>
-      </AuthProvider>
-    </ThemeProvider>
+    <AppProviders>
+      <AppRoutes />
+    </AppProviders>
   )
 }
 

--- a/src/app/README.md
+++ b/src/app/README.md
@@ -1,0 +1,12 @@
+# App Layer
+
+The `app/` directory owns frontend-wide composition concerns.
+
+Use this layer for:
+
+- provider composition
+- route composition
+- app bootstrap helpers
+- app-level shell wiring that is not owned by a single feature
+
+Do not put feature-specific UI or data logic here. That code should move into `modules/` as slices are created.

--- a/src/app/providers/AppProviders.tsx
+++ b/src/app/providers/AppProviders.tsx
@@ -1,0 +1,11 @@
+import type { PropsWithChildren } from 'react'
+import { AuthProvider } from '../../auth/AuthContext'
+import { ThemeProvider } from '../../theme/ThemeProvider'
+
+export function AppProviders({ children }: PropsWithChildren) {
+  return (
+    <ThemeProvider>
+      <AuthProvider>{children}</AuthProvider>
+    </ThemeProvider>
+  )
+}

--- a/src/app/providers/index.ts
+++ b/src/app/providers/index.ts
@@ -1,0 +1,1 @@
+export { AppProviders } from './AppProviders'

--- a/src/app/routes/AppRoutes.tsx
+++ b/src/app/routes/AppRoutes.tsx
@@ -1,0 +1,57 @@
+import { Navigate, Route, Routes } from 'react-router-dom'
+import { Layout } from '../../components/Layout'
+import { CreateScenePage } from '../../pages/CreateScenePage'
+import { HomePage } from '../../pages/HomePage'
+import { LoginPage } from '../../pages/LoginPage'
+import { MyScenesPage } from '../../pages/MyScenesPage'
+import { RegisterPage } from '../../pages/RegisterPage'
+import { SceneDetailPage } from '../../pages/SceneDetailPage'
+import { ScenesPage } from '../../pages/ScenesPage'
+import { SettingsPage } from '../../pages/SettingsPage'
+import { GuestOnlyRoute, ProtectedRoute } from './RouteGuards'
+
+export function AppRoutes() {
+  return (
+    <Layout>
+      <Routes>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/scenes" element={<ScenesPage />} />
+        <Route
+          path="/login"
+          element={
+            <GuestOnlyRoute>
+              <LoginPage />
+            </GuestOnlyRoute>
+          }
+        />
+        <Route
+          path="/my-scenes"
+          element={
+            <ProtectedRoute>
+              <MyScenesPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route path="/scenes/:id" element={<SceneDetailPage />} />
+        <Route
+          path="/register"
+          element={
+            <GuestOnlyRoute>
+              <RegisterPage />
+            </GuestOnlyRoute>
+          }
+        />
+        <Route path="/create-scene" element={<CreateScenePage />} />
+        <Route
+          path="/settings"
+          element={
+            <ProtectedRoute>
+              <SettingsPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route path="*" element={<Navigate replace to="/" />} />
+      </Routes>
+    </Layout>
+  )
+}

--- a/src/app/routes/RouteGuards.tsx
+++ b/src/app/routes/RouteGuards.tsx
@@ -1,0 +1,45 @@
+import type { ReactElement } from 'react'
+import { Navigate } from 'react-router-dom'
+import { useAuth } from '../../auth/AuthContext'
+
+type GuardedRouteProps = {
+  children: ReactElement
+}
+
+function SessionRestoreState() {
+  return (
+    <main className="card">
+      <div className="eyebrow">Session</div>
+      <h1>Checking your login...</h1>
+      <p className="sub">MAGE is restoring your account before opening this page.</p>
+    </main>
+  )
+}
+
+export function ProtectedRoute({ children }: GuardedRouteProps) {
+  const { isAuthenticated, isRestoringSession } = useAuth()
+
+  if (isRestoringSession) {
+    return <SessionRestoreState />
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate replace to="/login" />
+  }
+
+  return children
+}
+
+export function GuestOnlyRoute({ children }: GuardedRouteProps) {
+  const { isAuthenticated, isRestoringSession } = useAuth()
+
+  if (isRestoringSession) {
+    return <SessionRestoreState />
+  }
+
+  if (isAuthenticated) {
+    return <Navigate replace to="/" />
+  }
+
+  return children
+}

--- a/src/app/routes/index.ts
+++ b/src/app/routes/index.ts
@@ -1,0 +1,2 @@
+export { AppRoutes } from './AppRoutes'
+export { GuestOnlyRoute, ProtectedRoute } from './RouteGuards'

--- a/src/modules/README.md
+++ b/src/modules/README.md
@@ -1,0 +1,16 @@
+# Modules Layer
+
+The `modules/` directory is the long-term home for vertical feature slices.
+
+Target examples include:
+
+- `auth/`
+- `discovery/`
+- `my-scenes/`
+- `player/`
+- `scene-detail/`
+- `scene-editor/`
+- `settings/`
+- `theme/`
+
+Each module should eventually own its route-facing logic, data access, UI, tests, and internal helpers. Cross-module imports should go through stable public entrypoints once those modules are introduced.

--- a/src/shared/README.md
+++ b/src/shared/README.md
@@ -1,0 +1,12 @@
+# Shared Layer
+
+The `shared/` directory is reserved for true cross-cutting frontend code.
+
+Expected subareas:
+
+- `ui/` for reusable UI primitives
+- `lib/` for generic utilities
+- `styles/` for shared style foundations
+- `test/` for cross-cutting test helpers only
+
+Feature-specific helpers should stay inside their owning module instead of being added here by default.


### PR DESCRIPTION
## Summary
- introduce the initial `src/app`, `src/modules`, and `src/shared` frontend skeleton
- move app-wide provider and route composition out of `src/App.tsx` into dedicated `app/` entrypoints
- document the modular-monolith frontend structure and link the new architecture note from the docs index

## What Changed
- added `AppProviders` to own root provider composition
- added `AppRoutes` and route guard helpers to own route composition
- simplified `App.tsx` so it only wires the top-level app shell together
- added README guidance for the new `app/`, `modules/`, and `shared/` layers
- added `docs/frontend-architecture.md` describing ownership rules, current hybrid state, and the intended migration sequence

## Testing
- `npm run build`
- `npm run lint` *(currently failing due to pre-existing lint issues outside this change set)*
