### PR TITLE
92 modularize tests and add module local fixture builders

### DIFF
--- a/docs/frontend-architecture.md
+++ b/docs/frontend-architecture.md
@@ -35,6 +35,13 @@ Use `modules/` for vertical feature slices. A module should eventually own:
 - internal selectors/helpers
 - feature tests and fixtures
 
+Tests should follow the same ownership rule as production code:
+
+- keep module-specific specs next to the owning module instead of in generic top-level test buckets
+- split large integration-style specs into smaller files grouped by module behavior
+- add module-local `test-fixtures.ts` or `test-fixtures.tsx` builders when a feature needs richer sample data
+- keep `src/shared/test/` limited to true cross-cutting helpers such as shared auth/session or HTTP response setup
+
 Examples of target modules include `player`, `scene-detail`, `scene-editor`, `discovery`, `my-scenes`, `auth`, `settings`, and `theme`.
 
 The current `src/theme/` directory is already treated as a dedicated module boundary with its own public API, even though the broader module migration is still in progress.

--- a/src/modules/README.md
+++ b/src/modules/README.md
@@ -15,6 +15,12 @@ Target examples include:
 
 Each module should eventually own its route-facing logic, data access, UI, tests, and internal helpers. Cross-module imports should go through stable public entrypoints once those modules are introduced.
 
+Testing follows the same boundary:
+
+- prefer colocated module specs over oversized app-level test files
+- keep complex fixture builders in module-local `test-fixtures.ts` or `test-fixtures.tsx`
+- use `src/shared/test/` only for helpers that are genuinely reused across modules
+
 Current module-owned feature slices include:
 
 - `auth/`

--- a/src/modules/my-scenes/MyScenesPage.sample-scenes.test.tsx
+++ b/src/modules/my-scenes/MyScenesPage.sample-scenes.test.tsx
@@ -1,0 +1,112 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { buildApiUrl } from '@lib/api'
+import { jsonResponse } from '@shared/test/http'
+import {
+  buildMyScenesApiScene,
+  buildMyScenesStoredUser,
+  renderMyScenesPage,
+  storeMyScenesSession,
+} from './test-fixtures'
+
+vi.mock('@modules/player', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@modules/player')>()
+
+  return {
+    ...actual,
+    MagePlayer: ({
+      ariaLabel,
+      className,
+      sceneBlob,
+    }: {
+      ariaLabel?: string
+      className?: string
+      sceneBlob: unknown
+    }) => (
+      <div aria-label={ariaLabel} className={className} data-testid="mage-player">
+        {sceneBlob ? 'player-ready' : 'no-scene'}
+      </div>
+    ),
+  }
+})
+
+describe('MyScenesPage sample scene seeding', () => {
+  it('adds sample scenes from the empty state and reloads the list', async () => {
+    storeMyScenesSession()
+
+    const storedUser = buildMyScenesStoredUser()
+    const createdSceneBodies: Array<Record<string, unknown>> = []
+    let sceneListRequestCount = 0
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      if (input === buildApiUrl('/users/me')) {
+        return Promise.resolve(jsonResponse(storedUser))
+      }
+
+      if (input === buildApiUrl('/users/8/scenes')) {
+        sceneListRequestCount += 1
+
+        return Promise.resolve(
+          jsonResponse(
+            sceneListRequestCount === 1
+              ? []
+              : [
+                  buildMyScenesApiScene({
+                    id: 21,
+                    sceneId: 21,
+                  }),
+                  buildMyScenesApiScene({
+                    id: 22,
+                    name: 'Signal Bloom',
+                    sceneId: 22,
+                    thumbnailRef: null,
+                  }),
+                  buildMyScenesApiScene({
+                    id: 23,
+                    name: 'Glacier Echo',
+                    sceneId: 23,
+                    thumbnailRef: 'thumbnails/scene-23.png',
+                  }),
+                  buildMyScenesApiScene({
+                    id: 24,
+                    name: 'Solar Thread',
+                    sceneId: 24,
+                    thumbnailRef: 'thumbnails/scene-24.png',
+                  }),
+                ],
+          ),
+        )
+      }
+
+      if (input === buildApiUrl('/scenes')) {
+        createdSceneBodies.push(
+          JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>,
+        )
+
+        return Promise.resolve(
+          jsonResponse(
+            {
+              sceneId: 20 + createdSceneBodies.length,
+            },
+            201,
+          ),
+        )
+      }
+
+      throw new Error(`Unexpected request: ${String(input)}`)
+    })
+    const user = userEvent.setup()
+
+    renderMyScenesPage()
+
+    expect(await screen.findByText(/no scenes yet/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /add sample scenes/i }))
+
+    expect(await screen.findByRole('link', { name: /aurora drift/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /signal bloom/i })).toBeInTheDocument()
+    expect(createdSceneBodies).toHaveLength(4)
+    expect(sceneListRequestCount).toBe(2)
+  })
+})

--- a/src/modules/my-scenes/MyScenesPage.table.test.tsx
+++ b/src/modules/my-scenes/MyScenesPage.table.test.tsx
@@ -1,0 +1,304 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { buildApiUrl } from '@lib/api'
+import { jsonResponse } from '@shared/test/http'
+import {
+  buildMyScenesApiScene,
+  buildMyScenesStoredUser,
+  renderMyScenesPage,
+  storeMyScenesSession,
+} from './test-fixtures'
+
+vi.mock('@modules/player', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@modules/player')>()
+
+  return {
+    ...actual,
+    MagePlayer: ({
+      ariaLabel,
+      className,
+      sceneBlob,
+    }: {
+      ariaLabel?: string
+      className?: string
+      sceneBlob: unknown
+    }) => (
+      <div aria-label={ariaLabel} className={className} data-testid="mage-player">
+        {sceneBlob ? 'player-ready' : 'no-scene'}
+      </div>
+    ),
+  }
+})
+
+describe('MyScenesPage table behavior', () => {
+  it('renders the populated scene state with thumbnails, fallback UI, and navigation', async () => {
+    storeMyScenesSession()
+
+    const storedUser = buildMyScenesStoredUser()
+    const mockScenes = [
+      buildMyScenesApiScene(),
+      buildMyScenesApiScene({
+        createdAt: '2026-04-06T14:10:00Z',
+        description: undefined,
+        id: 2,
+        name: 'Signal Bloom',
+        sceneId: 2,
+        thumbnailRef: null,
+      }),
+      buildMyScenesApiScene({
+        createdAt: '2026-04-06T14:20:00Z',
+        description: undefined,
+        id: 3,
+        name: 'Very Long Scene Name To Test Wrapping In The Card Layout',
+        sceneId: 3,
+        thumbnailRef: 'thumbnails/scene-3.png',
+      }),
+    ]
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      if (input === buildApiUrl('/users/me')) {
+        return Promise.resolve(jsonResponse(storedUser))
+      }
+
+      if (input === buildApiUrl('/users/8/scenes')) {
+        return Promise.resolve(jsonResponse(mockScenes))
+      }
+
+      if (input === buildApiUrl('/scenes/1')) {
+        return Promise.resolve(jsonResponse(mockScenes[0]))
+      }
+
+      throw new Error(`Unexpected request: ${String(input)}`)
+    })
+    const user = userEvent.setup()
+
+    renderMyScenesPage()
+
+    const auroraScene = await screen.findByRole('link', { name: /aurora drift/i })
+
+    expect(auroraScene).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /signal bloom/i })).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', {
+        name: /very long scene name to test wrapping in the card layout/i,
+      }),
+    ).toBeInTheDocument()
+    expect(screen.getAllByText('Public')).toHaveLength(4)
+    expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Public' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /soft teal bloom with low-end drift\./i }),
+    ).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: /add description/i })).toHaveLength(2)
+    expect(screen.getByAltText('Aurora Drift thumbnail')).toBeInTheDocument()
+    expect(
+      screen.getByAltText('Very Long Scene Name To Test Wrapping In The Card Layout thumbnail'),
+    ).toBeInTheDocument()
+    expect(screen.getByLabelText('Signal Bloom thumbnail unavailable')).toBeInTheDocument()
+    expect(screen.getByText('1-3 of 3')).toBeInTheDocument()
+
+    const selectAllCheckbox = screen.getByRole('checkbox', {
+      name: /select all scenes on this page/i,
+    })
+
+    await user.click(selectAllCheckbox)
+
+    expect(screen.getByRole('checkbox', { name: /select aurora drift/i })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: /select signal bloom/i })).toBeChecked()
+    expect(
+      screen.getByRole('checkbox', {
+        name: /select very long scene name to test wrapping in the card layout/i,
+      }),
+    ).toBeChecked()
+
+    await user.click(auroraScene)
+
+    expect(await screen.findByTestId('mage-player')).toHaveTextContent('player-ready')
+    expect(screen.getByRole('heading', { name: /aurora drift/i })).toBeInTheDocument()
+  })
+
+  it('filters the table with the visible status pills', async () => {
+    storeMyScenesSession()
+
+    const storedUser = buildMyScenesStoredUser()
+    const mockScenes = [
+      buildMyScenesApiScene(),
+      buildMyScenesApiScene({
+        createdAt: '2026-04-06T14:10:00Z',
+        id: 2,
+        name: 'Signal Bloom',
+        sceneId: 2,
+        thumbnailRef: null,
+      }),
+      buildMyScenesApiScene({
+        createdAt: '2026-04-06T14:20:00Z',
+        id: 3,
+        name: 'Glacier Echo',
+        sceneId: 3,
+      }),
+    ]
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      if (input === buildApiUrl('/users/me')) {
+        return Promise.resolve(jsonResponse(storedUser))
+      }
+
+      if (input === buildApiUrl('/users/8/scenes')) {
+        return Promise.resolve(jsonResponse(mockScenes))
+      }
+
+      throw new Error(`Unexpected request: ${String(input)}`)
+    })
+    const user = userEvent.setup()
+
+    renderMyScenesPage()
+
+    expect(await screen.findByRole('button', { name: 'All' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Public' })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Public' }))
+
+    expect(screen.getByText('3 scenes')).toBeInTheDocument()
+    expect(screen.getAllByText('Public')).toHaveLength(4)
+  })
+
+  it('sorts the table when updated, views, and likes headers are clicked', async () => {
+    storeMyScenesSession()
+
+    const storedUser = buildMyScenesStoredUser()
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      if (input === buildApiUrl('/users/me')) {
+        return Promise.resolve(jsonResponse(storedUser))
+      }
+
+      if (input === buildApiUrl('/users/8/scenes')) {
+        return Promise.resolve(
+          jsonResponse([
+            buildMyScenesApiScene({
+              createdAt: '2026-04-06T14:10:00Z',
+              id: 7,
+              name: 'Signal Bloom',
+              sceneId: 7,
+            }),
+            buildMyScenesApiScene({
+              createdAt: '2026-04-06T14:00:00Z',
+              id: 2,
+              sceneId: 2,
+            }),
+            buildMyScenesApiScene({
+              createdAt: '2026-04-06T14:30:00Z',
+              id: 13,
+              name: 'Solar Thread',
+              sceneId: 13,
+            }),
+          ]),
+        )
+      }
+
+      throw new Error(`Unexpected request: ${String(input)}`)
+    })
+    const user = userEvent.setup()
+
+    renderMyScenesPage()
+
+    await screen.findByRole('link', { name: /signal bloom/i })
+
+    const titleLinks = () =>
+      screen
+        .getAllByRole('link')
+        .filter(
+          (link) =>
+            /\/scenes\/\d+$/.test(link.getAttribute('href') ?? '') &&
+            !/Open scene preview/i.test(link.getAttribute('aria-label') ?? ''),
+        )
+
+    expect(titleLinks().map((link) => link.textContent)).toEqual([
+      'Solar Thread',
+      'Signal Bloom',
+      'Aurora Drift',
+    ])
+    expect(screen.getByText('Newest items first')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /sort by views descending/i }))
+
+    expect(titleLinks().map((link) => link.textContent)).toEqual([
+      'Solar Thread',
+      'Signal Bloom',
+      'Aurora Drift',
+    ])
+    expect(screen.getByText('Highest views first')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /sort by views ascending/i }))
+
+    expect(titleLinks().map((link) => link.textContent)).toEqual([
+      'Aurora Drift',
+      'Signal Bloom',
+      'Solar Thread',
+    ])
+    expect(screen.getByText('Lowest views first')).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole('button', { name: /sort by likes \(vs dislikes\) descending/i }),
+    )
+
+    expect(titleLinks().map((link) => link.textContent)).toEqual([
+      'Solar Thread',
+      'Aurora Drift',
+      'Signal Bloom',
+    ])
+    expect(screen.getByText('Highest likes ratio first')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /sort by updated descending/i }))
+    await user.click(screen.getByRole('button', { name: /sort by updated ascending/i }))
+
+    expect(titleLinks().map((link) => link.textContent)).toEqual([
+      'Aurora Drift',
+      'Signal Bloom',
+      'Solar Thread',
+    ])
+    expect(screen.getByText('Oldest items first')).toBeInTheDocument()
+  })
+
+  it('paginates the table and shows the footer controls', async () => {
+    storeMyScenesSession()
+
+    const storedUser = buildMyScenesStoredUser()
+    const paginatedScenes = Array.from({ length: 31 }, (_, index) => {
+      const sceneNumber = index + 1
+      const day = String(sceneNumber).padStart(2, '0')
+
+      return buildMyScenesApiScene({
+        createdAt: `2026-04-${day}T14:00:00Z`,
+        id: sceneNumber,
+        name: `Scene ${sceneNumber}`,
+        sceneId: sceneNumber,
+      })
+    })
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      if (input === buildApiUrl('/users/me')) {
+        return Promise.resolve(jsonResponse(storedUser))
+      }
+
+      if (input === buildApiUrl('/users/8/scenes')) {
+        return Promise.resolve(jsonResponse(paginatedScenes))
+      }
+
+      throw new Error(`Unexpected request: ${String(input)}`)
+    })
+    const user = userEvent.setup()
+
+    renderMyScenesPage()
+
+    expect(await screen.findByText('1-30 of 31')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Scene 31' })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Scene 1' })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /go to next page/i }))
+
+    expect(await screen.findByText('31-31 of 31')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Scene 1' })).toBeInTheDocument()
+  })
+})

--- a/src/modules/my-scenes/MyScenesPage.test.tsx
+++ b/src/modules/my-scenes/MyScenesPage.test.tsx
@@ -1,12 +1,14 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { describe, expect, it, vi } from 'vitest'
-import { AUTH_SESSION_STORAGE_KEY, AuthProvider, type AuthenticatedUser } from '@auth'
-import { LoginPage } from '@modules/auth'
 import { buildApiUrl } from '@lib/api'
-import { SceneDetailPage } from '@modules/scene-detail'
-import { MyScenesPage } from './MyScenesPage'
+import { jsonResponse } from '@shared/test/http'
+import {
+  buildMyScenesApiScene,
+  buildMyScenesStoredUser,
+  renderMyScenesPage,
+  storeMyScenesSession,
+} from './test-fixtures'
 
 vi.mock('@modules/player', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@modules/player')>()
@@ -29,81 +31,7 @@ vi.mock('@modules/player', async (importOriginal) => {
   }
 })
 
