### PR TITLE
fix(theme): correct classic facebook fallback thumbnails

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1458,6 +1458,10 @@
   background: var(--card-thumbnail-image-background);
 }
 
+.mage-scene-card__thumb--fallback {
+  background: var(--card-thumbnail-placeholder-background);
+}
+
 .mage-scene-card__thumb::after {
   content: "";
   position: absolute;

--- a/src/components/my-scenes/MyScenesTable.tsx
+++ b/src/components/my-scenes/MyScenesTable.tsx
@@ -128,9 +128,8 @@ export function MyScenesTable({
                   <div
                     className="my-scenes-row__thumb-fallback"
                     aria-label={`${scene.name} thumbnail unavailable`}
-                  >
-                    No thumbnail available
-                  </div>
+                    role="img"
+                  />
                 )}
               </Link>
               <div className="my-scenes-row__copy">

--- a/src/components/scene-detail/SceneRecommendationRail.tsx
+++ b/src/components/scene-detail/SceneRecommendationRail.tsx
@@ -177,7 +177,7 @@ export function SceneRecommendationRail({
               ) : (
                 <div
                   aria-hidden="true"
-                  className="mage-scene-card__thumb"
+                  className="mage-scene-card__thumb mage-scene-card__thumb--fallback"
                   style={{ '--scene-accent': recommendedScene.accent } as CSSProperties}
                 />
               )}


### PR DESCRIPTION
## Summary

This PR fixes two classic theme thumbnail fallback issues.

In the My Scenes table, scenes without a thumbnail no longer show the visible "No thumbnail available" label. The fallback still preserves an accessible label, but the tile now renders as a visual placeholder only.

In the scene detail right sidebar, recommended scenes without thumbnails now use the shared fallback thumbnail class and theme placeholder token, so the classic theme gets its own fallback styling instead of inheriting the Mage Pulse-style thumbnail treatment.

## What Changed

- removed the visible fallback text from the My Scenes thumbnail placeholder
- kept the My Scenes fallback accessible with a thumbnail-unavailable label
- added a dedicated fallback modifier class for recommendation rail thumbnails
- mapped fallback recommendation thumbnails to `--card-thumbnail-placeholder-background`

## Testing

- `npx tsc -b`
- `npm run lint`
