### PR TITLE
56 update the registration page to include first and last name fields

### DIFF
--- a/docs/registration-page.md
+++ b/docs/registration-page.md
@@ -17,8 +17,8 @@ Access:
 
 - `src/pages/RegisterPage.tsx`
 - `src/lib/api.ts`
-- `src/lib/authForm.ts`
 - `src/pages/RegisterPage.test.tsx`
+- `src/shared/ui/TextInputField.tsx`
 
 ## Request Flow
 
@@ -30,6 +30,8 @@ Expected request body:
 
 ```json
 {
+  "firstName": "Example",
+  "lastName": "User",
   "displayName": "Example User",
   "email": "user@example.com",
   "password": "example-password"
@@ -40,20 +42,24 @@ Requests are built through `buildApiUrl()`. For local development, leave `VITE_A
 
 ## User-Facing Behavior
 
-- validates display name, email, and password before submission
+- validates first name, last name, display name, email, and password before submission
+- requires a minimum first-name length of `2`
+- requires a minimum last-name length of `2`
 - requires a minimum display-name length of `2`
 - requires a minimum password length of `8`
 - disables the submit button while the request is in flight
-- surfaces backend validation details when present
+- surfaces backend validation details for first name, last name, display name, email, and password when present
 - surfaces conflict responses such as duplicate-email registration
 - redirects to `/login` on success
 - passes the registered email and a success notice into login page state
+- explains that display name is the public name shown on scenes and comments
 
 ## Current Scope
 
 The registration page currently supports:
 
 - local account creation
+- separate first name, last name, and public display name inputs
 - client-side validation
 - backend error handling
 - post-registration redirect into login

--- a/src/pages/RegisterPage.test.tsx
+++ b/src/pages/RegisterPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { describe, expect, it, vi } from 'vitest'
@@ -21,7 +21,9 @@ function renderRegisterPage() {
 }
 
 async function fillValidForm(user: ReturnType<typeof userEvent.setup>) {
-  await user.type(screen.getByLabelText(/display name/i), ' New User ')
+  await user.type(screen.getByLabelText(/first name/i), ' Ada ')
+  await user.type(screen.getByLabelText(/last name/i), ' Lovelace ')
+  await user.type(screen.getByLabelText(/display name/i), ' Countess Ada ')
   await user.type(screen.getByLabelText(/^email$/i), ' user@example.com ')
   await user.type(screen.getByLabelText(/password/i), 'secret-value')
 }
@@ -33,15 +35,21 @@ describe('RegisterPage', () => {
 
     renderRegisterPage()
 
+    expect(
+      screen.getByText('This is the public name shown on scenes and comments.'),
+    ).toBeInTheDocument()
+
     await user.click(screen.getByRole('button', { name: /create account/i }))
 
-    expect(await screen.findByText('Display name is required.')).toBeInTheDocument()
+    expect(await screen.findByText('First name is required.')).toBeInTheDocument()
+    expect(screen.getByText('Last name is required.')).toBeInTheDocument()
+    expect(screen.getByText('Display name is required.')).toBeInTheDocument()
     expect(screen.getByText('Email is required.')).toBeInTheDocument()
     expect(screen.getByText('Password is required.')).toBeInTheDocument()
     expect(fetchSpy).not.toHaveBeenCalled()
   })
 