-const storedUser: AuthenticatedUser = {
-  userId: 8,
-  email: 'artist@example.com',
-  displayName: 'Scene Artist',
-  authProvider: 'LOCAL',
-}
-
-const mockScenes = [
-  {
-    sceneId: 1,
-    ownerUserId: 42,
-    name: 'Aurora Drift',
-    description: 'Soft teal bloom with low-end drift.',
-    sceneData: {
-      visualizer: { shader: 'nebula' },
-    },
-    thumbnailRef: 'thumbnails/scene-1.png',
-    createdAt: '2026-04-06T14:00:00Z',
-  },
-  {
-    sceneId: 2,
-    ownerUserId: 42,
-    name: 'Signal Bloom',
-    sceneData: {
-      visualizer: { shader: 'pulse' },
-    },
-    thumbnailRef: null,
-    createdAt: '2026-04-06T14:10:00Z',
-  },
-  {
-    sceneId: 3,
-    ownerUserId: 42,
-    name: 'Very Long Scene Name To Test Wrapping In The Card Layout',
-    sceneData: {
-      visualizer: { shader: 'glacier' },
-    },
-    thumbnailRef: 'thumbnails/scene-3.png',
-    createdAt: '2026-04-06T14:20:00Z',
-  },
-]
-
-function jsonResponse(payload: unknown, status = 200) {
-  return new Response(JSON.stringify(payload), {
-    status,
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  })
-}
-
-function storeSession() {
-  window.localStorage.setItem(
-    AUTH_SESSION_STORAGE_KEY,
-    JSON.stringify({
-      accessToken: 'stored-auth-token',
-      user: storedUser,
-    }),
-  )
-}
-
-function renderMyScenesPage(initialEntries = ['/my-scenes']) {
-  return render(
-    <MemoryRouter initialEntries={initialEntries}>
-      <AuthProvider>
-        <Routes>
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/my-scenes" element={<MyScenesPage />} />
-          <Route path="/scenes/:id" element={<SceneDetailPage />} />
-        </Routes>
-      </AuthProvider>
-    </MemoryRouter>,
-  )
-}
-
-describe('MyScenesPage', () => {
+describe('MyScenesPage states', () => {
   it('redirects signed-out visitors to login', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch')
 
@@ -114,9 +42,10 @@ describe('MyScenesPage', () => {
   })
 
   it('shows a loading state while scenes are being fetched', async () => {
-    storeSession()
+    storeMyScenesSession()
 
     let resolveScenesResponse: ((value: Response) => void) | undefined
+    const storedUser = buildMyScenesStoredUser()
 
     vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
       if (input === buildApiUrl('/users/me')) {
@@ -144,7 +73,17 @@ describe('MyScenesPage', () => {
   })
 
   it('renders the authenticated users scenes and opens the scene detail route', async () => {
-    storeSession()
+    storeMyScenesSession()
+
+    const storedUser = buildMyScenesStoredUser()
+    const auroraScene = buildMyScenesApiScene({ id: 12, sceneId: 12 })
+    const signalScene = buildMyScenesApiScene({
+      id: 13,
+      name: 'Signal Bloom',
+      sceneId: 13,
+      sceneData: undefined,
+      thumbnailRef: null,
+    })
 
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
       if (input === buildApiUrl('/users/me')) {
@@ -152,36 +91,11 @@ describe('MyScenesPage', () => {
       }
 
       if (input === buildApiUrl('/users/8/scenes')) {
-        return Promise.resolve(
-          jsonResponse([
-            {
-              id: 12,
-              name: 'Aurora Drift',
-              sceneData: {
-                visualizer: { shader: 'nebula' },
-              },
-            },
-            {
-              id: 13,
-              name: 'Signal Bloom',
-            },
-          ]),
-        )
+        return Promise.resolve(jsonResponse([auroraScene, signalScene]))
       }
 
       if (input === buildApiUrl('/scenes/12')) {
-        return Promise.resolve(
-          jsonResponse({
-            sceneId: 12,
-            ownerUserId: 8,
-            name: 'Aurora Drift',
-            sceneData: {
-              visualizer: { shader: 'nebula' },
-            },
-            thumbnailRef: 'thumbnails/scene-12.png',
-            createdAt: '2026-04-06T14:00:00Z',
-          }),
-        )
+        return Promise.resolve(jsonResponse(auroraScene))
       }
 
       throw new Error(`Unexpected request: ${String(input)}`)
@@ -209,81 +123,10 @@ describe('MyScenesPage', () => {
     expect(screen.getByRole('heading', { name: /aurora drift/i })).toBeInTheDocument()
   })
 
-  it('renders the populated scene state with thumbnails, fallback UI, and navigation', async () => {
-    storeSession()
-
-    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
-      if (input === buildApiUrl('/users/me')) {
-        return Promise.resolve(jsonResponse(storedUser))
-      }
-
-      if (input === buildApiUrl('/users/8/scenes')) {
-        return Promise.resolve(jsonResponse(mockScenes))
-      }
-
-      if (input === buildApiUrl('/scenes/1')) {
-        return Promise.resolve(
-          jsonResponse({
-            sceneId: 1,
-            ownerUserId: 42,
-            name: 'Aurora Drift',
-            sceneData: {
-              visualizer: { shader: 'nebula' },
-            },
-            thumbnailRef: 'thumbnails/scene-1.png',
-            createdAt: '2026-04-06T14:00:00Z',
-          }),
-        )
-      }
-
-      throw new Error(`Unexpected request: ${String(input)}`)
-    })
-    const user = userEvent.setup()
-
-    renderMyScenesPage()
-
-    const auroraScene = await screen.findByRole('link', { name: /aurora drift/i })
-
-    expect(auroraScene).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /signal bloom/i })).toBeInTheDocument()
-    expect(
-      screen.getByRole('link', { name: /very long scene name to test wrapping in the card layout/i }),
-    ).toBeInTheDocument()
-    expect(screen.getAllByText('Public')).toHaveLength(4)
-    expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Public' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /soft teal bloom with low-end drift\./i })).toBeInTheDocument()
-    expect(screen.getAllByRole('button', { name: /add description/i })).toHaveLength(2)
-    expect(screen.getByAltText('Aurora Drift thumbnail')).toBeInTheDocument()
-    expect(
-      screen.getByAltText('Very Long Scene Name To Test Wrapping In The Card Layout thumbnail'),
-    ).toBeInTheDocument()
-    expect(screen.getByLabelText('Signal Bloom thumbnail unavailable')).toBeInTheDocument()
-    expect(screen.getByText('1-3 of 3')).toBeInTheDocument()
-
-    const selectAllCheckbox = screen.getByRole('checkbox', {
-      name: /select all scenes on this page/i,
-    })
-
-    await user.click(selectAllCheckbox)
-
-    expect(screen.getByRole('checkbox', { name: /select aurora drift/i })).toBeChecked()
-    expect(screen.getByRole('checkbox', { name: /select signal bloom/i })).toBeChecked()
-    expect(
-      screen.getByRole('checkbox', {
-        name: /select very long scene name to test wrapping in the card layout/i,
-      }),
-    ).toBeChecked()
-
-    await user.click(auroraScene)
-
-    expect(await screen.findByTestId('mage-player')).toHaveTextContent('player-ready')
-    expect(screen.getByRole('heading', { name: /aurora drift/i })).toBeInTheDocument()
-  })
-
   it('shows empty and error states using simple messages', async () => {
-    storeSession()
+    storeMyScenesSession()
 
+    const storedUser = buildMyScenesStoredUser()
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
       if (input === buildApiUrl('/users/me')) {
         return Promise.resolve(jsonResponse(storedUser))
@@ -312,7 +155,9 @@ describe('MyScenesPage', () => {
   })
 
   it('shows a description placeholder when no description is stored', async () => {
-    storeSession()
+    storeMyScenesSession()
+
+    const storedUser = buildMyScenesStoredUser()
 
     vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
       if (input === buildApiUrl('/users/me')) {
@@ -322,19 +167,19 @@ describe('MyScenesPage', () => {
       if (input === buildApiUrl('/users/8/scenes')) {
         return Promise.resolve(
           jsonResponse([
-            {
+            buildMyScenesApiScene({
+              description: null,
               id: 31,
               name: 'Custom Shader Scene',
-              description: null,
               sceneData: {
                 visualizer: {
                   shader:
                     'let size = input() let pointerDown = input() time = 0.3*time rotateY(mouse.x * 2 * PI / 2 * (1+nsin(time)))',
                 },
               },
+              sceneId: 31,
               thumbnailRef: null,
-              createdAt: '2026-04-06T14:00:00Z',
-            },
+            }),
           ]),
         )
       }
@@ -347,256 +192,5 @@ describe('MyScenesPage', () => {
     expect(await screen.findByText('Custom Shader Scene')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /add description/i })).toBeInTheDocument()
     expect(screen.queryByText(/let size = input/i)).not.toBeInTheDocument()
-  })
-
-  it('filters the table with the visible status pills', async () => {
-    storeSession()
-
-    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
-      if (input === buildApiUrl('/users/me')) {
-        return Promise.resolve(jsonResponse(storedUser))
-      }
-
-      if (input === buildApiUrl('/users/8/scenes')) {
-        return Promise.resolve(jsonResponse(mockScenes))
-      }
-
-      throw new Error(`Unexpected request: ${String(input)}`)
-    })
-    const user = userEvent.setup()
-
-    renderMyScenesPage()
-
-    expect(await screen.findByRole('button', { name: 'All' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Public' })).toBeInTheDocument()
-
-    await user.click(screen.getByRole('button', { name: 'Public' }))
-
-    expect(screen.getByText('3 scenes')).toBeInTheDocument()
-    expect(screen.getAllByText('Public')).toHaveLength(4)
-  })
-
-  it('sorts the table when updated, views, and likes headers are clicked', async () => {
-    storeSession()
-
-    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
-      if (input === buildApiUrl('/users/me')) {
-        return Promise.resolve(jsonResponse(storedUser))
-      }
-
-      if (input === buildApiUrl('/users/8/scenes')) {
-        return Promise.resolve(
-          jsonResponse([
-            {
-              id: 7,
-              name: 'Signal Bloom',
-              createdAt: '2026-04-06T14:10:00Z',
-            },
-            {
-              id: 2,
-              name: 'Aurora Drift',
-              createdAt: '2026-04-06T14:00:00Z',
-            },
-            {
-              id: 13,
-              name: 'Solar Thread',
-              createdAt: '2026-04-06T14:30:00Z',
-            },
-          ]),
-        )
-      }
-
-      throw new Error(`Unexpected request: ${String(input)}`)
-    })
-    const user = userEvent.setup()
-
-    renderMyScenesPage()
-
-    await screen.findByRole('link', { name: /signal bloom/i })
-
-    const titleLinks = () =>
-      screen
-        .getAllByRole('link')
-        .filter(
-          (link) =>
-            /\/scenes\/\d+$/.test(link.getAttribute('href') ?? '') &&
-            !/Open scene preview/i.test(link.getAttribute('aria-label') ?? ''),
-        )
-
-    expect(titleLinks().map((link) => link.textContent)).toEqual([
-      'Solar Thread',
-      'Signal Bloom',
-      'Aurora Drift',
-    ])
-    expect(screen.getByText('Newest items first')).toBeInTheDocument()
-
-    await user.click(screen.getByRole('button', { name: /sort by views descending/i }))
-
-    expect(titleLinks().map((link) => link.textContent)).toEqual([
-      'Solar Thread',
-      'Signal Bloom',
-      'Aurora Drift',
-    ])
-    expect(screen.getByText('Highest views first')).toBeInTheDocument()
-
-    await user.click(screen.getByRole('button', { name: /sort by views ascending/i }))
-
-    expect(titleLinks().map((link) => link.textContent)).toEqual([
-      'Aurora Drift',
-      'Signal Bloom',
-      'Solar Thread',
-    ])
-    expect(screen.getByText('Lowest views first')).toBeInTheDocument()
-
-    await user.click(screen.getByRole('button', { name: /sort by likes \(vs dislikes\) descending/i }))
-
-    expect(titleLinks().map((link) => link.textContent)).toEqual([
-      'Solar Thread',
-      'Aurora Drift',
-      'Signal Bloom',
-    ])
-    expect(screen.getByText('Highest likes ratio first')).toBeInTheDocument()
-
-    await user.click(screen.getByRole('button', { name: /sort by updated descending/i }))
-    await user.click(screen.getByRole('button', { name: /sort by updated ascending/i }))
-
-    expect(titleLinks().map((link) => link.textContent)).toEqual([
-      'Aurora Drift',
-      'Signal Bloom',
-      'Solar Thread',
-    ])
-    expect(screen.getByText('Oldest items first')).toBeInTheDocument()
-  })
-
-  it('paginates the table and shows the footer controls', async () => {
-    storeSession()
-
-    const paginatedScenes = Array.from({ length: 31 }, (_, index) => {
-      const sceneNumber = index + 1
-      const day = String(sceneNumber).padStart(2, '0')
-
-      return {
-        id: sceneNumber,
-        name: `Scene ${sceneNumber}`,
-        createdAt: `2026-04-${day}T14:00:00Z`,
-      }
-    })
-
-    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
-      if (input === buildApiUrl('/users/me')) {
-        return Promise.resolve(jsonResponse(storedUser))
-      }
-
-      if (input === buildApiUrl('/users/8/scenes')) {
-        return Promise.resolve(jsonResponse(paginatedScenes))
-      }
-
-      throw new Error(`Unexpected request: ${String(input)}`)
-    })
-    const user = userEvent.setup()
-
-    renderMyScenesPage()
-
-    expect(await screen.findByText('1-30 of 31')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'Scene 31' })).toBeInTheDocument()
-    expect(screen.queryByRole('link', { name: 'Scene 1' })).not.toBeInTheDocument()
-
-    await user.click(screen.getByRole('button', { name: /go to next page/i }))
-
-    expect(await screen.findByText('31-31 of 31')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'Scene 1' })).toBeInTheDocument()
-  })
-
-  it('adds sample scenes from the empty state and reloads the list', async () => {
-    storeSession()
-
-    const createdSceneBodies: Array<Record<string, unknown>> = []
-    let sceneListRequestCount = 0
-
-    vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
-      if (input === buildApiUrl('/users/me')) {
-        return Promise.resolve(jsonResponse(storedUser))
-      }
-
-      if (input === buildApiUrl('/users/8/scenes')) {
-        sceneListRequestCount += 1
-
-        return Promise.resolve(
-          jsonResponse(
-            sceneListRequestCount === 1
-              ? []
-              : [
-                  {
-                    id: 21,
-                    name: 'Aurora Drift',
-                    thumbnailRef: 'thumbnails/scene-21.png',
-                  },
-                  {
-                    id: 22,
-                    name: 'Signal Bloom',
-                    thumbnailRef: null,
-                  },
-                  {
-                    id: 23,
-                    name: 'Glacier Echo',
-                    thumbnailRef: 'thumbnails/scene-23.png',
-                  },
-                  {
-                    id: 24,
-                    name: 'Solar Thread',
-                    thumbnailRef: 'thumbnails/scene-24.png',
-                  },
-                ],
-          ),
-        )
-      }
-
-      if (input === buildApiUrl('/scenes')) {
-        createdSceneBodies.push(JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>)
-
-        return Promise.resolve(
-          jsonResponse(
-            {
-              sceneId: 20 + createdSceneBodies.length,
-            },
-            201,
-          ),
-        )
-      }
-
-      throw new Error(`Unexpected request: ${String(input)}`)
-    })
-    const user = userEvent.setup()
-
-    renderMyScenesPage()
-
-    expect(await screen.findByText(/no scenes yet/i)).toBeInTheDocument()
-
-    await user.click(screen.getByRole('button', { name: /add sample scenes/i }))
-
-    expect(await screen.findByRole('link', { name: /aurora drift/i })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /signal bloom/i })).toBeInTheDocument()
-    expect(createdSceneBodies).toHaveLength(4)
-    expect(sceneListRequestCount).toBe(2)
-    expect(createdSceneBodies).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: 'Aurora Drift',
-          sceneData: expect.objectContaining({
-            visualizer: expect.objectContaining({
-              shader: 'nebula',
-            }),
-          }),
-        }),
-        expect.objectContaining({
-          name: 'Signal Bloom',
-          sceneData: expect.objectContaining({
-            visualizer: expect.objectContaining({
-              shader: 'pulse',
-            }),
-          }),
-        }),
-      ]),
-    )
   })
 })

--- a/src/modules/my-scenes/test-fixtures.tsx
+++ b/src/modules/my-scenes/test-fixtures.tsx
@@ -1,0 +1,58 @@
+import { render } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { AuthProvider, type AuthenticatedUser } from '@auth'
+import { LoginPage } from '@modules/auth'
+import { SceneDetailPage } from '@modules/scene-detail'
+import { buildAuthenticatedUser, storeAuthenticatedSession } from '@shared/test/auth'
+import { MyScenesPage } from './MyScenesPage'
+
+export function buildMyScenesStoredUser(
+  overrides: Partial<AuthenticatedUser> = {},
+) {
+  return buildAuthenticatedUser(overrides)
+}
+
+export function storeMyScenesSession(
+  user: AuthenticatedUser = buildMyScenesStoredUser(),
+) {
+  storeAuthenticatedSession(user)
+}
+
+export function buildMyScenesApiScene(
+  overrides: Partial<Record<string, unknown>> = {},
+) {
+  const sceneId =
+    typeof overrides.sceneId === 'number'
+      ? overrides.sceneId
+      : typeof overrides.id === 'number'
+        ? overrides.id
+        : 1
+
+  return {
+    createdAt: '2026-04-06T14:00:00Z',
+    description: 'Soft teal bloom with low-end drift.',
+    id: sceneId,
+    name: 'Aurora Drift',
+    ownerUserId: 42,
+    sceneData: {
+      visualizer: { shader: 'nebula' },
+    },
+    sceneId,
+    thumbnailRef: `thumbnails/scene-${sceneId}.png`,
+    ...overrides,
+  }
+}
+
+export function renderMyScenesPage(initialEntries = ['/my-scenes']) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <AuthProvider>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/my-scenes" element={<MyScenesPage />} />
+          <Route path="/scenes/:id" element={<SceneDetailPage />} />
+        </Routes>
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}

--- a/src/modules/player/MagePlayer.audio.test.tsx
+++ b/src/modules/player/MagePlayer.audio.test.tsx
@@ -1,0 +1,136 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MagePlayer } from './MagePlayer'
+import { createMagePlayer } from './infrastructure/engineAdapter'
+import {
+  buildMagePlayerController,
+  buildMagePlayerSceneBlob,
+} from './test-fixtures'
+
+vi.mock('./infrastructure/engineAdapter', () => ({
+  createMagePlayer: vi.fn(),
+}))
+
+describe('MagePlayer audio controls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('auto-loads saved scene audio into the playlist and exposes a clickable track summary', async () => {
+    const controller = buildMagePlayerController()
+    vi.mocked(createMagePlayer).mockResolvedValue(controller)
+
+    const onRequestPlaylistOpen = vi.fn()
+    const sceneBlob = buildMagePlayerSceneBlob({
+      audioPath: '/audio/crimson-reactor.mp3',
+    })
+
+    render(<MagePlayer onRequestPlaylistOpen={onRequestPlaylistOpen} sceneBlob={sceneBlob} />)
+
+    await waitFor(() => {
+      expect(controller.loadAudio).toHaveBeenLastCalledWith({
+        sourceLabel: 'crimson-reactor.mp3',
+        sourcePath: '/audio/crimson-reactor.mp3',
+      })
+    })
+
+    const trackSummaryButton = screen.getByRole('button', {
+      name: /track 1\/1: crimson-reactor\.mp3/i,
+    })
+
+    expect(trackSummaryButton).toBeInTheDocument()
+    expect(screen.getByText('3:05')).toBeInTheDocument()
+
+    fireEvent.click(trackSummaryButton)
+
+    expect(onRequestPlaylistOpen).toHaveBeenCalledTimes(1)
+  })
+
+  it('adds local audio tracks to the playlist and auto-loads the first added track', async () => {
+    const controller = buildMagePlayerController()
+    vi.mocked(createMagePlayer).mockResolvedValue(controller)
+
+    const user = userEvent.setup()
+    const onPlaylistChange = vi.fn()
+    const sceneBlob = buildMagePlayerSceneBlob()
+
+    const { container } = render(
+      <MagePlayer onPlaylistChange={onPlaylistChange} sceneBlob={sceneBlob} />,
+    )
+
+    const addButton = await screen.findByRole('button', { name: /add audio tracks/i })
+    const audioInput = container.querySelector('.mage-player__audio-input') as HTMLInputElement
+    const localAudioFile = new File(['audio'], 'device-track.mp3', { type: 'audio/mpeg' })
+
+    fireEvent.click(addButton)
+    await user.upload(audioInput, localAudioFile)
+
+    await waitFor(() => {
+      expect(controller.loadAudio).toHaveBeenLastCalledWith({
+        sourceLabel: 'device-track.mp3',
+        sourcePath: expect.stringMatching(/^blob:/),
+      })
+    })
+
+    expect(onPlaylistChange).toHaveBeenCalledTimes(1)
+    expect(onPlaylistChange).toHaveBeenLastCalledWith([
+      expect.objectContaining({
+        duration: expect.any(Number),
+        name: 'device-track.mp3',
+        sourcePath: expect.stringMatching(/^blob:/),
+        sourceType: 'device',
+      }),
+    ])
+    expect(screen.getByRole('button', { name: /track 1\/1: device-track\.mp3/i })).toBeInTheDocument()
+  })
+
+  it('supports audio scrubbing and volume control from the shared hover bar', async () => {
+    const controller = buildMagePlayerController()
+    vi.mocked(createMagePlayer).mockResolvedValue(controller)
+
+    const sceneBlob = buildMagePlayerSceneBlob({
+      audioPath: '/audio/crimson-reactor.mp3',
+    })
+
+    render(<MagePlayer sceneBlob={sceneBlob} />)
+
+    await waitFor(() => {
+      expect(controller.loadAudio).toHaveBeenCalled()
+    })
+
+    const scrubber = screen.getByRole('slider', { name: /seek scene audio/i })
+    fireEvent.change(scrubber, { target: { value: '42' } })
+
+    expect(controller.seekAudio).toHaveBeenLastCalledWith(42)
+    expect(screen.getByText('0:42')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /adjust audio volume/i }))
+
+    const volumeSlider = screen.getByRole('slider', { name: /audio volume/i })
+    fireEvent.change(volumeSlider, { target: { value: '0.4' } })
+
+    expect(controller.setAudioVolume).toHaveBeenLastCalledWith(0.4)
+    expect(screen.getByText('40%')).toBeInTheDocument()
+  })
+
+  it('shows a recoverable audio error when the selected playlist track fails to load', async () => {
+    const controller = buildMagePlayerController({
+      loadAudio: vi.fn(async () => {
+        throw new Error('Audio could not be loaded from the configured source.')
+      }),
+    })
+
+    vi.mocked(createMagePlayer).mockResolvedValue(controller)
+
+    const sceneBlob = buildMagePlayerSceneBlob({
+      audioPath: '/audio/crimson-reactor.mp3',
+    })
+
+    render(<MagePlayer sceneBlob={sceneBlob} />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Audio could not be loaded from the configured source.',
+    )
+  })
+})

--- a/src/modules/player/MagePlayer.playlist.test.tsx
+++ b/src/modules/player/MagePlayer.playlist.test.tsx
@@ -1,0 +1,368 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MagePlayer } from './MagePlayer'
+import {
+  createMagePlayer,
+  type MagePlayerAudioState,
+  type MagePlayerController,
+  type MagePlayerPlaybackState,
+} from './infrastructure/engineAdapter'
+import {
+  buildMagePlayerController,
+  buildMagePlayerSceneBlob,
+  buildMagePlayerTrack,
+} from './test-fixtures'
+
+vi.mock('./infrastructure/engineAdapter', () => ({
+  createMagePlayer: vi.fn(),
+}))
+
+describe('MagePlayer playlist behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('pauses playback and clears audio when the last playlist track is removed', async () => {
+    const controller = buildMagePlayerController()
+    vi.mocked(createMagePlayer).mockResolvedValue(controller)
+
+    const onlyTrack = buildMagePlayerTrack()
+    const sceneBlob = buildMagePlayerSceneBlob()
+
+    const { rerender } = render(
+      <MagePlayer
+        playlistTracks={[onlyTrack]}
+        sceneBlob={sceneBlob}
+        selectedTrackId={onlyTrack.id}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(controller.loadAudio).toHaveBeenLastCalledWith({
+        sourceLabel: 'track-one.mp3',
+        sourcePath: 'blob:track-one',
+      })
+    })
+
+    vi.mocked(controller.clearAudio).mockClear()
+    vi.mocked(controller.setPlaybackState).mockClear()
+
+    rerender(<MagePlayer playlistTracks={[]} sceneBlob={sceneBlob} selectedTrackId={null} />)
+
+    await waitFor(() => {
+      expect(controller.setPlaybackState).toHaveBeenLastCalledWith('paused')
+      expect(controller.clearAudio).toHaveBeenCalledTimes(1)
+    })
+
+    expect(screen.getByRole('button', { name: /play scene and audio playback/i })).toBeInTheDocument()
+  })
+
+  it('advances to the next playlist track when the current track finishes', async () => {
+    let playbackState: MagePlayerPlaybackState = 'playing'
+    let audioState: MagePlayerAudioState = {
+      currentTime: 0,
+      duration: 0,
+      hasSource: false,
+      isLoaded: false,
+      sourcePath: null,
+      volume: 1,
+    }
+
+    const controller: MagePlayerController = {
+      clearAudio: vi.fn(() => {
+        audioState = {
+          currentTime: 0,
+          duration: 0,
+          hasSource: false,
+          isLoaded: false,
+          sourcePath: null,
+          volume: audioState.volume,
+        }
+
+        return audioState
+      }),
+      dispose: vi.fn(),
+      getAudioState: vi.fn(() => audioState),
+      getPlaybackState: vi.fn(() => playbackState),
+      loadAudio: vi.fn(async (options?: { sourceLabel?: string; sourcePath?: string }) => {
+        audioState = {
+          currentTime: 0,
+          duration: options?.sourceLabel === 'track-two.mp3' ? 120 : 185,
+          hasSource: true,
+          isLoaded: true,
+          sourcePath: options?.sourceLabel ?? null,
+          volume: 1,
+        }
+
+        return audioState
+      }),
+      loadSceneBlob: vi.fn(() => {
+        audioState = {
+          currentTime: 0,
+          duration: 0,
+          hasSource: false,
+          isLoaded: false,
+          sourcePath: null,
+          volume: 1,
+        }
+      }),
+      resetPlayback: vi.fn(() => playbackState),
+      seekAudio: vi.fn((time: number) => {
+        audioState = {
+          ...audioState,
+          currentTime: time,
+        }
+
+        return audioState
+      }),
+      setAudioVolume: vi.fn((volume: number) => {
+        audioState = {
+          ...audioState,
+          volume,
+        }
+
+        return audioState
+      }),
+      setPlaybackState: vi.fn((nextPlaybackState: MagePlayerPlaybackState) => {
+        playbackState = nextPlaybackState
+        return playbackState
+      }),
+    }
+
+    vi.mocked(createMagePlayer).mockResolvedValue(controller)
+
+    const firstTrack = buildMagePlayerTrack()
+    const secondTrack = buildMagePlayerTrack({
+      duration: 120,
+      id: 'track-2',
+      name: 'track-two.mp3',
+      sourcePath: 'blob:track-two',
+    })
+    const onSelectedTrackChange = vi.fn()
+    const sceneBlob = buildMagePlayerSceneBlob()
+
+    render(
+      <MagePlayer
+        onSelectedTrackChange={onSelectedTrackChange}
+        playlistTracks={[firstTrack, secondTrack]}
+        sceneBlob={sceneBlob}
+        selectedTrackId={firstTrack.id}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(controller.loadAudio).toHaveBeenLastCalledWith({
+        sourceLabel: 'track-one.mp3',
+        sourcePath: 'blob:track-one',
+      })
+    })
+
+    audioState = {
+      ...audioState,
+      currentTime: 184.9,
+      duration: 185,
+      hasSource: true,
+      isLoaded: true,
+    }
+
+    await waitFor(() => {
+      expect(onSelectedTrackChange).toHaveBeenCalledWith(secondTrack.id)
+    })
+  })
+
+  it('wraps back to the first playlist track when repeat is enabled', async () => {
+    let playbackState: MagePlayerPlaybackState = 'playing'
+    let audioState: MagePlayerAudioState = {
+      currentTime: 0,
+      duration: 0,
+      hasSource: false,
+      isLoaded: false,
+      sourcePath: null,
+      volume: 1,
+    }
+
+    const controller: MagePlayerController = {
+      clearAudio: vi.fn(() => audioState),
+      dispose: vi.fn(),
+      getAudioState: vi.fn(() => audioState),
+      getPlaybackState: vi.fn(() => playbackState),
+      loadAudio: vi.fn(async (options?: { sourceLabel?: string; sourcePath?: string }) => {
+        audioState = {
+          currentTime: 0,
+          duration: options?.sourceLabel === 'track-two.mp3' ? 120 : 185,
+          hasSource: true,
+          isLoaded: true,
+          sourcePath: options?.sourceLabel ?? null,
+          volume: 1,
+        }
+
+        return audioState
+      }),
+      loadSceneBlob: vi.fn(() => {
+        audioState = {
+          currentTime: 0,
+          duration: 0,
+          hasSource: false,
+          isLoaded: false,
+          sourcePath: null,
+          volume: 1,
+        }
+      }),
+      resetPlayback: vi.fn(() => playbackState),
+      seekAudio: vi.fn((time: number) => {
+        audioState = { ...audioState, currentTime: time }
+        return audioState
+      }),
+      setAudioVolume: vi.fn((volume: number) => {
+        audioState = { ...audioState, volume }
+        return audioState
+      }),
+      setPlaybackState: vi.fn((nextPlaybackState: MagePlayerPlaybackState) => {
+        playbackState = nextPlaybackState
+        return playbackState
+      }),
+    }
+
+    vi.mocked(createMagePlayer).mockResolvedValue(controller)
+
+    const firstTrack = buildMagePlayerTrack()
+    const secondTrack = buildMagePlayerTrack({
+      duration: 120,
+      id: 'track-2',
+      name: 'track-two.mp3',
+      sourcePath: 'blob:track-two',
+    })
+    const onSelectedTrackChange = vi.fn()
+    const sceneBlob = buildMagePlayerSceneBlob()
+
+    render(
+      <MagePlayer
+        onSelectedTrackChange={onSelectedTrackChange}
+        playlistTracks={[firstTrack, secondTrack]}
+        repeatEnabled
+        sceneBlob={sceneBlob}
+        selectedTrackId={secondTrack.id}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(controller.loadAudio).toHaveBeenLastCalledWith({
+        sourceLabel: 'track-two.mp3',
+        sourcePath: 'blob:track-two',
+      })
+    })
+
+    audioState = {
+      ...audioState,
+      currentTime: 119.9,
+      duration: 120,
+      hasSource: true,
+      isLoaded: true,
+    }
+
+    await waitFor(() => {
+      expect(onSelectedTrackChange).toHaveBeenCalledWith(firstTrack.id)
+    })
+  })
+
+  it('continues through the supplied playlist order even when shuffle is enabled', async () => {
+    let playbackState: MagePlayerPlaybackState = 'playing'
+    let audioState: MagePlayerAudioState = {
+      currentTime: 0,
+      duration: 0,
+      hasSource: false,
+      isLoaded: false,
+      sourcePath: null,
+      volume: 1,
+    }
+
+    const controller: MagePlayerController = {
+      clearAudio: vi.fn(() => audioState),
+      dispose: vi.fn(),
+      getAudioState: vi.fn(() => audioState),
+      getPlaybackState: vi.fn(() => playbackState),
+      loadAudio: vi.fn(async (options?: { sourceLabel?: string; sourcePath?: string }) => {
+        audioState = {
+          currentTime: 0,
+          duration: 185,
+          hasSource: true,
+          isLoaded: true,
+          sourcePath: options?.sourceLabel ?? null,
+          volume: 1,
+        }
+
+        return audioState
+      }),
+      loadSceneBlob: vi.fn(() => {
+        audioState = {
+          currentTime: 0,
+          duration: 0,
+          hasSource: false,
+          isLoaded: false,
+          sourcePath: null,
+          volume: 1,
+        }
+      }),
+      resetPlayback: vi.fn(() => playbackState),
+      seekAudio: vi.fn((time: number) => {
+        audioState = { ...audioState, currentTime: time }
+        return audioState
+      }),
+      setAudioVolume: vi.fn((volume: number) => {
+        audioState = { ...audioState, volume }
+        return audioState
+      }),
+      setPlaybackState: vi.fn((nextPlaybackState: MagePlayerPlaybackState) => {
+        playbackState = nextPlaybackState
+        return playbackState
+      }),
+    }
+
+    vi.mocked(createMagePlayer).mockResolvedValue(controller)
+
+    const firstTrack = buildMagePlayerTrack()
+    const secondTrack = buildMagePlayerTrack({
+      duration: 120,
+      id: 'track-2',
+      name: 'track-two.mp3',
+      sourcePath: 'blob:track-two',
+    })
+    const thirdTrack = buildMagePlayerTrack({
+      duration: 95,
+      id: 'track-3',
+      name: 'track-three.mp3',
+      sourcePath: 'blob:track-three',
+    })
+    const onSelectedTrackChange = vi.fn()
+    const sceneBlob = buildMagePlayerSceneBlob()
+
+    render(
+      <MagePlayer
+        onSelectedTrackChange={onSelectedTrackChange}
+        playlistTracks={[firstTrack, secondTrack, thirdTrack]}
+        sceneBlob={sceneBlob}
+        selectedTrackId={firstTrack.id}
+        shuffleEnabled
+      />,
+    )
+
+    await waitFor(() => {
+      expect(controller.loadAudio).toHaveBeenLastCalledWith({
+        sourceLabel: 'track-one.mp3',
+        sourcePath: 'blob:track-one',
+      })
+    })
+
+    audioState = {
+      ...audioState,
+      currentTime: 184.9,
+      duration: 185,
+      hasSource: true,
+      isLoaded: true,
+    }
+
+    await waitFor(() => {
+      expect(onSelectedTrackChange).toHaveBeenCalledWith(secondTrack.id)
+    })
+  })
+})

--- a/src/modules/player/MagePlayer.test.tsx
+++ b/src/modules/player/MagePlayer.test.tsx
@@ -1,115 +1,15 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { MagePlayer } from './MagePlayer'
+import { createMagePlayer } from './infrastructure/engineAdapter'
 import {
-  createMagePlayer,
-  type MagePlayerAudioState,
-  type MagePlayerController,
-  type MagePlayerPlaybackState,
-} from './infrastructure/engineAdapter'
+  buildMagePlayerController,
+  buildMagePlayerSceneBlob,
+} from './test-fixtures'
 
 vi.mock('./infrastructure/engineAdapter', () => ({
   createMagePlayer: vi.fn(),
 }))