-  it('submits trimmed values with default first and last names, disables the button while loading, and hands the user into login', async () => {
+  it('submits trimmed first name, last name, and display name values, disables the button while loading, and hands the user into login', async () => {
     let resolveResponse: ((value: Response) => void) | undefined
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
       () =>
@@ -56,19 +64,21 @@ describe('RegisterPage', () => {
     await fillValidForm(user)
     await user.click(screen.getByRole('button', { name: /create account/i }))
 
-    expect(fetchSpy).toHaveBeenCalledWith(
-      buildApiUrl('/auth/register'),
-      expect.objectContaining({
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      }),
+    await waitFor(() =>
+      expect(fetchSpy).toHaveBeenCalledWith(
+        buildApiUrl('/auth/register'),
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }),
+      ),
     )
     expect(JSON.parse(String(fetchSpy.mock.calls[0][1]?.body))).toEqual({
-      firstName: 'NoName',
-      lastName: 'NoName',
-      displayName: 'New User',
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      displayName: 'Countess Ada',
       email: 'user@example.com',
       password: 'secret-value',
     })
@@ -123,6 +133,8 @@ describe('RegisterPage', () => {
         JSON.stringify({
           message: 'Registration failed. Please review your information and try again.',
           details: {
+            firstName: 'firstName must not be blank',
+            lastName: 'lastName must not be blank',
             displayName: 'displayName must not be blank',
             email: 'email must not be blank',
             password: 'password must not be blank',
@@ -143,7 +155,9 @@ describe('RegisterPage', () => {
     await fillValidForm(user)
     await user.click(screen.getByRole('button', { name: /create account/i }))
 
-    expect(await screen.findByText('displayName must not be blank')).toBeInTheDocument()
+    expect(await screen.findByText('firstName must not be blank')).toBeInTheDocument()
+    expect(screen.getByText('lastName must not be blank')).toBeInTheDocument()
+    expect(screen.getByText('displayName must not be blank')).toBeInTheDocument()
     expect(screen.getByText('email must not be blank')).toBeInTheDocument()
     expect(screen.getByText('password must not be blank')).toBeInTheDocument()
   })

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -27,15 +27,12 @@ type RegistrationResponse = {
 }
 
 const initialValues: RegistrationFormValues = {
-  firstName:'',
+  firstName: '',
   lastName: '',
   displayName: '',
   email: '',
   password: '',
 }
-
-const DEFAULT_REGISTRATION_FIRST_NAME = 'NoName'
-const DEFAULT_REGISTRATION_LAST_NAME = 'NoName'
 
 function validateRegistrationForm(values: RegistrationFormValues): RegistrationFormErrors {
   const errors: RegistrationFormErrors = {}
@@ -125,7 +122,7 @@ export function RegisterPage() {
     setErrors({})
 
     try {
-      const response = await fetch(buildApiUrl('/api/auth/register'), {
+      const response = await fetch(buildApiUrl('/auth/register'), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -142,6 +139,8 @@ export function RegisterPage() {
             : undefined
 
         setErrors({
+          firstName: backendDetails.firstName,
+          lastName: backendDetails.lastName,
           displayName: backendDetails.displayName,
           email: backendDetails.email,
           password: backendDetails.password,
@@ -183,7 +182,7 @@ export function RegisterPage() {
 
           <form className="auth-form" noValidate onSubmit={handleSubmit}>
             <TextInputField
-              autoComplete="first-name"
+              autoComplete="given-name"
               error={errors.firstName}
               id="firstName"
               label="First name"
@@ -196,7 +195,7 @@ export function RegisterPage() {
               value={values.firstName}
             />
             <TextInputField
-              autoComplete="last-name"
+              autoComplete="family-name"
               error={errors.lastName}
               id="lastName"
               label="Last name"
@@ -211,6 +210,7 @@ export function RegisterPage() {
             <TextInputField
               autoComplete="nickname"
               error={errors.displayName}
+              hint="This is the public name shown on scenes and comments."
               id="displayName"
               label="Display name"
               minLength={2}


### PR DESCRIPTION
## Summary

Closes #56.

This PR updates the registration flow to match the new backend contract by collecting `firstName`, `lastName`, and `displayName` separately instead of relying on a single display-name input.

## What Changed

- added separate first name, last name, and display name handling to the register page
- updated registration submission to send:
  - `firstName`
  - `lastName`
  - `displayName`
  - `email`
  - `password`
- surfaced backend validation errors for first name and last name in addition to the existing display name, email, and password errors
- clarified in the form UI that display name is the public name shown on scenes and comments
- updated registration tests to cover:
  - client-side validation for first name, last name, and display name
  - trimmed request payload submission
  - backend validation error mapping for all name fields
  - existing login redirect behavior after successful registration
- updated registration docs to reflect the new request shape and behavior

## Testing

- `npm test -- --run src/pages/RegisterPage.test.tsx`
- `npx tsc -b`
- `npm run lint`
- `npm test`