-
-function createController(overrides: Partial<MagePlayerController> = {}): MagePlayerController {
-  let playbackState: MagePlayerPlaybackState = 'playing'
-  let audioState: MagePlayerAudioState = {
-    currentTime: 0,
-    duration: 0,
-    hasSource: false,
-    isLoaded: false,
-    sourcePath: null,
-    volume: 1,
-  }
-
-  return {
-    clearAudio: vi.fn(() => {
-      audioState = {
-        currentTime: 0,
-        duration: 0,
-        hasSource: false,
-        isLoaded: false,
-        sourcePath: null,
-        volume: audioState.volume,
-      }
-
-      return audioState
-    }),
-    dispose: vi.fn(),
-    getAudioState: vi.fn(() => audioState),
-    getPlaybackState: vi.fn(() => playbackState),
-    loadAudio: vi.fn(async (options?: { sourceLabel?: string; sourcePath?: string }) => {
-      audioState = {
-        ...audioState,
-        currentTime: 0,
-        duration: 185,
-        hasSource: true,
-        isLoaded: true,
-        sourcePath: options?.sourceLabel ?? audioState.sourcePath,
-      }
-
-      return audioState
-    }),
-    loadSceneBlob: vi.fn((sceneBlob: unknown) => {
-      if (typeof sceneBlob === 'object' && sceneBlob !== null) {
-        const nextSceneBlob = sceneBlob as Record<string, unknown>
-        const audioValue = nextSceneBlob.audio
-        const sourcePath =
-          typeof nextSceneBlob.audioPath === 'string'
-            ? nextSceneBlob.audioPath
-            : typeof audioValue === 'string'
-              ? audioValue
-              : audioValue && typeof audioValue === 'object'
-                ? typeof (audioValue as Record<string, unknown>).path === 'string'
-                  ? ((audioValue as Record<string, unknown>).path as string)
-                  : typeof (audioValue as Record<string, unknown>).url === 'string'
-                    ? ((audioValue as Record<string, unknown>).url as string)
-                    : null
-                : null
-
-        audioState = {
-          currentTime: 0,
-          duration: 0,
-          hasSource: Boolean(sourcePath),
-          isLoaded: false,
-          sourcePath,
-          volume: 1,
-        }
-      }
-    }),
-    resetPlayback: vi.fn(() => {
-      audioState = {
-        ...audioState,
-        currentTime: 0,
-      }
-      playbackState = 'paused'
-      return playbackState
-    }),
-    seekAudio: vi.fn((time: number) => {
-      audioState = {
-        ...audioState,
-        currentTime: time,
-      }
-
-      return audioState
-    }),
-    setAudioVolume: vi.fn((volume: number) => {
-      audioState = {
-        ...audioState,
-        volume,
-      }
-
-      return audioState
-    }),
-    setPlaybackState: vi.fn((nextPlaybackState: MagePlayerPlaybackState) => {
-      playbackState = nextPlaybackState
-      return playbackState
-    }),
-    ...overrides,
-  }
-}
 
 describe('MagePlayer', () => {
   beforeEach(() => {
@@ -117,15 +17,10 @@ describe('MagePlayer', () => {
   })
 
   it('loads a scene blob and disposes the engine on unmount', async () => {
-    const controller = createController()
+    const controller = buildMagePlayerController()
     vi.mocked(createMagePlayer).mockResolvedValue(controller)
 
-    const sceneBlob = {
-      visualizer: {
-        skyboxPreset: 6,
-      },
-    }
-
+    const sceneBlob = buildMagePlayerSceneBlob()
     const { unmount } = render(<MagePlayer sceneBlob={sceneBlob} />)
 
     expect(screen.getByText('Loading scene preview.')).toBeInTheDocument()
@@ -152,19 +47,15 @@ describe('MagePlayer', () => {
   })
 
   it('reuses the same engine instance when the scene blob changes', async () => {
-    const controller = createController()
+    const controller = buildMagePlayerController()
     vi.mocked(createMagePlayer).mockResolvedValue(controller)
 
-    const firstSceneBlob = {
-      visualizer: {
-        skyboxPreset: 6,
-      },
-    }
-    const secondSceneBlob = {
+    const firstSceneBlob = buildMagePlayerSceneBlob()
+    const secondSceneBlob = buildMagePlayerSceneBlob({
       visualizer: {
         skyboxPreset: 2,
       },
-    }
+    })
 
     const { rerender } = render(<MagePlayer sceneBlob={firstSceneBlob} />)
 
@@ -184,7 +75,7 @@ describe('MagePlayer', () => {
   })
 
   it('shows a recoverable error state when the scene is invalid', async () => {
-    const controller = createController({
+    const controller = buildMagePlayerController({
       loadSceneBlob: vi.fn((sceneBlob: unknown) => {
         if (typeof sceneBlob === 'object' && sceneBlob !== null && 'invalid' in sceneBlob) {
           throw new Error('Scene data is missing required MAGE fields.')
@@ -207,11 +98,7 @@ describe('MagePlayer', () => {
     )
     expect(controller.dispose).not.toHaveBeenCalled()
 
-    const validSceneBlob = {
-      visualizer: {
-        skyboxPreset: 6,
-      },
-    }
+    const validSceneBlob = buildMagePlayerSceneBlob()
 
     rerender(<MagePlayer sceneBlob={validSceneBlob} />)
 
@@ -223,14 +110,10 @@ describe('MagePlayer', () => {
   })
 
   it('supports a paused initial playback state and toggles playback from the shared control bar', async () => {
-    const controller = createController()
+    const controller = buildMagePlayerController()
     vi.mocked(createMagePlayer).mockResolvedValue(controller)
 
-    const sceneBlob = {
-      visualizer: {
-        skyboxPreset: 6,
-      },
-    }
+    const sceneBlob = buildMagePlayerSceneBlob()
 
     render(<MagePlayer initialPlayback="paused" sceneBlob={sceneBlob} />)
 
@@ -255,525 +138,8 @@ describe('MagePlayer', () => {
     })
   })
 
-  it('auto-loads saved scene audio into the playlist and exposes a clickable track summary', async () => {
-    const controller = createController()
-    vi.mocked(createMagePlayer).mockResolvedValue(controller)
-
-    const onRequestPlaylistOpen = vi.fn()
-    const sceneBlob = {
-      audioPath: '/audio/crimson-reactor.mp3',
-      visualizer: {
-        skyboxPreset: 6,
-      },
-    }
-
-    render(<MagePlayer onRequestPlaylistOpen={onRequestPlaylistOpen} sceneBlob={sceneBlob} />)
-
-    await waitFor(() => {
-      expect(controller.loadAudio).toHaveBeenLastCalledWith({
-        sourceLabel: 'crimson-reactor.mp3',
-        sourcePath: '/audio/crimson-reactor.mp3',
-      })
-    })
-
-    const trackSummaryButton = screen.getByRole('button', {
-      name: /track 1\/1: crimson-reactor\.mp3/i,
-    })
-
-    expect(trackSummaryButton).toBeInTheDocument()
-    expect(screen.getByText('3:05')).toBeInTheDocument()
-
-    fireEvent.click(trackSummaryButton)
-
-    expect(onRequestPlaylistOpen).toHaveBeenCalledTimes(1)
-  })
-
-  it('adds local audio tracks to the playlist and auto-loads the first added track', async () => {
-    const controller = createController()
-    vi.mocked(createMagePlayer).mockResolvedValue(controller)
-
-    const user = userEvent.setup()
-    const onPlaylistChange = vi.fn()
-    const sceneBlob = {
-      visualizer: {
-        skyboxPreset: 6,
-      },
-    }
-
-    const { container } = render(<MagePlayer onPlaylistChange={onPlaylistChange} sceneBlob={sceneBlob} />)
-
-    const addButton = await screen.findByRole('button', { name: /add audio tracks/i })
-    const audioInput = container.querySelector('.mage-player__audio-input') as HTMLInputElement
-    const localAudioFile = new File(['audio'], 'device-track.mp3', { type: 'audio/mpeg' })
-
-    fireEvent.click(addButton)
-    await user.upload(audioInput, localAudioFile)
-
-    await waitFor(() => {
-      expect(controller.loadAudio).toHaveBeenLastCalledWith({
-        sourceLabel: 'device-track.mp3',
-        sourcePath: expect.stringMatching(/^blob:/),
-      })
-    })
-
-    expect(onPlaylistChange).toHaveBeenCalledTimes(1)
-    expect(onPlaylistChange).toHaveBeenLastCalledWith([
-      expect.objectContaining({
-        duration: expect.any(Number),
-        name: 'device-track.mp3',
-        sourcePath: expect.stringMatching(/^blob:/),
-        sourceType: 'device',
-      }),
-    ])
-    expect(screen.getByRole('button', { name: /track 1\/1: device-track\.mp3/i })).toBeInTheDocument()
-  })
-
-  it('supports audio scrubbing and volume control from the shared hover bar', async () => {
-    const controller = createController()
-    vi.mocked(createMagePlayer).mockResolvedValue(controller)
-
-    const sceneBlob = {
-      audioPath: '/audio/crimson-reactor.mp3',
-      visualizer: {
-        skyboxPreset: 6,
-      },
-    }
-
-    render(<MagePlayer sceneBlob={sceneBlob} />)
-
-    await waitFor(() => {
-      expect(controller.loadAudio).toHaveBeenCalled()
-    })
-
-    const scrubber = screen.getByRole('slider', { name: /seek scene audio/i })
-    fireEvent.change(scrubber, { target: { value: '42' } })
-
-    expect(controller.seekAudio).toHaveBeenLastCalledWith(42)
-    expect(screen.getByText('0:42')).toBeInTheDocument()
-
-    fireEvent.click(screen.getByRole('button', { name: /adjust audio volume/i }))
-
-    const volumeSlider = screen.getByRole('slider', { name: /audio volume/i })
-    fireEvent.change(volumeSlider, { target: { value: '0.4' } })
-
-    expect(controller.setAudioVolume).toHaveBeenLastCalledWith(0.4)
-    expect(screen.getByText('40%')).toBeInTheDocument()
-  })
-
-  it('pauses playback and clears audio when the last playlist track is removed', async () => {
-    const controller = createController()
-    vi.mocked(createMagePlayer).mockResolvedValue(controller)
-
-    const onlyTrack = {
-      duration: 185,
-      id: 'track-1',
-      name: 'track-one.mp3',
-      sourcePath: 'blob:track-one',
-      sourceType: 'device' as const,
-    }
-    const sceneBlob = {
-      visualizer: {
-        skyboxPreset: 6,
-      },
-    }
-
-    const { rerender } = render(
-      <MagePlayer
-        playlistTracks={[onlyTrack]}
-        sceneBlob={sceneBlob}
-        selectedTrackId={onlyTrack.id}
-      />,
-    )
-
-    await waitFor(() => {
-      expect(controller.loadAudio).toHaveBeenLastCalledWith({
-        sourceLabel: 'track-one.mp3',
-        sourcePath: 'blob:track-one',
-      })
-    })
-
-    vi.mocked(controller.clearAudio).mockClear()
-    vi.mocked(controller.setPlaybackState).mockClear()
-
-    rerender(<MagePlayer playlistTracks={[]} sceneBlob={sceneBlob} selectedTrackId={null} />)
-
-    await waitFor(() => {
-      expect(controller.setPlaybackState).toHaveBeenLastCalledWith('paused')
-      expect(controller.clearAudio).toHaveBeenCalledTimes(1)
-    })
-
-    expect(screen.getByRole('button', { name: /play scene and audio playback/i })).toBeInTheDocument()
-  })
-
-  it('advances to the next playlist track when the current track finishes', async () => {
-    let playbackState: MagePlayerPlaybackState = 'playing'
-    let audioState: MagePlayerAudioState = {
-      currentTime: 0,
-      duration: 0,
-      hasSource: false,
-      isLoaded: false,
-      sourcePath: null,
-      volume: 1,
-    }
-
-    const controller: MagePlayerController = {
-      clearAudio: vi.fn(() => {
-        audioState = {
-          currentTime: 0,
-          duration: 0,
-          hasSource: false,
-          isLoaded: false,
-          sourcePath: null,
-          volume: audioState.volume,
-        }
-
-        return audioState
-      }),
-      dispose: vi.fn(),
-      getAudioState: vi.fn(() => audioState),
-      getPlaybackState: vi.fn(() => playbackState),
-      loadAudio: vi.fn(async (options?: { sourceLabel?: string; sourcePath?: string }) => {
-        audioState = {
-          currentTime: 0,
-          duration: options?.sourceLabel === 'track-two.mp3' ? 120 : 185,
-          hasSource: true,
-          isLoaded: true,
-          sourcePath: options?.sourceLabel ?? null,
-          volume: 1,
-        }
-
-        return audioState
-      }),
-      loadSceneBlob: vi.fn(() => {
-        audioState = {
-          currentTime: 0,
-          duration: 0,
-          hasSource: false,
-          isLoaded: false,
-          sourcePath: null,
-          volume: 1,
-        }
-      }),
-      resetPlayback: vi.fn(() => playbackState),
-      seekAudio: vi.fn((time: number) => {
-        audioState = {
-          ...audioState,
-          currentTime: time,
-        }
-
-        return audioState
-      }),
-      setAudioVolume: vi.fn((volume: number) => {
-        audioState = {
-          ...audioState,
-          volume,
-        }
-
-        return audioState
-      }),
-      setPlaybackState: vi.fn((nextPlaybackState: MagePlayerPlaybackState) => {
-        playbackState = nextPlaybackState
-        return playbackState
-      }),
-    }
-
-    vi.mocked(createMagePlayer).mockResolvedValue(controller)
-
-    const firstTrack = {
-      duration: 185,
-      id: 'track-1',
-      name: 'track-one.mp3',
-      sourcePath: 'blob:track-one',
-      sourceType: 'device' as const,
-    }
-    const secondTrack = {
-      duration: 120,
-      id: 'track-2',
-      name: 'track-two.mp3',
-      sourcePath: 'blob:track-two',
-      sourceType: 'device' as const,
-    }
-    const onSelectedTrackChange = vi.fn()
-    const sceneBlob = {
-      visualizer: {
-        skyboxPreset: 6,
-      },
-    }
-
-    render(
-      <MagePlayer
-        onSelectedTrackChange={onSelectedTrackChange}
-        playlistTracks={[firstTrack, secondTrack]}
-        sceneBlob={sceneBlob}
-        selectedTrackId={firstTrack.id}
-      />,
-    )
-
-    await waitFor(() => {
-      expect(controller.loadAudio).toHaveBeenLastCalledWith({
-        sourceLabel: 'track-one.mp3',
-        sourcePath: 'blob:track-one',
-      })
-    })
-
-    audioState = {
-      ...audioState,
-      currentTime: 184.9,
-      duration: 185,
-      hasSource: true,
-      isLoaded: true,
-    }
-
-    await waitFor(() => {
-      expect(onSelectedTrackChange).toHaveBeenCalledWith(secondTrack.id)
-    })
-  })
-
-  it('wraps back to the first playlist track when repeat is enabled', async () => {
-    let playbackState: MagePlayerPlaybackState = 'playing'
-    let audioState: MagePlayerAudioState = {
-      currentTime: 0,
-      duration: 0,
-      hasSource: false,
-      isLoaded: false,
-      sourcePath: null,
-      volume: 1,
-    }
-
-    const controller: MagePlayerController = {
-      clearAudio: vi.fn(() => audioState),
-      dispose: vi.fn(),
-      getAudioState: vi.fn(() => audioState),
-      getPlaybackState: vi.fn(() => playbackState),
-      loadAudio: vi.fn(async (options?: { sourceLabel?: string; sourcePath?: string }) => {
-        audioState = {
-          currentTime: 0,
-          duration: options?.sourceLabel === 'track-two.mp3' ? 120 : 185,
-          hasSource: true,
-          isLoaded: true,
-          sourcePath: options?.sourceLabel ?? null,
-          volume: 1,
-        }
-
-        return audioState
-      }),
-      loadSceneBlob: vi.fn(() => {
-        audioState = {
-          currentTime: 0,
-          duration: 0,
-          hasSource: false,
-          isLoaded: false,
-          sourcePath: null,
-          volume: 1,
-        }
-      }),
-      resetPlayback: vi.fn(() => playbackState),
-      seekAudio: vi.fn((time: number) => {
-        audioState = { ...audioState, currentTime: time }
-        return audioState
-      }),
-      setAudioVolume: vi.fn((volume: number) => {
-        audioState = { ...audioState, volume }
-        return audioState
-      }),
-      setPlaybackState: vi.fn((nextPlaybackState: MagePlayerPlaybackState) => {
-        playbackState = nextPlaybackState
-        return playbackState
-      }),
-    }
-
-    vi.mocked(createMagePlayer).mockResolvedValue(controller)
-
-    const firstTrack = {
-      duration: 185,
-      id: 'track-1',
-      name: 'track-one.mp3',
-      sourcePath: 'blob:track-one',
-      sourceType: 'device' as const,
-    }
-    const secondTrack = {
-      duration: 120,
-      id: 'track-2',
-      name: 'track-two.mp3',
-      sourcePath: 'blob:track-two',
-      sourceType: 'device' as const,
-    }
-    const onSelectedTrackChange = vi.fn()
-    const sceneBlob = {
-      visualizer: {
-        skyboxPreset: 6,
-      },
-    }
-
-    render(
-      <MagePlayer
-        onSelectedTrackChange={onSelectedTrackChange}
-        playlistTracks={[firstTrack, secondTrack]}
-        repeatEnabled
-        sceneBlob={sceneBlob}
-        selectedTrackId={secondTrack.id}
-      />,
-    )
-
-    await waitFor(() => {
-      expect(controller.loadAudio).toHaveBeenLastCalledWith({
-        sourceLabel: 'track-two.mp3',
-        sourcePath: 'blob:track-two',
-      })
-    })
-
-    audioState = {
-      ...audioState,
-      currentTime: 119.9,
-      duration: 120,
-      hasSource: true,
-      isLoaded: true,
-    }
-
-    await waitFor(() => {
-      expect(onSelectedTrackChange).toHaveBeenCalledWith(firstTrack.id)
-    })
-  })
-
-  it('continues through the supplied playlist order even when shuffle is enabled', async () => {
-    let playbackState: MagePlayerPlaybackState = 'playing'
-    let audioState: MagePlayerAudioState = {
-      currentTime: 0,
-      duration: 0,
-      hasSource: false,
-      isLoaded: false,
-      sourcePath: null,
-      volume: 1,
-    }
-
-    const controller: MagePlayerController = {
-      clearAudio: vi.fn(() => audioState),
-      dispose: vi.fn(),
-      getAudioState: vi.fn(() => audioState),
-      getPlaybackState: vi.fn(() => playbackState),
-      loadAudio: vi.fn(async (options?: { sourceLabel?: string; sourcePath?: string }) => {
-        audioState = {
-          currentTime: 0,
-          duration: 185,
-          hasSource: true,
-          isLoaded: true,
-          sourcePath: options?.sourceLabel ?? null,
-          volume: 1,
-        }
-
-        return audioState
-      }),
-      loadSceneBlob: vi.fn(() => {
-        audioState = {
-          currentTime: 0,
-          duration: 0,
-          hasSource: false,
-          isLoaded: false,
-          sourcePath: null,
-          volume: 1,
-        }
-      }),
-      resetPlayback: vi.fn(() => playbackState),
-      seekAudio: vi.fn((time: number) => {
-        audioState = { ...audioState, currentTime: time }
-        return audioState
-      }),
-      setAudioVolume: vi.fn((volume: number) => {
-        audioState = { ...audioState, volume }
-        return audioState
-      }),
-      setPlaybackState: vi.fn((nextPlaybackState: MagePlayerPlaybackState) => {
-        playbackState = nextPlaybackState
-        return playbackState
-      }),
-    }
-
-    vi.mocked(createMagePlayer).mockResolvedValue(controller)
-
-    const firstTrack = {
-      duration: 185,
-      id: 'track-1',
-      name: 'track-one.mp3',
-      sourcePath: 'blob:track-one',
-      sourceType: 'device' as const,
-    }
-    const secondTrack = {
-      duration: 120,
-      id: 'track-2',
-      name: 'track-two.mp3',
-      sourcePath: 'blob:track-two',
-      sourceType: 'device' as const,
-    }
-    const thirdTrack = {
-      duration: 95,
-      id: 'track-3',
-      name: 'track-three.mp3',
-      sourcePath: 'blob:track-three',
-      sourceType: 'device' as const,
-    }
-    const onSelectedTrackChange = vi.fn()
-    const sceneBlob = {
-      visualizer: {
-        skyboxPreset: 6,
-      },
-    }
-
-    render(
-      <MagePlayer
-        onSelectedTrackChange={onSelectedTrackChange}
-        playlistTracks={[firstTrack, secondTrack, thirdTrack]}
-        sceneBlob={sceneBlob}
-        selectedTrackId={firstTrack.id}
-        shuffleEnabled
-      />,
-    )
-
-    await waitFor(() => {
-      expect(controller.loadAudio).toHaveBeenLastCalledWith({
-        sourceLabel: 'track-one.mp3',
-        sourcePath: 'blob:track-one',
-      })
-    })
-
-    audioState = {
-      ...audioState,
-      currentTime: 184.9,
-      duration: 185,
-      hasSource: true,
-      isLoaded: true,
-    }
-
-    await waitFor(() => {
-      expect(onSelectedTrackChange).toHaveBeenCalledWith(secondTrack.id)
-    })
-
-  })
-
-  it('shows a recoverable audio error when the selected playlist track fails to load', async () => {
-    const controller = createController({
-      loadAudio: vi.fn(async () => {
-        throw new Error('Audio could not be loaded from the configured source.')
-      }),
-    })
-
-    vi.mocked(createMagePlayer).mockResolvedValue(controller)
-
-    const sceneBlob = {
-      audioPath: '/audio/crimson-reactor.mp3',
-      visualizer: {
-        skyboxPreset: 6,
-      },
-    }
-
-    render(<MagePlayer sceneBlob={sceneBlob} />)
-
-    expect(await screen.findByRole('alert')).toHaveTextContent(
-      'Audio could not be loaded from the configured source.',
-    )
-  })
-
   it('suppresses playback controls while the player is empty', async () => {
-    const controller = createController()
+    const controller = buildMagePlayerController()
     vi.mocked(createMagePlayer).mockResolvedValue(controller)
 
     render(<MagePlayer sceneBlob={null} />)

--- a/src/modules/player/test-fixtures.ts
+++ b/src/modules/player/test-fixtures.ts
@@ -1,0 +1,136 @@
+import { vi } from 'vitest'
+import {
+  type MagePlayerAudioState,
+  type MagePlayerController,
+  type MagePlayerPlaybackState,
+} from './infrastructure/engineAdapter'
+
+export function buildMagePlayerTrack(
+  overrides: Partial<{
+    duration: number
+    id: string
+    name: string
+    sourcePath: string
+    sourceType: 'device'
+  }> = {},
+) {
+  return {
+    duration: 185,
+    id: 'track-1',
+    name: 'track-one.mp3',
+    sourcePath: 'blob:track-one',
+    sourceType: 'device' as const,
+    ...overrides,
+  }
+}
+
+export function buildMagePlayerSceneBlob(
+  overrides: Partial<Record<string, unknown>> = {},
+) {
+  return {
+    visualizer: {
+      skyboxPreset: 6,
+    },
+    ...overrides,
+  }
+}
+
+export function buildMagePlayerController(
+  overrides: Partial<MagePlayerController> = {},
+): MagePlayerController {
+  let playbackState: MagePlayerPlaybackState = 'playing'
+  let audioState: MagePlayerAudioState = {
+    currentTime: 0,
+    duration: 0,
+    hasSource: false,
+    isLoaded: false,
+    sourcePath: null,
+    volume: 1,
+  }
+
+  return {
+    clearAudio: vi.fn(() => {
+      audioState = {
+        currentTime: 0,
+        duration: 0,
+        hasSource: false,
+        isLoaded: false,
+        sourcePath: null,
+        volume: audioState.volume,
+      }
+
+      return audioState
+    }),
+    dispose: vi.fn(),
+    getAudioState: vi.fn(() => audioState),
+    getPlaybackState: vi.fn(() => playbackState),
+    loadAudio: vi.fn(async (options?: { sourceLabel?: string; sourcePath?: string }) => {
+      audioState = {
+        ...audioState,
+        currentTime: 0,
+        duration: 185,
+        hasSource: true,
+        isLoaded: true,
+        sourcePath: options?.sourceLabel ?? audioState.sourcePath,
+      }
+
+      return audioState
+    }),
+    loadSceneBlob: vi.fn((sceneBlob: unknown) => {
+      if (typeof sceneBlob === 'object' && sceneBlob !== null) {
+        const nextSceneBlob = sceneBlob as Record<string, unknown>
+        const audioValue = nextSceneBlob.audio
+        const sourcePath =
+          typeof nextSceneBlob.audioPath === 'string'
+            ? nextSceneBlob.audioPath
+            : typeof audioValue === 'string'
+              ? audioValue
+              : audioValue && typeof audioValue === 'object'
+                ? typeof (audioValue as Record<string, unknown>).path === 'string'
+                  ? ((audioValue as Record<string, unknown>).path as string)
+                  : typeof (audioValue as Record<string, unknown>).url === 'string'
+                    ? ((audioValue as Record<string, unknown>).url as string)
+                    : null
+                : null
+
+        audioState = {
+          currentTime: 0,
+          duration: 0,
+          hasSource: Boolean(sourcePath),
+          isLoaded: false,
+          sourcePath,
+          volume: 1,
+        }
+      }
+    }),
+    resetPlayback: vi.fn(() => {
+      audioState = {
+        ...audioState,
+        currentTime: 0,
+      }
+      playbackState = 'paused'
+      return playbackState
+    }),
+    seekAudio: vi.fn((time: number) => {
+      audioState = {
+        ...audioState,
+        currentTime: time,
+      }
+
+      return audioState
+    }),
+    setAudioVolume: vi.fn((volume: number) => {
+      audioState = {
+        ...audioState,
+        volume,
+      }
+
+      return audioState
+    }),
+    setPlaybackState: vi.fn((nextPlaybackState: MagePlayerPlaybackState) => {
+      playbackState = nextPlaybackState
+      return playbackState
+    }),
+    ...overrides,
+  }
+}

--- a/src/modules/scene-detail/SceneDetailPage.metadata.test.tsx
+++ b/src/modules/scene-detail/SceneDetailPage.metadata.test.tsx
@@ -1,0 +1,147 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { buildApiUrl } from '@lib/api'
+import { jsonResponse } from '@shared/test/http'
+import {
+  buildSceneDetailResponse,
+  buildSceneDetailStoredUser,
+  renderSceneDetailPage,
+  storeSceneDetailSession,
+} from './test-fixtures'
+
+vi.mock('@modules/player', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@modules/player')>()
+
+  return {
+    ...actual,
+    MagePlayer: ({
+      ariaLabel,
+      className,
+      sceneBlob,
+    }: {
+      ariaLabel?: string
+      className?: string
+      sceneBlob: unknown
+    }) => (
+      <div aria-label={ariaLabel} className={className} data-testid="mage-player">
+        {sceneBlob ? 'player-ready' : 'no-scene'}
+      </div>
+    ),
+  }
+})
+
+describe('SceneDetailPage metadata', () => {
+  it('shows the real creator name for another users scene', async () => {
+    storeSceneDetailSession()
+
+    const storedUser = buildSceneDetailStoredUser()
+    const creatorScene = buildSceneDetailResponse({
+      creatorDisplayName: 'Peter',
+      name: 'Test 3',
+      ownerUserId: 77,
+      sceneId: 44,
+      tags: ['chill'],
+      thumbnailRef: 'thumbnails/scene-44.png',
+    })
+    const relatedScene = buildSceneDetailResponse({
+      creatorDisplayName: 'Peter',
+      createdAt: '2026-04-08T14:00:00Z',
+      name: 'Pulse Coast',
+      ownerUserId: 77,
+      sceneId: 45,
+      tags: [],
+      thumbnailRef: 'thumbnails/scene-45.png',
+    })
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      if (input === buildApiUrl('/users/me')) {
+        return Promise.resolve(jsonResponse(storedUser))
+      }
+
+      if (input === buildApiUrl('/scenes/44')) {
+        return Promise.resolve(jsonResponse(creatorScene))
+      }
+
+      if (input === buildApiUrl('/scenes')) {
+        return Promise.resolve(jsonResponse([creatorScene, relatedScene]))
+      }
+
+      if (input === buildApiUrl('/scenes?tag=chill')) {
+        return Promise.resolve(jsonResponse([creatorScene]))
+      }
+
+      throw new Error(`Unexpected request: ${String(input)}`)
+    })
+
+    renderSceneDetailPage(['/scenes/44'])
+
+    expect(await screen.findAllByText('Peter')).not.toHaveLength(0)
+    expect(screen.getByRole('button', { name: /from peter/i })).toBeInTheDocument()
+    expect(screen.queryByText('Talia North')).not.toBeInTheDocument()
+  })
+
+  it('shows attached scene tags and routes to the filtered scenes grid when clicked', async () => {
+    storeSceneDetailSession()
+
+    const storedUser = buildSceneDetailStoredUser()
+    const sceneResponse = buildSceneDetailResponse()
+    const creatorSceneResponse = buildSceneDetailResponse({
+      createdAt: '2026-04-08T14:00:00Z',
+      name: 'Signal Bloom',
+      sceneId: 16,
+      tags: [],
+      thumbnailRef: 'thumbnails/scene-16.png',
+    })
+    const tagSceneResponse = buildSceneDetailResponse({
+      createdAt: '2026-04-09T14:00:00Z',
+      creatorDisplayName: 'Night Archive',
+      name: 'Afterglow Static',
+      ownerUserId: 42,
+      sceneId: 21,
+      thumbnailRef: 'thumbnails/scene-21.png',
+    })
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      if (input === buildApiUrl('/users/me')) {
+        return Promise.resolve(jsonResponse(storedUser))
+      }
+
+      if (input === buildApiUrl('/scenes/12')) {
+        return Promise.resolve(jsonResponse(sceneResponse))
+      }
+
+      if (input === buildApiUrl('/scenes')) {
+        return Promise.resolve(jsonResponse([sceneResponse, creatorSceneResponse]))
+      }
+
+      if (input === buildApiUrl('/scenes?tag=ambient')) {
+        return Promise.resolve(jsonResponse([sceneResponse, tagSceneResponse]))
+      }
+
+      if (input === buildApiUrl('/scenes?tag=focus-friendly')) {
+        return Promise.resolve(jsonResponse([sceneResponse, creatorSceneResponse]))
+      }
+
+      throw new Error(`Unexpected request: ${String(input)}`)
+    })
+
+    const user = userEvent.setup()
+
+    renderSceneDetailPage()
+
+    await screen.findByRole('heading', { name: /aurora drift/i })
+    await user.click(screen.getByRole('button', { name: /^show$/i }))
+
+    const ambientTagLink = screen.getByRole('link', { name: /^ambient$/i })
+    expect(ambientTagLink).toHaveAttribute('href', '/scenes?tag=ambient')
+    expect(screen.getByRole('link', { name: /^focus-friendly$/i })).toHaveAttribute(
+      'href',
+      '/scenes?tag=focus-friendly',
+    )
+
+    await user.click(ambientTagLink)
+
+    expect(await screen.findByTestId('scenes-route')).toHaveTextContent('?tag=ambient')
+  })
+})

--- a/src/modules/scene-detail/SceneDetailPage.recommendations.test.tsx
+++ b/src/modules/scene-detail/SceneDetailPage.recommendations.test.tsx
@@ -1,0 +1,117 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { buildApiUrl } from '@lib/api'
+import { jsonResponse } from '@shared/test/http'
+import {
+  buildSceneDetailResponse,
+  buildSceneDetailStoredUser,
+  renderSceneDetailPage,
+  storeSceneDetailSession,
+} from './test-fixtures'
+
+vi.mock('@modules/player', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@modules/player')>()
+
+  return {
+    ...actual,
+    MagePlayer: ({
+      ariaLabel,
+      className,
+      sceneBlob,
+    }: {
+      ariaLabel?: string
+      className?: string
+      sceneBlob: unknown
+    }) => (
+      <div aria-label={ariaLabel} className={className} data-testid="mage-player">
+        {sceneBlob ? 'player-ready' : 'no-scene'}
+      </div>
+    ),
+  }
+})
+
+describe('SceneDetailPage recommendations', () => {
+  it('filters sidebar recommendations by creator and the current scene tags', async () => {
+    storeSceneDetailSession()
+
+    const storedUser = buildSceneDetailStoredUser()
+    const sceneResponse = buildSceneDetailResponse()
+    const creatorSceneResponse = buildSceneDetailResponse({
+      createdAt: '2026-04-08T14:00:00Z',
+      name: 'Signal Bloom',
+      sceneId: 16,
+      tags: [],
+      thumbnailRef: 'thumbnails/scene-16.png',
+    })
+    const tagSceneResponse = buildSceneDetailResponse({
+      createdAt: '2026-04-09T14:00:00Z',
+      creatorDisplayName: 'Night Archive',
+      name: 'Afterglow Static',
+      ownerUserId: 42,
+      sceneId: 21,
+      thumbnailRef: 'thumbnails/scene-21.png',
+    })
+    const unrelatedSceneResponse = buildSceneDetailResponse({
+      createdAt: '2026-04-10T14:00:00Z',
+      creatorDisplayName: 'Other Creator',
+      name: 'Unrelated Echo',
+      ownerUserId: 77,
+      sceneId: 34,
+      thumbnailRef: 'thumbnails/scene-34.png',
+    })
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      if (input === buildApiUrl('/users/me')) {
+        return Promise.resolve(jsonResponse(storedUser))
+      }
+
+      if (input === buildApiUrl('/scenes/12')) {
+        return Promise.resolve(jsonResponse(sceneResponse))
+      }
+
+      if (input === buildApiUrl('/scenes')) {
+        return Promise.resolve(
+          jsonResponse([
+            sceneResponse,
+            creatorSceneResponse,
+            unrelatedSceneResponse,
+          ]),
+        )
+      }
+
+      if (input === buildApiUrl('/scenes?tag=ambient')) {
+        return Promise.resolve(jsonResponse([sceneResponse, tagSceneResponse]))
+      }
+
+      if (input === buildApiUrl('/scenes?tag=focus-friendly')) {
+        return Promise.resolve(jsonResponse([sceneResponse, creatorSceneResponse]))
+      }
+
+      throw new Error(`Unexpected request: ${String(input)}`)
+    })
+
+    const user = userEvent.setup()
+
+    renderSceneDetailPage()
+
+    expect(await screen.findByRole('link', { name: /signal bloom/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /afterglow static/i })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /from scene artist/i }))
+
+    expect(screen.getByRole('link', { name: /signal bloom/i })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /afterglow static/i })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /^ambient$/i }))
+
+    expect(screen.getByRole('link', { name: /afterglow static/i })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /signal bloom/i })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /^all$/i }))
+
+    expect(screen.getByRole('link', { name: /signal bloom/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /afterglow static/i })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /unrelated echo/i })).not.toBeInTheDocument()
+  })
+})

--- a/src/modules/scene-detail/SceneDetailPage.test.tsx
+++ b/src/modules/scene-detail/SceneDetailPage.test.tsx
@@ -1,16 +1,13 @@
-import { render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
+import { screen, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
-import {
-  AUTH_SESSION_STORAGE_KEY,
-  AuthProvider,
-  type AuthenticatedUser,
-} from '@auth'
 import { buildApiUrl } from '@lib/api'
-import { LoginPage } from '@modules/auth'
-import { MyScenesPage } from '@modules/my-scenes'
-import { SceneDetailPage } from './SceneDetailPage'
+import { jsonResponse } from '@shared/test/http'
+import {
+  buildSceneDetailResponse,
+  buildSceneDetailStoredUser,
+  renderSceneDetailPage,
+  storeSceneDetailSession,
+} from './test-fixtures'
 
 vi.mock('@modules/player', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@modules/player')>()
@@ -40,114 +37,34 @@ vi.mock('@modules/player', async (importOriginal) => {
   }
 })
 
-const storedUser: AuthenticatedUser = {
-  userId: 8,
-  email: 'artist@example.com',
-  displayName: 'Scene Artist',
-  authProvider: 'LOCAL',
-}
-
-const sceneResponse = {
-  sceneId: 12,
-  ownerUserId: 8,
-  creatorDisplayName: 'Scene Artist',
-  name: 'Aurora Drift',
-  sceneData: {
-    visualizer: {
-      shader: 'nebula',
-    },
-  },
-  thumbnailRef: 'thumbnails/scene-12.png',
-  createdAt: '2026-04-06T14:00:00Z',
-  tags: ['ambient', 'focus-friendly'],
-}
-
-const creatorSceneResponse = {
-  sceneId: 16,
-  ownerUserId: 8,
-  creatorDisplayName: 'Scene Artist',
-  name: 'Signal Bloom',
-  sceneData: {
-    visualizer: {
-      shader: 'pulse',
-    },
-  },
-  thumbnailRef: 'thumbnails/scene-16.png',
-  createdAt: '2026-04-08T14:00:00Z',
-}
-
-const tagSceneResponse = {
-  sceneId: 21,
-  ownerUserId: 42,
-  creatorDisplayName: 'Night Archive',
-  name: 'Afterglow Static',
-  sceneData: {
-    visualizer: {
-      shader: 'mist',
-    },
-  },
-  thumbnailRef: 'thumbnails/scene-21.png',
-  createdAt: '2026-04-09T14:00:00Z',
-}
-
-const unrelatedSceneResponse = {
-  sceneId: 34,
-  ownerUserId: 77,
-  creatorDisplayName: 'Other Creator',
-  name: 'Unrelated Echo',
-  sceneData: {
-    visualizer: {
-      shader: 'echo',
-    },
-  },
-  thumbnailRef: 'thumbnails/scene-34.png',
-  createdAt: '2026-04-10T14:00:00Z',
-}
-
-function jsonResponse(payload: unknown, status = 200) {
-  return new Response(JSON.stringify(payload), {
-    status,
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  })
-}
-
-function storeSession() {
-  window.localStorage.setItem(
-    AUTH_SESSION_STORAGE_KEY,
-    JSON.stringify({
-      accessToken: 'stored-auth-token',
-      user: storedUser,
-    }),
-  )
-}
-
-function renderSceneDetailPage(initialEntries = ['/scenes/12']) {
-  function ScenesRouteProbe() {
-    const location = useLocation()
-
-    return <div data-testid="scenes-route">{location.search}</div>
-  }
-
-  return render(
-    <MemoryRouter initialEntries={initialEntries}>
-      <AuthProvider>
-        <Routes>
-          <Route path="/" element={<div>Home</div>} />
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/my-scenes" element={<MyScenesPage />} />
-          <Route path="/scenes" element={<ScenesRouteProbe />} />
-          <Route path="/scenes/:id" element={<SceneDetailPage />} />
-        </Routes>
-      </AuthProvider>
-    </MemoryRouter>,
-  )
-}
-
-describe('SceneDetailPage', () => {
+describe('SceneDetailPage route states', () => {
   it('loads scene detail on a direct route visit and renders the player', async () => {
-    storeSession()
+    storeSceneDetailSession()
+
+    const storedUser = buildSceneDetailStoredUser()
+    const sceneResponse = buildSceneDetailResponse()
+    const creatorSceneResponse = buildSceneDetailResponse({
+      createdAt: '2026-04-08T14:00:00Z',
+      name: 'Signal Bloom',
+      sceneId: 16,
+      thumbnailRef: 'thumbnails/scene-16.png',
+    })
+    const tagSceneResponse = buildSceneDetailResponse({
+      createdAt: '2026-04-09T14:00:00Z',
+      creatorDisplayName: 'Night Archive',
+      name: 'Afterglow Static',
+      ownerUserId: 42,
+      sceneId: 21,
+      thumbnailRef: 'thumbnails/scene-21.png',
+    })
+    const unrelatedSceneResponse = buildSceneDetailResponse({
+      createdAt: '2026-04-10T14:00:00Z',
+      creatorDisplayName: 'Other Creator',
+      name: 'Unrelated Echo',
+      ownerUserId: 77,
+      sceneId: 34,
+      thumbnailRef: 'thumbnails/scene-34.png',
+    })
 
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
       if (input === buildApiUrl('/users/me')) {
@@ -226,7 +143,9 @@ describe('SceneDetailPage', () => {
   })
 
   it('shows a not-found state when the scene request returns 404', async () => {
-    storeSession()
+    storeSceneDetailSession()
+
+    const storedUser = buildSceneDetailStoredUser()
 
     vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
       if (input === buildApiUrl('/users/me')) {
@@ -273,198 +192,5 @@ describe('SceneDetailPage', () => {
 
     expect(await screen.findByRole('heading', { name: /sign in to view this scene/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /go to login/i })).toBeInTheDocument()
-  })
-
-  it('shows the real creator name for another users scene', async () => {
-    storeSession()
-
-    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
-      if (input === buildApiUrl('/users/me')) {
-        return Promise.resolve(jsonResponse(storedUser))
-      }
-
-      if (input === buildApiUrl('/scenes/44')) {
-        return Promise.resolve(
-          jsonResponse({
-            sceneId: 44,
-            ownerUserId: 77,
-            creatorDisplayName: 'Peter',
-            name: 'Test 3',
-            sceneData: {
-              visualizer: {
-                shader: 'nebula',
-              },
-            },
-            thumbnailRef: 'thumbnails/scene-44.png',
-            createdAt: '2026-04-06T14:00:00Z',
-            tags: ['chill'],
-          }),
-        )
-      }
-
-      if (input === buildApiUrl('/scenes')) {
-        return Promise.resolve(
-          jsonResponse([
-            {
-              sceneId: 44,
-              ownerUserId: 77,
-              creatorDisplayName: 'Peter',
-              name: 'Test 3',
-              sceneData: {
-                visualizer: {
-                  shader: 'nebula',
-                },
-              },
-              thumbnailRef: 'thumbnails/scene-44.png',
-              createdAt: '2026-04-06T14:00:00Z',
-            },
-            {
-              sceneId: 45,
-              ownerUserId: 77,
-              creatorDisplayName: 'Peter',
-              name: 'Pulse Coast',
-              sceneData: {
-                visualizer: {
-                  shader: 'nebula',
-                },
-              },
-              thumbnailRef: 'thumbnails/scene-45.png',
-              createdAt: '2026-04-08T14:00:00Z',
-            },
-          ]),
-        )
-      }
-
-      if (input === buildApiUrl('/scenes?tag=chill')) {
-        return Promise.resolve(
-          jsonResponse([
-            {
-              sceneId: 44,
-              ownerUserId: 77,
-              creatorDisplayName: 'Peter',
-              name: 'Test 3',
-              sceneData: {
-                visualizer: {
-                  shader: 'nebula',
-                },
-              },
-              thumbnailRef: 'thumbnails/scene-44.png',
-              createdAt: '2026-04-06T14:00:00Z',
-            },
-          ]),
-        )
-      }
-
-      throw new Error(`Unexpected request: ${String(input)}`)
-    })
-
-    renderSceneDetailPage(['/scenes/44'])
-
-    expect(await screen.findAllByText('Peter')).not.toHaveLength(0)
-    expect(screen.getByRole('button', { name: /from peter/i })).toBeInTheDocument()
-    expect(screen.queryByText('Talia North')).not.toBeInTheDocument()
-  })
-
-  it('shows attached scene tags and routes to the filtered scenes grid when clicked', async () => {
-    storeSession()
-
-    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
-      if (input === buildApiUrl('/users/me')) {
-        return Promise.resolve(jsonResponse(storedUser))
-      }
-
-      if (input === buildApiUrl('/scenes/12')) {
-        return Promise.resolve(jsonResponse(sceneResponse))
-      }
-
-      if (input === buildApiUrl('/scenes')) {
-        return Promise.resolve(jsonResponse([sceneResponse, creatorSceneResponse]))
-      }
-
-      if (input === buildApiUrl('/scenes?tag=ambient')) {
-        return Promise.resolve(jsonResponse([sceneResponse, tagSceneResponse]))
-      }
-
-      if (input === buildApiUrl('/scenes?tag=focus-friendly')) {
-        return Promise.resolve(jsonResponse([sceneResponse, creatorSceneResponse]))
-      }
-
-      throw new Error(`Unexpected request: ${String(input)}`)
-    })
-
-    const user = userEvent.setup()
-
-    renderSceneDetailPage()
-
-    await screen.findByRole('heading', { name: /aurora drift/i })
-    await user.click(screen.getByRole('button', { name: /^show$/i }))
-
-    const ambientTagLink = screen.getByRole('link', { name: /^ambient$/i })
-    expect(ambientTagLink).toHaveAttribute('href', '/scenes?tag=ambient')
-    expect(screen.getByRole('link', { name: /^focus-friendly$/i })).toHaveAttribute(
-      'href',
-      '/scenes?tag=focus-friendly',
-    )
-
-    await user.click(ambientTagLink)
-
-    expect(await screen.findByTestId('scenes-route')).toHaveTextContent('?tag=ambient')
-  })
-
-  it('filters sidebar recommendations by creator and the current scene tags', async () => {
-    storeSession()
-
-    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
-      if (input === buildApiUrl('/users/me')) {
-        return Promise.resolve(jsonResponse(storedUser))
-      }
-
-      if (input === buildApiUrl('/scenes/12')) {
-        return Promise.resolve(jsonResponse(sceneResponse))
-      }
-
-      if (input === buildApiUrl('/scenes')) {
-        return Promise.resolve(
-          jsonResponse([
-            sceneResponse,
-            creatorSceneResponse,
-            unrelatedSceneResponse,
-          ]),
-        )
-      }
-
-      if (input === buildApiUrl('/scenes?tag=ambient')) {
-        return Promise.resolve(jsonResponse([sceneResponse, tagSceneResponse]))
-      }
-
-      if (input === buildApiUrl('/scenes?tag=focus-friendly')) {
-        return Promise.resolve(jsonResponse([sceneResponse, creatorSceneResponse]))
-      }
-
-      throw new Error(`Unexpected request: ${String(input)}`)
-    })
-
-    const user = userEvent.setup()
-
-    renderSceneDetailPage()
-
-    expect(await screen.findByRole('link', { name: /signal bloom/i })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /afterglow static/i })).toBeInTheDocument()
-
-    await user.click(screen.getByRole('button', { name: /from scene artist/i }))
-
-    expect(screen.getByRole('link', { name: /signal bloom/i })).toBeInTheDocument()
-    expect(screen.queryByRole('link', { name: /afterglow static/i })).not.toBeInTheDocument()
-
-    await user.click(screen.getByRole('button', { name: /^ambient$/i }))
-
-    expect(screen.getByRole('link', { name: /afterglow static/i })).toBeInTheDocument()
-    expect(screen.queryByRole('link', { name: /signal bloom/i })).not.toBeInTheDocument()
-
-    await user.click(screen.getByRole('button', { name: /^all$/i }))
-
-    expect(screen.getByRole('link', { name: /signal bloom/i })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /afterglow static/i })).toBeInTheDocument()
-    expect(screen.queryByRole('link', { name: /unrelated echo/i })).not.toBeInTheDocument()
   })
 })

--- a/src/modules/scene-detail/test-fixtures.tsx
+++ b/src/modules/scene-detail/test-fixtures.tsx
@@ -1,0 +1,64 @@
+import { render } from '@testing-library/react'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
+import { AuthProvider, type AuthenticatedUser } from '@auth'
+import { LoginPage } from '@modules/auth'
+import { MyScenesPage } from '@modules/my-scenes'
+import { buildAuthenticatedUser, storeAuthenticatedSession } from '@shared/test/auth'
+import { SceneDetailPage } from './SceneDetailPage'
+
+export function buildSceneDetailStoredUser(
+  overrides: Partial<AuthenticatedUser> = {},
+) {
+  return buildAuthenticatedUser(overrides)
+}
+
+export function storeSceneDetailSession(
+  user: AuthenticatedUser = buildSceneDetailStoredUser(),
+) {
+  storeAuthenticatedSession(user)
+}
+
+export function buildSceneDetailResponse(
+  overrides: Partial<Record<string, unknown>> = {},
+) {
+  const sceneId =
+    typeof overrides.sceneId === 'number' ? overrides.sceneId : 12
+
+  return {
+    createdAt: '2026-04-06T14:00:00Z',
+    creatorDisplayName: 'Scene Artist',
+    name: 'Aurora Drift',
+    ownerUserId: 8,
+    sceneData: {
+      visualizer: {
+        shader: 'nebula',
+      },
+    },
+    sceneId,
+    tags: ['ambient', 'focus-friendly'],
+    thumbnailRef: `thumbnails/scene-${sceneId}.png`,
+    ...overrides,
+  }
+}
+
+export function renderSceneDetailPage(initialEntries = ['/scenes/12']) {
+  function ScenesRouteProbe() {
+    const location = useLocation()
+
+    return <div data-testid="scenes-route">{location.search}</div>
+  }
+
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <AuthProvider>
+        <Routes>
+          <Route path="/" element={<div>Home</div>} />
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/my-scenes" element={<MyScenesPage />} />
+          <Route path="/scenes" element={<ScenesRouteProbe />} />
+          <Route path="/scenes/:id" element={<SceneDetailPage />} />
+        </Routes>
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}

--- a/src/modules/scene-editor/CreateScenePage.submission.test.tsx
+++ b/src/modules/scene-editor/CreateScenePage.submission.test.tsx
@@ -1,0 +1,315 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { buildApiUrl } from '@lib/api'
+import {
+  mockCreateScenePageFetch,
+  renderCreateScenePage,
+  selectExistingTag,
+  storeSceneEditorSession,
+} from './test-fixtures'
+
+vi.mock('@modules/player', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@modules/player')>()
+
+  return {
+    ...actual,
+    MagePlayer: ({ sceneBlob }: { sceneBlob: unknown }) => (
+      <div data-testid="mage-player">{sceneBlob ? 'preview-ready' : 'no-preview'}</div>
+    ),
+  }
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  window.localStorage.clear()
+})
+
+describe('CreateScenePage submission', () => {
+  it('submits the structured scene data and converts degree controls back to radians', async () => {
+    storeSceneEditorSession()
+
+    let submittedBody: Record<string, unknown> | null = null
+
+    mockCreateScenePageFetch((input, init) => {
+      if (input === buildApiUrl('/scenes')) {
+        submittedBody = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
+        return Promise.resolve(
+          new Response(JSON.stringify({ sceneId: 18 }), {
+            status: 201,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        )
+      }
+    })
+
+    const user = userEvent.setup()
+
+    renderCreateScenePage()
+
+    await user.type(screen.getByLabelText(/scene name/i), 'Aurora Drift')
+    await user.click(screen.getByRole('button', { name: /^camera$/i }))
+    expect(screen.getByRole('heading', { name: /^camera$/i })).toBeInTheDocument()
+    fireEvent.change(screen.getByLabelText(/camera orientation/i), {
+      target: { value: '90' },
+    })
+    await user.click(screen.getByRole('button', { name: /create scene/i }))
+
+    await waitFor(() => expect(submittedBody).not.toBeNull())
+
+    if (!submittedBody) {
+      throw new Error('Expected scene submission payload to be captured.')
+    }
+
+    const responseBody: { name: string; sceneData: Record<string, unknown> } = submittedBody
+    const sceneData = responseBody.sceneData
+    const intent = sceneData.intent as Record<string, number>
+    const fx = sceneData.fx as Record<string, unknown>
+    const passOrder = fx.passOrder as string[]
+
+    expect(responseBody).toMatchObject({
+      name: 'Aurora Drift',
+    })
+    expect(intent.camTilt).toBeCloseTo(Math.PI / 2, 5)
+    expect(passOrder.at(-1)).toBe('outputPass')
+    expect(await screen.findByText('My Scenes')).toBeInTheDocument()
+  })
+
+  it('attaches selected tags after the scene is created', async () => {
+    storeSceneEditorSession()
+
+    let createBody: Record<string, unknown> | null = null
+    const attachedTagIds: number[] = []
+
+    mockCreateScenePageFetch((input, init) => {
+      if (input === buildApiUrl('/scenes')) {
+        createBody = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
+        return Promise.resolve(
+          new Response(JSON.stringify({ sceneId: 18 }), {
+            status: 201,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        )
+      }
+
+      if (input === buildApiUrl('/scenes/18/tags')) {
+        const payload = JSON.parse(String(init?.body ?? '{}')) as { tagId?: number }
+
+        if (typeof payload.tagId === 'number') {
+          attachedTagIds.push(payload.tagId)
+        }
+
+        return Promise.resolve(
+          new Response(JSON.stringify({ sceneId: 18, tagId: payload.tagId }), {
+            status: 201,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        )
+      }
+    })
+
+    const user = userEvent.setup()
+
+    renderCreateScenePage()
+
+    await user.type(screen.getByLabelText(/scene name/i), 'Aurora Drift')
+    await selectExistingTag(user, 'ambient')
+    await selectExistingTag(user, 'focus-friendly')
+    await user.click(screen.getByRole('button', { name: /create scene/i }))
+
+    await screen.findByText('My Scenes')
+
+    expect(createBody).toMatchObject({
+      name: 'Aurora Drift',
+    })
+    expect(attachedTagIds).toEqual([1, 2])
+  })
+
+  it('keeps the created scene in retry mode when one or more tag attachments fail', async () => {
+    storeSceneEditorSession()
+
+    const attachCalls: number[] = []
+
+    mockCreateScenePageFetch((input, init) => {
+      if (input === buildApiUrl('/scenes')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ sceneId: 18 }), {
+            status: 201,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        )
+      }
+
+      if (input === buildApiUrl('/scenes/18/tags')) {
+        const payload = JSON.parse(String(init?.body ?? '{}')) as { tagId?: number }
+
+        if (typeof payload.tagId === 'number') {
+          attachCalls.push(payload.tagId)
+        }
+
+        if (payload.tagId === 2) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                code: 'TAG_ATTACH_FAILED',
+                message: 'Tag attachment is unavailable right now.',
+              }),
+              {
+                status: 503,
+                headers: { 'Content-Type': 'application/json' },
+              },
+            ),
+          )
+        }
+
+        return Promise.resolve(
+          new Response(JSON.stringify({ sceneId: 18, tagId: payload.tagId }), {
+            status: 201,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        )
+      }
+    })
+
+    const user = userEvent.setup()
+
+    renderCreateScenePage()
+
+    await user.type(screen.getByLabelText(/scene name/i), 'Aurora Drift')
+    await selectExistingTag(user, 'ambient')
+    await selectExistingTag(user, 'focus-friendly')
+    await user.click(screen.getByRole('button', { name: /create scene/i }))
+
+    expect(
+      await screen.findByText(/scene created, but we couldn't attach focus-friendly\./i),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /retry tag attachment/i })).toBeInTheDocument()
+    expect(screen.getByText(/waiting to retry attachment for:/i)).toBeInTheDocument()
+    expect(attachCalls).toEqual([1, 2])
+  })
+
+  it('uploads a selected thumbnail before the scene create request is sent', async () => {
+    storeSceneEditorSession()
+
+    const uploadedFiles: File[] = []
+    let presignBody: Record<string, unknown> | null = null
+    let createBody: Record<string, unknown> | null = null
+
+    mockCreateScenePageFetch((input, init) => {
+      if (input === buildApiUrl('/scenes/thumbnail/presign')) {
+        presignBody = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              objectKey: 'scenes/pending/8/thumbnails/abc123.png',
+              uploadUrl: 'https://upload.example.com/scenes/pending/8/thumbnails/abc123.png',
+              method: 'PUT',
+              headers: {
+                'Content-Type': 'image/png',
+              },
+            }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            },
+          ),
+        )
+      }
+
+      if (input === 'https://upload.example.com/scenes/pending/8/thumbnails/abc123.png') {
+        if (init?.body instanceof File) {
+          uploadedFiles.push(init.body)
+        }
+
+        return Promise.resolve(new Response(null, { status: 200 }))
+      }
+
+      if (input === buildApiUrl('/scenes')) {
+        createBody = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
+        return Promise.resolve(
+          new Response(JSON.stringify({ sceneId: 18 }), {
+            status: 201,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        )
+      }
+    })
+
+    const user = userEvent.setup()
+
+    renderCreateScenePage()
+
+    await user.type(screen.getByLabelText(/scene name/i), 'Aurora Drift')
+    fireEvent.change(screen.getByLabelText(/upload thumbnail file/i), {
+      target: {
+        files: [new File(['cover'], 'cover.png', { type: 'image/png' })],
+      },
+    })
+    await user.click(screen.getByRole('button', { name: /create scene/i }))
+
+    await waitFor(() => expect(presignBody).not.toBeNull())
+
+    expect(presignBody).toMatchObject({
+      filename: 'cover.png',
+      contentType: 'image/png',
+      sizeBytes: 5,
+    })
+    expect(uploadedFiles).toHaveLength(1)
+    expect(uploadedFiles[0].name).toBe('cover.png')
+    expect(createBody).toMatchObject({
+      name: 'Aurora Drift',
+      thumbnailObjectKey: 'scenes/pending/8/thumbnails/abc123.png',
+    })
+    expect(await screen.findByText('My Scenes')).toBeInTheDocument()
+  })
+
+  it('does not create the scene when thumbnail upload preparation fails', async () => {
+    storeSceneEditorSession()
+
+    let createAttempted = false
+
+    mockCreateScenePageFetch((input) => {
+      if (input === buildApiUrl('/scenes/thumbnail/presign')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              code: 'THUMBNAIL_STORAGE_UNAVAILABLE',
+              message: 'Thumbnail storage is unavailable right now.',
+            }),
+            {
+              status: 503,
+              headers: { 'Content-Type': 'application/json' },
+            },
+          ),
+        )
+      }
+
+      if (input === buildApiUrl('/scenes')) {
+        createAttempted = true
+        return Promise.resolve(
+          new Response(JSON.stringify({ sceneId: 18 }), {
+            status: 201,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        )
+      }
+    })
+
+    const user = userEvent.setup()
+
+    renderCreateScenePage()
+
+    await user.type(screen.getByLabelText(/scene name/i), 'Aurora Drift')
+    fireEvent.change(screen.getByLabelText(/upload thumbnail file/i), {
+      target: {
+        files: [new File(['cover'], 'cover.png', { type: 'image/png' })],
+      },
+    })
+    await user.click(screen.getByRole('button', { name: /create scene/i }))
+
+    expect(
+      await screen.findByText(/thumbnail storage is unavailable right now\./i),
+    ).toBeInTheDocument()
+    expect(createAttempted).toBe(false)
+  })
+})

--- a/src/modules/scene-editor/CreateScenePage.tags.test.tsx
+++ b/src/modules/scene-editor/CreateScenePage.tags.test.tsx
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { buildApiUrl } from '@lib/api'
+import {
+  addTagFromSearch,
+  mockCreateScenePageFetch,
+  renderCreateScenePage,
+  selectExistingTag,
+  storeSceneEditorSession,
+} from './test-fixtures'
+import { screen } from '@testing-library/react'
+
+vi.mock('@modules/player', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@modules/player')>()
+
+  return {
+    ...actual,
+    MagePlayer: ({ sceneBlob }: { sceneBlob: unknown }) => (
+      <div data-testid="mage-player">{sceneBlob ? 'preview-ready' : 'no-preview'}</div>
+    ),
+  }
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  window.localStorage.clear()
+})
+
+describe('CreateScenePage tags', () => {
+  it('loads available tags and lets the user select more than one before saving', async () => {
+    storeSceneEditorSession()
+    mockCreateScenePageFetch()
+
+    const user = userEvent.setup()
+
+    renderCreateScenePage()
+
+    await selectExistingTag(user, 'ambient')
+    await selectExistingTag(user, 'focus-friendly')
+
+    expect(screen.queryByLabelText(/create a new tag/i)).not.toBeInTheDocument()
+    expect(screen.getByText(/^selected tags$/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^ambient$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^focus-friendly$/i })).toBeInTheDocument()
+  })
+
+  it('creates a new tag in the editor and auto-selects it after success', async () => {
+    storeSceneEditorSession()
+
+    let createTagBody: Record<string, unknown> | null = null
+
+    mockCreateScenePageFetch((input, init) => {
+      if (input === buildApiUrl('/tags')) {
+        createTagBody = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
+        return Promise.resolve(new Response(JSON.stringify({ tagId: 7, name: 'late night' }), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        }))
+      }
+    })
+
+    const user = userEvent.setup()
+
+    renderCreateScenePage()
+
+    await addTagFromSearch(user, 'Late Night')
+
+    expect(createTagBody).toEqual({ name: 'late night' })
+    expect(screen.getByRole('button', { name: /^late night$/i })).toBeInTheDocument()
+  })
+
+  it('selects the existing tag when create-tag returns a duplicate-name conflict', async () => {
+    storeSceneEditorSession()
+    let tagFetchCount = 0
+
+    mockCreateScenePageFetch((input, init) => {
+      const method =
+        typeof init?.method === 'string' ? init.method.toUpperCase() : 'GET'
+
+      if (input === buildApiUrl('/tags') && method === 'GET') {
+        tagFetchCount += 1
+
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              { tagId: 1, name: 'ambient' },
+              { tagId: 2, name: 'focus-friendly' },
+              ...(tagFetchCount > 1 ? [{ tagId: 3, name: 'late night' }] : []),
+            ]),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            },
+          ),
+        )
+      }
+
+      if (input === buildApiUrl('/tags')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              code: 'TAG_ALREADY_EXISTS',
+              message: 'Tag already exists.',
+            }),
+            {
+              status: 409,
+              headers: { 'Content-Type': 'application/json' },
+            },
+          ),
+        )
+      }
+    })
+
+    const user = userEvent.setup()
+
+    renderCreateScenePage()
+
+    await addTagFromSearch(user, 'Late Night')
+
+    expect(await screen.findByRole('button', { name: /^late night$/i })).toBeInTheDocument()
+  })
+
+  it('clicking a selected tag pill removes it from the scene', async () => {
+    storeSceneEditorSession()
+    mockCreateScenePageFetch()
+
+    const user = userEvent.setup()
+
+    renderCreateScenePage()
+
+    await selectExistingTag(user, 'ambient')
+    await user.click(screen.getByRole('button', { name: /^ambient$/i }))
+
+    expect(screen.getByText(/no tags selected yet\./i)).toBeInTheDocument()
+  })
+})

--- a/src/modules/scene-editor/CreateScenePage.test.tsx
+++ b/src/modules/scene-editor/CreateScenePage.test.tsx
@@ -1,14 +1,11 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { fireEvent, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import userEvent from '@testing-library/user-event'
 import {
-  AUTH_SESSION_STORAGE_KEY,
-  AuthProvider,
-  type AuthenticatedUser,
-} from '@auth'
-import { buildApiUrl } from '@lib/api'
-import { CreateScenePage } from './CreateScenePage'
+  mockCreateScenePageFetch,
+  renderCreateScenePage,
+  storeSceneEditorSession,
+} from './test-fixtures'
 
 vi.mock('@modules/player', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@modules/player')>()
@@ -29,112 +26,14 @@ vi.mock('@modules/player', async (importOriginal) => {
   }
 })
 
-const storedUser: AuthenticatedUser = {
-  userId: 8,
-  email: 'artist@example.com',
-  displayName: 'Scene Artist',
-  authProvider: 'LOCAL',
-}
-
-const mockTags = [
-  { tagId: 1, name: 'ambient' },
-  { tagId: 2, name: 'focus-friendly' },
-]
-
-type FetchHandler = (
-  input: RequestInfo | URL,
-  init?: RequestInit,
-) => Response | Promise<Response> | null | undefined
-
-function jsonResponse(payload: unknown, status = 200) {
-  return new Response(JSON.stringify(payload), {
-    status,
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  })
-}
-
-function storeSession() {
-  window.localStorage.setItem(
-    AUTH_SESSION_STORAGE_KEY,
-    JSON.stringify({
-      accessToken: 'stored-auth-token',
-      user: storedUser,
-    }),
-  )
-}
-
-function mockCreateScenePageFetch(
-  handler?: FetchHandler,
-  tagsResponse: unknown[] = mockTags,
-) {
-  return vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
-    const method = typeof init?.method === 'string' ? init.method.toUpperCase() : 'GET'
-
-    if (input === buildApiUrl('/users/me')) {
-      return Promise.resolve(jsonResponse(storedUser))
-    }
-
-    if (input === buildApiUrl('/tags') && method === 'GET') {
-      return Promise.resolve(jsonResponse(tagsResponse))
-    }
-
-    const nextResponse = handler?.(input, init)
-
-    if (nextResponse) {
-      return Promise.resolve(nextResponse)
-    }
-
-    throw new Error(`Unexpected request: ${String(input)}`)
-  })
-}
-
-function renderCreateScenePage() {
-  return render(
-    <MemoryRouter initialEntries={['/create-scene']}>
-      <AuthProvider>
-        <Routes>
-          <Route path="/create-scene" element={<CreateScenePage />} />
-          <Route path="/my-scenes" element={<div>My Scenes</div>} />
-        </Routes>
-      </AuthProvider>
-    </MemoryRouter>,
-  )
-}
-
-async function selectExistingTag(user: ReturnType<typeof userEvent.setup>, tagName: string) {
-  const searchInput = await screen.findByLabelText(/select existing tags/i)
-
-  await user.click(searchInput)
-  await user.clear(searchInput)
-  await user.type(searchInput, tagName)
-  await user.click(screen.getByRole('button', { name: new RegExp(`^${tagName}$`, 'i') }))
-}
-
-async function addTagFromSearch(user: ReturnType<typeof userEvent.setup>, tagName: string) {
-  const normalizedTagName = tagName.trim().toLowerCase()
-  const searchInput = await screen.findByLabelText(/select existing tags/i)
-
-  await user.click(searchInput)
-  await user.clear(searchInput)
-  await user.type(searchInput, tagName)
-  await user.click(
-    screen.getByRole('button', {
-      name: new RegExp(`^Add tag "${normalizedTagName}"$`, 'i'),
-    }),
-  )
-}
-
 afterEach(() => {
   vi.restoreAllMocks()
   window.localStorage.clear()
 })
 
-describe('CreateScenePage', () => {
+describe('CreateScenePage workflow', () => {
   it('renders the details step first while keeping the full section menu available', async () => {
-    storeSession()
-
+    storeSceneEditorSession()
     mockCreateScenePageFetch()
 
     renderCreateScenePage()
@@ -159,8 +58,7 @@ describe('CreateScenePage', () => {
   })
 
   it('renders interactive metadata controls beneath the scene name field', async () => {
-    storeSession()
-
+    storeSceneEditorSession()
     mockCreateScenePageFetch()
 
     renderCreateScenePage()
@@ -187,8 +85,7 @@ describe('CreateScenePage', () => {
   })
 
   it('keeps the first section ordered around scene metadata and shows sticky navigation actions', async () => {
-    storeSession()
-
+    storeSceneEditorSession()
     mockCreateScenePageFetch()
 
     renderCreateScenePage()
@@ -222,127 +119,8 @@ describe('CreateScenePage', () => {
     expect(screen.getByRole('button', { name: /create scene/i })).toBeInTheDocument()
   })
 
-  it('loads available tags and lets the user select more than one before saving', async () => {
-    storeSession()
-
-    mockCreateScenePageFetch()
-
-    const user = userEvent.setup()
-
-    renderCreateScenePage()
-
-    await selectExistingTag(user, 'ambient')
-    await selectExistingTag(user, 'focus-friendly')
-
-    expect(screen.queryByLabelText(/create a new tag/i)).not.toBeInTheDocument()
-    expect(screen.getByText(/^selected tags$/i)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /^ambient$/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /^focus-friendly$/i })).toBeInTheDocument()
-  })
-
-  it('creates a new tag in the editor and auto-selects it after success', async () => {
-    storeSession()
-
-    let createTagBody: Record<string, unknown> | null = null
-
-    mockCreateScenePageFetch((input, init) => {
-      if (input === buildApiUrl('/tags')) {
-        createTagBody = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
-        return Promise.resolve(jsonResponse({ tagId: 7, name: 'late night' }, 201))
-      }
-    })
-
-    const user = userEvent.setup()
-
-    renderCreateScenePage()
-
-    await addTagFromSearch(user, 'Late Night')
-
-    await waitFor(() => expect(screen.getByRole('button', { name: /^late night$/i })).toBeInTheDocument())
-
-    expect(createTagBody).toMatchObject({
-      name: 'late night',
-    })
-    expect(screen.getByRole('button', { name: /^late night$/i })).toBeInTheDocument()
-  })
-
-  it('selects the existing tag when create-tag returns a duplicate-name conflict', async () => {
-    storeSession()
-
-    let tagListRequestCount = 0
-
-    const fetchSpy = vi.spyOn(globalThis, 'fetch')
-    fetchSpy.mockImplementation((input, init) => {
-      const method = typeof init?.method === 'string' ? init.method.toUpperCase() : 'GET'
-
-      if (input === buildApiUrl('/users/me')) {
-        return Promise.resolve(jsonResponse(storedUser))
-      }
-
-      if (input === buildApiUrl('/tags') && method === 'GET') {
-        tagListRequestCount += 1
-
-        const tagList =
-          tagListRequestCount === 1
-            ? [
-                { tagId: 1, name: 'ambient' },
-                { tagId: 2, name: 'focus-friendly' },
-              ]
-            : [
-                { tagId: 1, name: 'ambient' },
-                { tagId: 2, name: 'focus-friendly' },
-                { tagId: 7, name: 'late night' },
-              ]
-
-        return Promise.resolve(
-          jsonResponse(tagList),
-        )
-      }
-
-      if (input === buildApiUrl('/tags') && method === 'POST') {
-        return Promise.resolve(
-          jsonResponse(
-            {
-              code: 'TAG_ALREADY_EXISTS',
-              message: 'A tag with this name already exists.',
-            },
-            409,
-          ),
-        )
-      }
-
-      throw new Error(`Unexpected request: ${String(input)}`)
-    })
-
-    const user = userEvent.setup()
-
-    renderCreateScenePage()
-
-    await addTagFromSearch(user, 'Late Night')
-
-    await waitFor(() => expect(tagListRequestCount).toBeGreaterThanOrEqual(2))
-    expect(screen.getByRole('button', { name: /^late night$/i })).toBeInTheDocument()
-    expect(screen.queryByText(/failed to create tag/i)).not.toBeInTheDocument()
-  })
-
-  it('clicking a selected tag pill removes it from the scene', async () => {
-    storeSession()
-
-    mockCreateScenePageFetch()
-
-    const user = userEvent.setup()
-
-    renderCreateScenePage()
-
-    await selectExistingTag(user, 'ambient')
-    await user.click(screen.getByRole('button', { name: /^ambient$/i }))
-
-    expect(screen.getByText(/no tags selected yet\./i)).toBeInTheDocument()
-  })
-
   it('keeps the Motion section focused on the persisted MAGE engine motion controls', async () => {
-    storeSession()
-
+    storeSceneEditorSession()
     mockCreateScenePageFetch()
 
     const user = userEvent.setup()
@@ -365,8 +143,7 @@ describe('CreateScenePage', () => {
   })
 
   it('moves between sections with the next and back buttons and keeps the menu in sync', async () => {
-    storeSession()
-
+    storeSceneEditorSession()
     mockCreateScenePageFetch()
 
     const user = userEvent.setup()
@@ -393,8 +170,7 @@ describe('CreateScenePage', () => {
   })
 
   it('switches the shader select to Custom Shader when the source no longer matches a built-in shader', async () => {
-    storeSession()
-
+    storeSceneEditorSession()
     mockCreateScenePageFetch()
 
     const user = userEvent.setup()
@@ -414,8 +190,7 @@ describe('CreateScenePage', () => {
   })
 
   it('marks previous required sections as needing attention when you move past them incomplete', async () => {
-    storeSession()
-
+    storeSceneEditorSession()
     mockCreateScenePageFetch()
 
     const user = userEvent.setup()
@@ -433,8 +208,7 @@ describe('CreateScenePage', () => {
   })
 
   it('splits pass ordering into its own section and groups effects into categorized cards', async () => {
-    storeSession()
-
+    storeSceneEditorSession()
     mockCreateScenePageFetch()
 
     const user = userEvent.setup()
@@ -461,247 +235,8 @@ describe('CreateScenePage', () => {
     expect(screen.queryByRole('heading', { name: /^finish & output$/i })).not.toBeInTheDocument()
   })
 
-  it('submits the structured scene data and converts degree controls back to radians', async () => {
-    storeSession()
-
-    let submittedBody: Record<string, unknown> | null = null
-
-    mockCreateScenePageFetch((input, init) => {
-      if (input === buildApiUrl('/scenes')) {
-        submittedBody = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
-        return Promise.resolve(jsonResponse({ sceneId: 18 }, 201))
-      }
-    })
-
-    const user = userEvent.setup()
-
-    renderCreateScenePage()
-
-    await user.type(screen.getByLabelText(/scene name/i), 'Aurora Drift')
-    await user.click(screen.getByRole('button', { name: /^camera$/i }))
-    expect(screen.getByRole('heading', { name: /^camera$/i })).toBeInTheDocument()
-    fireEvent.change(screen.getByLabelText(/camera orientation/i), { target: { value: '90' } })
-    await user.click(screen.getByRole('button', { name: /create scene/i }))
-
-    await waitFor(() => expect(submittedBody).not.toBeNull())
-
-    if (!submittedBody) {
-      throw new Error('Expected scene submission payload to be captured.')
-    }
-
-    const responseBody: { name: string; sceneData: Record<string, unknown> } = submittedBody
-    const sceneData = responseBody.sceneData
-    const intent = sceneData.intent as Record<string, number>
-    const fx = sceneData.fx as Record<string, unknown>
-    const passOrder = fx.passOrder as string[]
-
-    expect(responseBody).toMatchObject({
-      name: 'Aurora Drift',
-    })
-    expect(intent.camTilt).toBeCloseTo(Math.PI / 2, 5)
-    expect(passOrder.at(-1)).toBe('outputPass')
-    expect(await screen.findByText('My Scenes')).toBeInTheDocument()
-  })
-
-  it('attaches selected tags after the scene is created', async () => {
-    storeSession()
-
-    let createBody: Record<string, unknown> | null = null
-    const attachedTagIds: number[] = []
-
-    mockCreateScenePageFetch((input, init) => {
-      if (input === buildApiUrl('/scenes')) {
-        createBody = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
-        return Promise.resolve(jsonResponse({ sceneId: 18 }, 201))
-      }
-
-      if (input === buildApiUrl('/scenes/18/tags')) {
-        const payload = JSON.parse(String(init?.body ?? '{}')) as { tagId?: number }
-
-        if (typeof payload.tagId === 'number') {
-          attachedTagIds.push(payload.tagId)
-        }
-
-        return Promise.resolve(jsonResponse({ sceneId: 18, tagId: payload.tagId }, 201))
-      }
-    })
-
-    const user = userEvent.setup()
-
-    renderCreateScenePage()
-
-    await user.type(screen.getByLabelText(/scene name/i), 'Aurora Drift')
-    await selectExistingTag(user, 'ambient')
-    await selectExistingTag(user, 'focus-friendly')
-    await user.click(screen.getByRole('button', { name: /create scene/i }))
-
-    await screen.findByText('My Scenes')
-
-    expect(createBody).toMatchObject({
-      name: 'Aurora Drift',
-    })
-    expect(attachedTagIds).toEqual([1, 2])
-  })
-
-  it('keeps the created scene in retry mode when one or more tag attachments fail', async () => {
-    storeSession()
-
-    const attachCalls: number[] = []
-
-    mockCreateScenePageFetch((input, init) => {
-      if (input === buildApiUrl('/scenes')) {
-        return Promise.resolve(jsonResponse({ sceneId: 18 }, 201))
-      }
-
-      if (input === buildApiUrl('/scenes/18/tags')) {
-        const payload = JSON.parse(String(init?.body ?? '{}')) as { tagId?: number }
-
-        if (typeof payload.tagId === 'number') {
-          attachCalls.push(payload.tagId)
-        }
-
-        if (payload.tagId === 2) {
-          return Promise.resolve(
-            jsonResponse(
-              {
-                code: 'TAG_ATTACH_FAILED',
-                message: 'Tag attachment is unavailable right now.',
-              },
-              503,
-            ),
-          )
-        }
-
-        return Promise.resolve(jsonResponse({ sceneId: 18, tagId: payload.tagId }, 201))
-      }
-    })
-
-    const user = userEvent.setup()
-
-    renderCreateScenePage()
-
-    await user.type(screen.getByLabelText(/scene name/i), 'Aurora Drift')
-    await selectExistingTag(user, 'ambient')
-    await selectExistingTag(user, 'focus-friendly')
-    await user.click(screen.getByRole('button', { name: /create scene/i }))
-
-    expect(
-      await screen.findByText(/scene created, but we couldn't attach focus-friendly\./i),
-    ).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /retry tag attachment/i })).toBeInTheDocument()
-    expect(screen.getByText(/waiting to retry attachment for:/i)).toBeInTheDocument()
-    expect(attachCalls).toEqual([1, 2])
-  })
-
-  it('uploads a selected thumbnail before the scene create request is sent', async () => {
-    storeSession()
-
-    const uploadedFiles: File[] = []
-    let presignBody: Record<string, unknown> | null = null
-    let createBody: Record<string, unknown> | null = null
-
-    mockCreateScenePageFetch((input, init) => {
-      if (input === buildApiUrl('/scenes/thumbnail/presign')) {
-        presignBody = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
-        return Promise.resolve(
-          jsonResponse({
-            objectKey: 'scenes/pending/8/thumbnails/abc123.png',
-            uploadUrl: 'https://upload.example.com/scenes/pending/8/thumbnails/abc123.png',
-            method: 'PUT',
-            headers: {
-              'Content-Type': 'image/png',
-            },
-          }),
-        )
-      }
-
-      if (input === 'https://upload.example.com/scenes/pending/8/thumbnails/abc123.png') {
-        if (init?.body instanceof File) {
-          uploadedFiles.push(init.body)
-        }
-
-        return Promise.resolve(new Response(null, { status: 200 }))
-      }
-
-      if (input === buildApiUrl('/scenes')) {
-        createBody = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
-        return Promise.resolve(jsonResponse({ sceneId: 18 }, 201))
-      }
-    })
-
-    const user = userEvent.setup()
-
-    renderCreateScenePage()
-
-    await user.type(screen.getByLabelText(/scene name/i), 'Aurora Drift')
-    fireEvent.change(screen.getByLabelText(/upload thumbnail file/i), {
-      target: {
-        files: [new File(['cover'], 'cover.png', { type: 'image/png' })],
-      },
-    })
-    await user.click(screen.getByRole('button', { name: /create scene/i }))
-
-    await waitFor(() => expect(presignBody).not.toBeNull())
-
-    expect(presignBody).toMatchObject({
-      filename: 'cover.png',
-      contentType: 'image/png',
-      sizeBytes: 5,
-    })
-    expect(uploadedFiles).toHaveLength(1)
-    expect(uploadedFiles[0].name).toBe('cover.png')
-    expect(createBody).toMatchObject({
-      name: 'Aurora Drift',
-      thumbnailObjectKey: 'scenes/pending/8/thumbnails/abc123.png',
-    })
-    expect(await screen.findByText('My Scenes')).toBeInTheDocument()
-  })
-
-  it('does not create the scene when thumbnail upload preparation fails', async () => {
-    storeSession()
-
-    let createAttempted = false
-
-    mockCreateScenePageFetch((input) => {
-      if (input === buildApiUrl('/scenes/thumbnail/presign')) {
-        return Promise.resolve(
-          jsonResponse(
-            {
-              code: 'THUMBNAIL_STORAGE_UNAVAILABLE',
-              message: 'Thumbnail storage is unavailable right now.',
-            },
-            503,
-          ),
-        )
-      }
-
-      if (input === buildApiUrl('/scenes')) {
-        createAttempted = true
-        return Promise.resolve(jsonResponse({ sceneId: 18 }, 201))
-      }
-    })
-
-    const user = userEvent.setup()
-
-    renderCreateScenePage()
-
-    await user.type(screen.getByLabelText(/scene name/i), 'Aurora Drift')
-    fireEvent.change(screen.getByLabelText(/upload thumbnail file/i), {
-      target: {
-        files: [new File(['cover'], 'cover.png', { type: 'image/png' })],
-      },
-    })
-    await user.click(screen.getByRole('button', { name: /create scene/i }))
-
-    expect(
-      await screen.findByText(/thumbnail storage is unavailable right now\./i),
-    ).toBeInTheDocument()
-    expect(createAttempted).toBe(false)
-  })
-
   it('moves advanced controls into collapsible groups and uses confirm as the final review step', async () => {
-    storeSession()
-
+    storeSceneEditorSession()
     mockCreateScenePageFetch()
 
     const user = userEvent.setup()

--- a/src/modules/scene-editor/test-fixtures.tsx
+++ b/src/modules/scene-editor/test-fixtures.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { vi } from 'vitest'
+import { AuthProvider, type AuthenticatedUser } from '@auth'
+import { buildApiUrl } from '@lib/api'
+import { buildAuthenticatedUser, storeAuthenticatedSession } from '@shared/test/auth'
+import { jsonResponse } from '@shared/test/http'
+import { CreateScenePage } from './CreateScenePage'
+
+export type SceneEditorFetchHandler = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Response | Promise<Response> | null | undefined
+
+export function buildSceneEditorStoredUser(
+  overrides: Partial<AuthenticatedUser> = {},
+) {
+  return buildAuthenticatedUser(overrides)
+}
+
+export function buildSceneEditorTag(
+  overrides: Partial<{ tagId: number; name: string }> = {},
+) {
+  return {
+    name: 'ambient',
+    tagId: 1,
+    ...overrides,
+  }
+}
+
+export function buildSceneEditorTags() {
+  return [
+    buildSceneEditorTag(),
+    buildSceneEditorTag({
+      name: 'focus-friendly',
+      tagId: 2,
+    }),
+  ]
+}
+
+export function storeSceneEditorSession(
+  user: AuthenticatedUser = buildSceneEditorStoredUser(),
+) {
+  storeAuthenticatedSession(user)
+}
+
+export function mockCreateScenePageFetch(
+  handler?: SceneEditorFetchHandler,
+  tagsResponse: unknown[] = buildSceneEditorTags(),
+  storedUser: AuthenticatedUser = buildSceneEditorStoredUser(),
+) {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+    const method =
+      typeof init?.method === 'string' ? init.method.toUpperCase() : 'GET'
+
+    if (input === buildApiUrl('/users/me')) {
+      return Promise.resolve(jsonResponse(storedUser))
+    }
+
+    const nextResponse = handler?.(input, init)
+
+    if (nextResponse) {
+      return Promise.resolve(nextResponse)
+    }
+
+    if (input === buildApiUrl('/tags') && method === 'GET') {
+      return Promise.resolve(jsonResponse(tagsResponse))
+    }
+
+    throw new Error(`Unexpected request: ${String(input)}`)
+  })
+}
+
+export function renderCreateScenePage() {
+  return render(
+    <MemoryRouter initialEntries={['/create-scene']}>
+      <AuthProvider>
+        <Routes>
+          <Route path="/create-scene" element={<CreateScenePage />} />
+          <Route path="/my-scenes" element={<div>My Scenes</div>} />
+        </Routes>
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+export async function selectExistingTag(
+  user: ReturnType<typeof userEvent.setup>,
+  tagName: string,
+) {
+  const searchInput = await screen.findByLabelText(/select existing tags/i)
+
+  await user.click(searchInput)
+  await user.clear(searchInput)
+  await user.type(searchInput, tagName)
+  await user.click(
+    screen.getByRole('button', { name: new RegExp(`^${tagName}$`, 'i') }),
+  )
+}
+
+export async function addTagFromSearch(
+  user: ReturnType<typeof userEvent.setup>,
+  tagName: string,
+) {
+  const normalizedTagName = tagName.trim().toLowerCase()
+  const searchInput = await screen.findByLabelText(/select existing tags/i)
+
+  await user.click(searchInput)
+  await user.clear(searchInput)
+  await user.type(searchInput, tagName)
+  await user.click(
+    screen.getByRole('button', {
+      name: new RegExp(`^Add tag "${normalizedTagName}"$`, 'i'),
+    }),
+  )
+}

--- a/src/shared/test/auth.ts
+++ b/src/shared/test/auth.ts
@@ -1,0 +1,26 @@
+import { AUTH_SESSION_STORAGE_KEY, type AuthenticatedUser } from '@auth'
+
+export function buildAuthenticatedUser(
+  overrides: Partial<AuthenticatedUser> = {},
+): AuthenticatedUser {
+  return {
+    authProvider: 'LOCAL',
+    displayName: 'Scene Artist',
+    email: 'artist@example.com',
+    userId: 8,
+    ...overrides,
+  }
+}
+
+export function storeAuthenticatedSession(
+  user: AuthenticatedUser = buildAuthenticatedUser(),
+  accessToken = 'stored-auth-token',
+) {
+  window.localStorage.setItem(
+    AUTH_SESSION_STORAGE_KEY,
+    JSON.stringify({
+      accessToken,
+      user,
+    }),
+  )
+}

--- a/src/shared/test/http.ts
+++ b/src/shared/test/http.ts
@@ -1,0 +1,8 @@
+export function jsonResponse(payload: unknown, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    status,
+  })
+}


### PR DESCRIPTION
## Summary

Closes #92.

This PR reorganizes frontend tests so they follow module ownership instead of accumulating in oversized single-file specs. It also adds module-local fixture builders for richer feature data setup, while keeping truly cross-cutting test utilities in `src/shared/test`.

## What Changed

- added shared cross-cutting test helpers for:
  - auth/session setup
  - JSON/HTTP response setup
- split the large scene-editor spec into focused files for:
  - editor workflow and navigation
  - tag behavior
  - submission behavior
- split the large my-scenes spec into focused files for:
  - auth/load/base states
  - table behavior
  - sample-scene seeding
- split the large scene-detail spec into focused files for:
  - route/loading/error states
  - metadata behavior
  - recommendation behavior
- split the large player spec into focused files for:
  - player lifecycle/rendering
  - audio behavior
  - playlist behavior
- added module-local `test-fixtures.ts` or `test-fixtures.tsx` builders for:
  - `scene-editor`
  - `my-scenes`
  - `scene-detail`
  - `player`
- updated the frontend architecture docs and modules-layer docs to make the testing rule explicit:
  - module-specific tests and fixture builders stay with the owning module
  - `src/shared/test/` is reserved for genuinely cross-cutting helpers

## Notes

- this is a test-ownership and maintainability refactor; product behavior is unchanged
- the goal is to make future test additions local to each feature module instead of expanding a few broad integration-heavy files

## Testing

- `npx tsc -b`
- `npm run lint`
- `npm test`
