### PR TITLE
108 capture a scene thumbnail from the live preview in the editor

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -12,7 +12,7 @@ The intended production contract is:
 
 This keeps deployment aligned with the current auth flow and avoids introducing CORS requirements into the supported path.
 
-The one exception is scene thumbnail uploads: when a user selects a thumbnail in the create scene flow, the browser uploads that file directly to the configured object-storage provider using a presigned `PUT` URL issued by the backend.
+The one exception is scene thumbnail uploads: when the create scene flow has a thumbnail to persist, the browser uploads that generated image directly to the configured object-storage provider using a presigned `PUT` URL issued by the backend.
 
 ## Container Notes
 

--- a/src/App.css
+++ b/src/App.css
@@ -2713,15 +2713,24 @@
 
 .scene-thumbnail-picker__grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 12px;
+}
+
+.scene-thumbnail-picker__row {
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) 176px;
+  align-items: stretch;
+  gap: 20px;
+  width: fit-content;
+  max-width: 100%;
 }
 
 .scene-thumbnail-choice {
   appearance: none;
   display: grid;
   gap: 10px;
-  min-height: 132px;
+  width: 100%;
+  min-height: 176px;
+  align-content: start;
   padding: 16px;
   border-radius: var(--editor-choice-radius);
   border: 1px dashed var(--editor-choice-border);
@@ -2736,6 +2745,7 @@
   border-color: var(--editor-choice-hover-border);
   background: var(--editor-choice-hover-background);
   box-shadow: var(--editor-choice-hover-shadow);
+  transform: translateY(-1px);
 }
 
 .scene-thumbnail-choice.is-selected {
@@ -2743,6 +2753,11 @@
   border-color: var(--editor-choice-selected-border);
   background: var(--editor-choice-selected-background);
   box-shadow: var(--editor-choice-selected-shadow);
+}
+
+.scene-thumbnail-choice:disabled {
+  cursor: wait;
+  opacity: 0.72;
 }
 
 .scene-thumbnail-choice__eyebrow {
@@ -2762,6 +2777,57 @@
   color: var(--muted);
   font-size: 0.92rem;
   line-height: 1.55;
+}
+
+.scene-thumbnail-preview {
+  display: grid;
+  gap: 10px;
+  justify-items: start;
+  width: 176px;
+  flex: 0 0 176px;
+}
+
+.scene-thumbnail-preview__frame {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  overflow: hidden;
+  border-radius: var(--editor-choice-radius);
+  border: 1px solid var(--editor-choice-border);
+  background: var(--editor-choice-background);
+  box-shadow: var(--card-thumbnail-shadow);
+  transition:
+    background-color 0.18s ease,
+    border-color 0.18s ease,
+    box-shadow 0.18s ease,
+    transform 0.18s ease;
+}
+
+.scene-thumbnail-preview__image {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+  transition:
+    transform 0.22s ease,
+    filter 0.22s ease;
+}
+
+.scene-thumbnail-preview__placeholder {
+  width: 100%;
+  height: 100%;
+  background-size: 80%;
+}
+
+.scene-thumbnail-preview__frame:hover {
+  border-color: var(--card-thumbnail-hover-border);
+  box-shadow: var(--card-thumbnail-hover-shadow);
+  transform: translateY(-2px);
+}
+
+.scene-thumbnail-preview__frame:hover .scene-thumbnail-preview__image,
+.scene-thumbnail-preview__frame:hover .scene-thumbnail-preview__placeholder {
+  transform: scale(1.018);
+  filter: saturate(1.05) brightness(1.03);
 }
 
 .scene-select {
@@ -3271,10 +3337,6 @@
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .scene-thumbnail-picker__grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
   .scene-editor-preview__card {
     position: static;
   }
@@ -3325,8 +3387,13 @@
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .scene-thumbnail-picker__grid {
+  .scene-thumbnail-picker__row {
     grid-template-columns: minmax(0, 1fr);
+    width: 100%;
+  }
+
+  .scene-thumbnail-preview {
+    width: 176px;
   }
 
   .scene-slider__controls,

--- a/src/modules/player/MagePlayer.test.tsx
+++ b/src/modules/player/MagePlayer.test.tsx
@@ -138,6 +138,40 @@ describe('MagePlayer', () => {
     })
   })
 
+  it('publishes a capture callback once the live preview is ready', async () => {
+    const controller = buildMagePlayerController()
+    vi.mocked(createMagePlayer).mockResolvedValue(controller)
+
+    const onCaptureFramePreviewChange = vi.fn()
+    const sceneBlob = buildMagePlayerSceneBlob()
+
+    render(
+      <MagePlayer
+        onCaptureFramePreviewChange={onCaptureFramePreviewChange}
+        sceneBlob={sceneBlob}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(controller.loadSceneBlob).toHaveBeenCalledWith(sceneBlob)
+      expect(onCaptureFramePreviewChange).toHaveBeenCalledWith(
+        expect.any(Function),
+      )
+    })
+
+    const captureFramePreview =
+      onCaptureFramePreviewChange.mock.calls.at(-1)?.[0]
+
+    const previewDataUrl = await captureFramePreview?.()
+
+    expect(controller.captureFramePreview).toHaveBeenCalledWith({
+      height: 512,
+      type: 'image/png',
+      width: 512,
+    })
+    expect(previewDataUrl).toMatch(/^data:image\/png;base64,/)
+  })
+
   it('suppresses playback controls while the player is empty', async () => {
     const controller = buildMagePlayerController()
     vi.mocked(createMagePlayer).mockResolvedValue(controller)

--- a/src/modules/player/MagePlayer.tsx
+++ b/src/modules/player/MagePlayer.tsx
@@ -25,6 +25,9 @@ export type MagePlayerProps = {
   className?: string
   initialPlayback?: MagePlayerPlaybackState
   log?: boolean
+  onCaptureFramePreviewChange?: (
+    captureFramePreview: (() => Promise<string | null>) | null,
+  ) => void
   onPlaylistChange?: (tracks: MagePlayerPlaylistTrack[]) => void
   onRequestPlaylistOpen?: () => void
   onSelectedTrackChange?: (trackId: string | null) => void
@@ -53,6 +56,7 @@ export function MagePlayer({
   className,
   initialPlayback = 'playing',
   log = false,
+  onCaptureFramePreviewChange,
   onPlaylistChange,
   onRequestPlaylistOpen,
   onSelectedTrackChange,
@@ -242,6 +246,34 @@ export function MagePlayer({
         : loadedSceneBlob === sceneBlob
           ? 'ready'
           : 'loading'
+
+  useEffect(() => {
+    if (!onCaptureFramePreviewChange) {
+      return
+    }
+
+    const player = playerRef.current
+
+    if (status === 'ready' && typeof player?.captureFramePreview === 'function') {
+      onCaptureFramePreviewChange(() =>
+        player.captureFramePreview?.({
+          height: 512,
+          type: 'image/png',
+          width: 512,
+        }) ?? Promise.resolve(null),
+      )
+
+      return () => {
+        onCaptureFramePreviewChange(null)
+      }
+    }
+
+    onCaptureFramePreviewChange(null)
+
+    return () => {
+      onCaptureFramePreviewChange(null)
+    }
+  }, [onCaptureFramePreviewChange, playerVersion, status])
 
   useEffect(() => {
     const player = playerRef.current

--- a/src/modules/player/infrastructure/engineAdapter.ts
+++ b/src/modules/player/infrastructure/engineAdapter.ts
@@ -19,6 +19,7 @@ const DEFAULT_ENGINE_CONTROLS = {
 const GENERIC_RENDER_ERROR_MESSAGE = 'Scene data could not be rendered by the MAGE engine.'
 
 type MageEngineBridge = {
+  captureFramePreview?: MAGEEngineAPI['captureFramePreview']
   dispose: MAGEEngineAPI['dispose']
   getAudioDuration?: MAGEEngineAPI['getAudioDuration']
   getAudioTime?: MAGEEngineAPI['getAudioTime']
@@ -61,7 +62,17 @@ export type MagePlayerAudioState = {
   volume: number
 }
 
+export type MagePlayerCaptureFrameOptions = {
+  height?: number
+  quality?: number
+  type?: string
+  width?: number
+}
+
 export type MagePlayerController = {
+  captureFramePreview?: (
+    options?: MagePlayerCaptureFrameOptions,
+  ) => Promise<string | null>
   clearAudio: () => MagePlayerAudioState
   dispose: () => void
   getAudioState: () => MagePlayerAudioState
@@ -344,6 +355,28 @@ export async function createMagePlayer(
   }
 
   return {
+    async captureFramePreview(options = {}) {
+      if (!hasLoadedScene || !currentSceneBlob) {
+        throw new MagePlayerAdapterError(
+          'Load a scene before capturing a thumbnail.',
+        )
+      }
+
+      if (typeof engine.captureFramePreview !== 'function') {
+        throw new MagePlayerAdapterError(
+          'This MAGE engine build does not support preview capture.',
+        )
+      }
+
+      try {
+        return await engine.captureFramePreview(options)
+      } catch (error) {
+        throw new MagePlayerAdapterError(
+          'The live preview could not be captured.',
+          { cause: error },
+        )
+      }
+    },
     clearAudio() {
       if (typeof engine.unloadAudio === 'function') {
         engine.unloadAudio()

--- a/src/modules/player/test-fixtures.ts
+++ b/src/modules/player/test-fixtures.ts
@@ -49,6 +49,10 @@ export function buildMagePlayerController(
   }
 
   return {
+    captureFramePreview: vi.fn(
+      async () =>
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+j+7sAAAAASUVORK5CYII=',
+    ),
     clearAudio: vi.fn(() => {
       audioState = {
         currentTime: 0,

--- a/src/modules/scene-editor/CreateScenePage.submission.test.tsx
+++ b/src/modules/scene-editor/CreateScenePage.submission.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import userEvent from '@testing-library/user-event'
 import { buildApiUrl } from '@shared/lib'
 import {
@@ -9,15 +9,49 @@ import {
   storeSceneEditorSession,
 } from './test-fixtures'
 
+const CAPTURED_THUMBNAIL_DATA_URL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+j+7sAAAAASUVORK5CYII='
+const mockCaptureFramePreview = vi.fn(
+  async (): Promise<string | null> => CAPTURED_THUMBNAIL_DATA_URL,
+)
+
 vi.mock('@modules/player', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@modules/player')>()
+  const React = await import('react')
 
   return {
     ...actual,
-    MagePlayer: ({ sceneBlob }: { sceneBlob: unknown }) => (
-      <div data-testid="mage-player">{sceneBlob ? 'preview-ready' : 'no-preview'}</div>
-    ),
+    MagePlayer: ({
+      onCaptureFramePreviewChange,
+      sceneBlob,
+    }: {
+      onCaptureFramePreviewChange?: (
+        captureFramePreview: (() => Promise<string | null>) | null,
+      ) => void
+      sceneBlob: unknown
+    }) => {
+      React.useEffect(() => {
+        onCaptureFramePreviewChange?.(
+          sceneBlob ? () => mockCaptureFramePreview() : null,
+        )
+
+        return () => {
+          onCaptureFramePreviewChange?.(null)
+        }
+      }, [onCaptureFramePreviewChange, sceneBlob])
+
+      return (
+        <div data-testid="mage-player">
+          {sceneBlob ? 'preview-ready' : 'no-preview'}
+        </div>
+      )
+    },
   }
+})
+
+beforeEach(() => {
+  mockCaptureFramePreview.mockReset()
+  mockCaptureFramePreview.mockResolvedValue(CAPTURED_THUMBNAIL_DATA_URL)
 })
 
 afterEach(() => {
@@ -188,16 +222,26 @@ describe('CreateScenePage submission', () => {
     expect(attachCalls).toEqual([1, 2])
   })
 
-  it('uploads a selected thumbnail before the scene create request is sent', async () => {
+  it('captures a thumbnail automatically from the live preview before the scene create request is sent', async () => {
     storeSceneEditorSession()
 
     const uploadedFiles: File[] = []
-    let presignBody: Record<string, unknown> | null = null
+    let presignBody:
+      | {
+          contentType: string
+          filename: string
+          sizeBytes: number
+        }
+      | null = null
     let createBody: Record<string, unknown> | null = null
 
     mockCreateScenePageFetch((input, init) => {
       if (input === buildApiUrl('/scenes/thumbnail/presign')) {
-        presignBody = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
+        presignBody = JSON.parse(String(init?.body ?? '{}')) as {
+          contentType: string
+          filename: string
+          sizeBytes: number
+        }
         return Promise.resolve(
           new Response(
             JSON.stringify({
@@ -240,27 +284,56 @@ describe('CreateScenePage submission', () => {
     renderCreateScenePage()
 
     await user.type(screen.getByLabelText(/scene name/i), 'Aurora Drift')
-    fireEvent.change(screen.getByLabelText(/upload thumbnail file/i), {
-      target: {
-        files: [new File(['cover'], 'cover.png', { type: 'image/png' })],
-      },
-    })
     await user.click(screen.getByRole('button', { name: /create scene/i }))
 
     await waitFor(() => expect(presignBody).not.toBeNull())
 
-    expect(presignBody).toMatchObject({
-      filename: 'cover.png',
-      contentType: 'image/png',
-      sizeBytes: 5,
-    })
+    const capturedPresignBody = presignBody!
+
+    expect(capturedPresignBody.filename).toBe('scene-preview-thumbnail.png')
+    expect(capturedPresignBody.contentType).toBe('image/png')
+    expect(capturedPresignBody.sizeBytes).toEqual(expect.any(Number))
+    expect(capturedPresignBody.sizeBytes).toBeGreaterThan(0)
     expect(uploadedFiles).toHaveLength(1)
-    expect(uploadedFiles[0].name).toBe('cover.png')
+    expect(uploadedFiles[0].name).toBe('scene-preview-thumbnail.png')
     expect(createBody).toMatchObject({
       name: 'Aurora Drift',
       thumbnailObjectKey: 'scenes/pending/8/thumbnails/abc123.png',
     })
     expect(await screen.findByText('My Scenes')).toBeInTheDocument()
+  })
+
+  it('does not create the scene when automatic thumbnail capture fails during submit', async () => {
+    storeSceneEditorSession()
+
+    let createAttempted = false
+    mockCaptureFramePreview.mockResolvedValueOnce(null)
+
+    mockCreateScenePageFetch((input) => {
+      if (input === buildApiUrl('/scenes')) {
+        createAttempted = true
+        return Promise.resolve(
+          new Response(JSON.stringify({ sceneId: 18 }), {
+            status: 201,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        )
+      }
+    })
+
+    const user = userEvent.setup()
+
+    renderCreateScenePage()
+
+    await user.type(screen.getByLabelText(/scene name/i), 'Aurora Drift')
+    await user.click(screen.getByRole('button', { name: /create scene/i }))
+
+    expect(
+      await screen.findByText(
+        /we couldn't capture the current preview frame\. let the preview finish loading and try again\./i,
+      ),
+    ).toBeInTheDocument()
+    expect(createAttempted).toBe(false)
   })
 
   it('does not create the scene when thumbnail upload preparation fails', async () => {
@@ -300,11 +373,6 @@ describe('CreateScenePage submission', () => {
     renderCreateScenePage()
 
     await user.type(screen.getByLabelText(/scene name/i), 'Aurora Drift')
-    fireEvent.change(screen.getByLabelText(/upload thumbnail file/i), {
-      target: {
-        files: [new File(['cover'], 'cover.png', { type: 'image/png' })],
-      },
-    })
     await user.click(screen.getByRole('button', { name: /create scene/i }))
 
     expect(

--- a/src/modules/scene-editor/CreateScenePage.test.tsx
+++ b/src/modules/scene-editor/CreateScenePage.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import userEvent from '@testing-library/user-event'
 import {
   mockCreateScenePageFetch,
@@ -7,23 +7,51 @@ import {
   storeSceneEditorSession,
 } from './test-fixtures'
 
+const CAPTURED_THUMBNAIL_DATA_URL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+j+7sAAAAASUVORK5CYII='
+const mockCaptureFramePreview = vi.fn(
+  async (): Promise<string | null> => CAPTURED_THUMBNAIL_DATA_URL,
+)
+
 vi.mock('@modules/player', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@modules/player')>()
+  const React = await import('react')
 
   return {
     ...actual,
     MagePlayer: ({
       initialPlayback,
+      onCaptureFramePreviewChange,
       sceneBlob,
     }: {
       initialPlayback?: string
+      onCaptureFramePreviewChange?: (
+        captureFramePreview: (() => Promise<string | null>) | null,
+      ) => void
       sceneBlob: unknown
-    }) => (
-      <div data-playback={initialPlayback} data-testid="mage-player">
-        {sceneBlob ? 'preview-ready' : 'no-preview'}
-      </div>
-    ),
+    }) => {
+      React.useEffect(() => {
+        onCaptureFramePreviewChange?.(
+          sceneBlob ? () => mockCaptureFramePreview() : null,
+        )
+
+        return () => {
+          onCaptureFramePreviewChange?.(null)
+        }
+      }, [onCaptureFramePreviewChange, sceneBlob])
+
+      return (
+        <div data-playback={initialPlayback} data-testid="mage-player">
+          {sceneBlob ? 'preview-ready' : 'no-preview'}
+        </div>
+      )
+    },
   }
+})
+
+beforeEach(() => {
+  mockCaptureFramePreview.mockReset()
+  mockCaptureFramePreview.mockResolvedValue(CAPTURED_THUMBNAIL_DATA_URL)
 })
 
 afterEach(() => {
@@ -60,6 +88,7 @@ describe('CreateScenePage workflow', () => {
   it('renders interactive metadata controls beneath the scene name field', async () => {
     storeSceneEditorSession()
     mockCreateScenePageFetch()
+    const user = userEvent.setup()
 
     renderCreateScenePage()
 
@@ -69,18 +98,20 @@ describe('CreateScenePage workflow', () => {
     fireEvent.change(screen.getByLabelText(/playlists/i), {
       target: { value: 'ambient-atlas' },
     })
-    fireEvent.change(screen.getByLabelText(/upload thumbnail file/i), {
-      target: {
-        files: [new File(['cover'], 'cover.png', { type: 'image/png' })],
-      },
-    })
+    await user.click(
+      screen.getByRole('button', { name: /capture thumbnail/i }),
+    )
 
     expect(screen.getByLabelText(/description/i)).toHaveValue(
       'A soft drifting scene for night scenes.',
     )
     expect(screen.getByLabelText(/playlists/i)).toHaveValue('ambient-atlas')
-    expect(screen.getByText(/selected file:/i)).toBeInTheDocument()
-    expect(screen.getByText(/cover\.png/i)).toBeInTheDocument()
+    expect(
+      screen.getByAltText(/captured thumbnail preview/i),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /capture again/i }),
+    ).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /a\/b testing/i })).not.toBeInTheDocument()
   })
 
@@ -93,7 +124,9 @@ describe('CreateScenePage workflow', () => {
     const nameField = screen.getByLabelText(/scene name/i)
     const descriptionField = screen.getByLabelText(/description/i)
     const playlistsField = screen.getByLabelText(/playlists/i)
-    const thumbnailField = screen.getByLabelText(/upload thumbnail file/i)
+    const thumbnailField = screen.getByRole('button', {
+      name: /capture thumbnail/i,
+    })
     const tagSearchField = await screen.findByLabelText(/select existing tags/i)
 
     expect(screen.getByRole('heading', { name: /^details$/i })).toBeInTheDocument()
@@ -117,6 +150,24 @@ describe('CreateScenePage workflow', () => {
     expect(screen.getByRole('button', { name: /^back$/i })).toBeDisabled()
     expect(screen.getByRole('button', { name: /^next$/i })).toBeEnabled()
     expect(screen.getByRole('button', { name: /create scene/i })).toBeInTheDocument()
+  })
+
+  it('shows a clear thumbnail error when the live preview cannot be captured', async () => {
+    storeSceneEditorSession()
+    mockCreateScenePageFetch()
+    mockCaptureFramePreview.mockResolvedValueOnce(null)
+
+    const user = userEvent.setup()
+
+    renderCreateScenePage()
+
+    await user.click(screen.getByRole('button', { name: /capture thumbnail/i }))
+
+    expect(
+      await screen.findByText(
+        /we couldn't capture the current preview frame\. let the preview finish loading and try again\./i,
+      ),
+    ).toBeInTheDocument()
   })
 
   it('keeps the Motion section focused on the persisted MAGE engine motion controls', async () => {

--- a/src/modules/scene-editor/README.md
+++ b/src/modules/scene-editor/README.md
@@ -21,7 +21,7 @@ Exports:
 - `useSceneEditorPreview.ts`
   Preview scene-data coordination and derived preview selections.
 - `useSceneEditorSubmission.ts`
-  Save/create submission, thumbnail upload, and tag attachment retry behavior.
+  Save/create submission, thumbnail capture persistence, and tag attachment retry behavior.
 - `fixtures.ts`
   Editor defaults, section config, and create-flow fixtures.
 - `types.ts`
@@ -54,8 +54,9 @@ Editor structure:
 
 Request flow:
 
+- live preview capture from the shared `MagePlayer`
 - `POST /api/scenes/thumbnail/presign`
-- direct browser `PUT` to the returned object-storage URL when a thumbnail is selected
+- direct browser `PUT` to the returned object-storage URL when a thumbnail is captured
 - `POST /api/scenes`
 - `POST /api/scenes/:sceneId/tags` for follow-up tag attachment
 
@@ -63,8 +64,10 @@ User-facing behavior:
 
 - uses the shared `MagePlayer` component for inline preview
 - updates the preview from the current in-memory scene blob instead of waiting for persistence
-- validates required fields before upload or create requests
-- uploads thumbnails before scene creation so failed uploads block partial saves
+- captures thumbnails from the current live preview instead of asking for a local file upload
+- validates required fields before scene creation
+- automatically captures a thumbnail during scene creation if the user has not already captured one manually
+- uploads captured thumbnails before scene creation so failed uploads block partial saves
 - retries failed tag attachments through a dedicated pending retry state after scene creation
 
 Current limitations:

--- a/src/modules/scene-editor/SceneEditorShell.tsx
+++ b/src/modules/scene-editor/SceneEditorShell.tsx
@@ -1,4 +1,4 @@
-import type { PropsWithChildren, ReactNode } from "react";
+import { useRef, type PropsWithChildren, type ReactNode } from "react";
 import type { AuthenticatedFetch } from "@auth";
 import { AuthPage, AuthPageHeader } from "@shared/ui";
 import { MagePlayer } from "@modules/player";
@@ -28,7 +28,11 @@ import {
 import { useSceneEditorPreview } from "./useSceneEditorPreview";
 import { useSceneEditorState } from "./useSceneEditorState";
 import { useSceneEditorSubmission } from "./useSceneEditorSubmission";
-import { describePassState } from "./utils";
+import {
+  buildCapturedThumbnailFile,
+  describePassState,
+  validateThumbnailFile,
+} from "./utils";
 
 function formatFixed(value: number, fractionDigits = 2) {
   return value.toFixed(fractionDigits).replace(/0+$/, "").replace(/\.$/, "");
@@ -198,9 +202,7 @@ export function SceneEditorShell({
     handleSectionJump,
     handleSectionStep,
     handleTagSearchChange,
-    handleThumbnailFileChange,
-    handleThumbnailModeChange,
-    handleThumbnailUploadClick,
+    handleThumbnailCapture,
     isActionBarStuck,
     isCameraAdvancedEnabled,
     isConfirmJsonOpen,
@@ -238,10 +240,7 @@ export function SceneEditorShell({
     tagsError,
     tagsLoading,
     thumbnailFile,
-    thumbnailFileInputRef,
-    thumbnailFileName,
-    thumbnailInputId,
-    thumbnailMode,
+    thumbnailPreviewUrl,
     titleId,
     toggleTagSelection,
     updateBranch,
@@ -258,6 +257,50 @@ export function SceneEditorShell({
     isMotionAdvancedEnabled,
     sceneData,
   });
+  const captureFramePreviewRef = useRef<(() => Promise<string | null>) | null>(
+    null,
+  );
+
+  async function captureThumbnailFromPreview() {
+    if (!captureFramePreviewRef.current) {
+      throw new Error(
+        "Wait for the live preview to finish loading before capturing a thumbnail.",
+      );
+    }
+
+    const capturedPreviewUrl = await captureFramePreviewRef.current();
+
+    if (!capturedPreviewUrl) {
+      throw new Error(
+        "We couldn't capture the current preview frame. Let the preview finish loading and try again.",
+      );
+    }
+
+    const capturedThumbnailFile = buildCapturedThumbnailFile(capturedPreviewUrl);
+    const thumbnailError = validateThumbnailFile(capturedThumbnailFile);
+
+    if (thumbnailError) {
+      throw new Error(thumbnailError);
+    }
+
+    handleThumbnailCapture(capturedThumbnailFile, capturedPreviewUrl);
+    return capturedThumbnailFile;
+  }
+
+  async function handleThumbnailCaptureRequest() {
+    try {
+      await captureThumbnailFromPreview();
+    } catch (error) {
+      setErrors((currentErrors) => ({
+        ...currentErrors,
+        form: undefined,
+        thumbnail:
+          error instanceof Error && error.message.trim()
+            ? error.message
+            : "The live preview could not be captured right now. Please try again.",
+      }));
+    }
+  }
 
   function renderAdditionalPassCard(passConfig: {
     description: string;
@@ -492,57 +535,50 @@ export function SceneEditorShell({
   function renderThumbnailField() {
     return (
       <div className="field-group">
-        <FieldGroupLabel htmlFor={thumbnailInputId} label="Thumbnail" />
+        <FieldGroupLabel label="Thumbnail" />
         <div className="scene-thumbnail-picker">
-          <input
-            accept="image/jpeg,image/png,image/webp,image/gif"
-            aria-label="Upload thumbnail file"
-            className="scene-thumbnail-input"
-            id={thumbnailInputId}
-            onChange={(event) =>
-              handleThumbnailFileChange(event.currentTarget.files)
-            }
-            ref={thumbnailFileInputRef}
-            type="file"
-          />
+          <div className="scene-thumbnail-picker__row">
+            <div className="scene-thumbnail-picker__grid">
+              <button
+                className={`scene-thumbnail-choice${
+                  thumbnailPreviewUrl ? " is-selected" : ""
+                }`}
+                disabled={isSubmitting}
+                onClick={() => {
+                  void handleThumbnailCaptureRequest();
+                }}
+                type="button"
+              >
+                <span className="scene-thumbnail-choice__eyebrow">
+                  {thumbnailPreviewUrl ? "Recapture" : "Live Preview"}
+                </span>
+                <strong className="scene-thumbnail-choice__title">
+                  {thumbnailPreviewUrl ? "Capture Again" : "Capture Thumbnail"}
+                </strong>
+                <span className="scene-thumbnail-choice__description">
+                  Use the current live preview frame as the scene thumbnail.
+                </span>
+              </button>
+            </div>
 
-          <div className="scene-thumbnail-picker__grid">
-            <button
-              className={`scene-thumbnail-choice${
-                thumbnailMode === "upload" ? " is-selected" : ""
-              }`}
-              onClick={handleThumbnailUploadClick}
-              type="button"
-            >
-              <span className="scene-thumbnail-choice__eyebrow">Upload</span>
-              <strong className="scene-thumbnail-choice__title">Upload File</strong>
-              <span className="scene-thumbnail-choice__description">
-                Use a custom image.
-              </span>
-            </button>
-
-            <button
-              className={`scene-thumbnail-choice${
-                thumbnailMode === "skip" ? " is-selected" : ""
-              }`}
-              onClick={() => handleThumbnailModeChange("skip")}
-              type="button"
-            >
-              <span className="scene-thumbnail-choice__eyebrow">Optional</span>
-              <strong className="scene-thumbnail-choice__title">
-                Skip for Now
-              </strong>
-              <span className="scene-thumbnail-choice__description">
-                Create the scene without a thumbnail.
-              </span>
-            </button>
+            <div className="scene-thumbnail-preview">
+              <div className="scene-thumbnail-preview__frame">
+                {thumbnailPreviewUrl ? (
+                  <img
+                    alt="Captured thumbnail preview"
+                    className="scene-thumbnail-preview__image"
+                    src={thumbnailPreviewUrl}
+                  />
+                ) : (
+                  <div
+                    aria-hidden="true"
+                    className="scene-card__thumbnail-placeholder scene-thumbnail-preview__placeholder"
+                  />
+                )}
+              </div>
+            </div>
           </div>
 
-          {thumbnailFileName ? (
-            <p className="field-hint">
-              Selected file: <strong>{thumbnailFileName}</strong>
-            </p>
-          ) : null}
           {errors.thumbnail ? (
             <p className="field-error" role="alert">
               {errors.thumbnail}
@@ -791,6 +827,7 @@ export function SceneEditorShell({
   const { handleSubmit } = useSceneEditorSubmission({
     authenticatedFetch,
     availableTags,
+    captureThumbnailIfMissing: captureThumbnailFromPreview,
     isCameraAdvancedEnabled,
     isMotionAdvancedEnabled,
     name,
@@ -803,7 +840,6 @@ export function SceneEditorShell({
     setIsSubmitting,
     setPendingTagAttachment,
     thumbnailFile,
-    thumbnailMode,
   });
 
   return (
@@ -1745,9 +1781,9 @@ export function SceneEditorShell({
                       <ConfirmSummaryItem
                         label="Thumbnail"
                         value={
-                          thumbnailMode === "upload"
-                            ? thumbnailFileName || "Upload selected"
-                            : "Skipped"
+                          thumbnailPreviewUrl
+                            ? "Captured from live preview"
+                            : "Not captured yet"
                         }
                       />
                       <ConfirmSummaryItem
@@ -1892,6 +1928,9 @@ export function SceneEditorShell({
               <MagePlayer
                 className="scene-editor-preview__player"
                 initialPlayback="playing"
+                onCaptureFramePreviewChange={(nextCapture) => {
+                  captureFramePreviewRef.current = nextCapture;
+                }}
                 sceneBlob={previewSceneData}
               />
             </section>

--- a/src/modules/scene-editor/test-fixtures.tsx
+++ b/src/modules/scene-editor/test-fixtures.tsx
@@ -50,6 +50,9 @@ export function mockCreateScenePageFetch(
   tagsResponse: unknown[] = buildSceneEditorTags(),
   storedUser: AuthenticatedUser = buildSceneEditorStoredUser(),
 ) {
+  const defaultThumbnailUploadUrl =
+    'https://upload.example.com/scenes/pending/default/thumbnails/scene-preview-thumbnail.png'
+
   return vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
     const method =
       typeof init?.method === 'string' ? init.method.toUpperCase() : 'GET'
@@ -66,6 +69,24 @@ export function mockCreateScenePageFetch(
 
     if (input === buildApiUrl('/tags') && method === 'GET') {
       return Promise.resolve(jsonResponse(tagsResponse))
+    }
+
+    if (input === buildApiUrl('/scenes/thumbnail/presign') && method === 'POST') {
+      return Promise.resolve(
+        jsonResponse({
+          headers: {
+            'Content-Type': 'image/png',
+          },
+          method: 'PUT',
+          objectKey:
+            'scenes/pending/default/thumbnails/scene-preview-thumbnail.png',
+          uploadUrl: defaultThumbnailUploadUrl,
+        }),
+      )
+    }
+
+    if (input === defaultThumbnailUploadUrl && method === 'PUT') {
+      return Promise.resolve(new Response(null, { status: 200 }))
     }
 
     throw new Error(`Unexpected request: ${String(input)}`)

--- a/src/modules/scene-editor/types.ts
+++ b/src/modules/scene-editor/types.ts
@@ -15,8 +15,6 @@ export type EditorSectionId =
 
 export type EffectCategoryId = 'color' | 'finish' | 'pattern' | 'trail'
 
-export type ThumbnailMode = 'skip' | 'upload'
-
 export type PendingTagAttachment = {
   sceneId: number
   tagIds: number[]
@@ -49,7 +47,6 @@ export type SceneEditorStateSnapshot = {
   sceneDataText: string
   selectedTagIds: number[]
   thumbnailFile: File | null
-  thumbnailMode: ThumbnailMode
 }
 
 export type SceneEditorStateBranchUpdater = <K extends keyof SceneEditorModel>(

--- a/src/modules/scene-editor/useSceneEditorState.ts
+++ b/src/modules/scene-editor/useSceneEditorState.ts
@@ -11,7 +11,7 @@ import {
 } from './sceneEditor'
 import { parseApiError } from '@shared/lib'
 import { EDITOR_SECTIONS, MAX_TAG_NAME_LENGTH, initialSceneData, initialSceneModel } from './fixtures'
-import type { CreateSceneFormErrors, EditorSectionId, PendingTagAttachment, ThumbnailMode } from './types'
+import type { CreateSceneFormErrors, EditorSectionId, PendingTagAttachment } from './types'
 import {
   buildEffectiveSceneData,
   loadAvailableTagsFromBackend,
@@ -35,9 +35,10 @@ export function useSceneEditorState({
     useState<EditorSectionId>('details')
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
-  const [thumbnailMode, setThumbnailMode] = useState<ThumbnailMode>('skip')
   const [thumbnailFile, setThumbnailFile] = useState<File | null>(null)
-  const [thumbnailFileName, setThumbnailFileName] = useState('')
+  const [thumbnailPreviewUrl, setThumbnailPreviewUrl] = useState<string | null>(
+    null,
+  )
   const [playlistValue, setPlaylistValue] = useState('')
   const [availableTags, setAvailableTags] = useState<TagResponse[]>([])
   const [selectedTagIds, setSelectedTagIds] = useState<number[]>([])
@@ -66,12 +67,10 @@ export function useSceneEditorState({
   const [isCreatingTag, setIsCreatingTag] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const tagDropdownRef = useRef<HTMLDivElement | null>(null)
-  const thumbnailFileInputRef = useRef<HTMLInputElement | null>(null)
   const actionBarSentinelRef = useRef<HTMLDivElement | null>(null)
 
   const formErrorId = useId()
   const tagSearchInputId = useId()
-  const thumbnailInputId = useId()
   const titleId = 'create-scene-title'
 
   const normalizedTagSearchValue = normalizeTagName(tagSearchValue)
@@ -124,7 +123,7 @@ export function useSceneEditorState({
       : null
   const detailsSectionIssueMessages = [
     validateSceneName(name),
-    thumbnailMode === 'upload' ? validateThumbnailFile(thumbnailFile) : null,
+    thumbnailFile ? validateThumbnailFile(thumbnailFile) : null,
   ].filter((message): message is string => Boolean(message))
   const confirmSectionIssueMessage = validateSceneDataText(sceneDataText).error
   const sectionIssuesById: Partial<Record<EditorSectionId, string | null>> = {
@@ -239,14 +238,6 @@ export function useSceneEditorState({
     })
   }
 
-  function clearThumbnailSelection() {
-    setThumbnailFile(null)
-    setThumbnailFileName('')
-    if (thumbnailFileInputRef.current) {
-      thumbnailFileInputRef.current.value = ''
-    }
-  }
-
   function applySceneData(nextSceneData: SceneData) {
     const sanitizedSceneData = buildEffectiveSceneData(nextSceneData, {
       isCameraAdvancedEnabled,
@@ -310,39 +301,9 @@ export function useSceneEditorState({
     clearErrors('name', 'form')
   }
 
-  function handleThumbnailModeChange(nextValue: ThumbnailMode) {
-    setThumbnailMode(nextValue)
-    if (nextValue === 'skip') {
-      clearThumbnailSelection()
-    }
-    setErrors((currentErrors) => ({
-      ...currentErrors,
-      thumbnail: undefined,
-      form: undefined,
-    }))
-  }
-
-  function handleThumbnailUploadClick() {
-    setThumbnailMode('upload')
-    thumbnailFileInputRef.current?.click()
-  }
-
-  function handleThumbnailFileChange(fileList: FileList | File[] | null) {
-    let nextFile: File | null = null
-
-    if (Array.isArray(fileList)) {
-      nextFile = fileList[0] ?? null
-    } else {
-      nextFile = fileList?.item(0) ?? null
-    }
-
-    if (!nextFile) {
-      return
-    }
-
-    setThumbnailMode('upload')
+  function handleThumbnailCapture(nextFile: File, previewUrl: string) {
     setThumbnailFile(nextFile)
-    setThumbnailFileName(nextFile.name)
+    setThumbnailPreviewUrl(previewUrl)
     setErrors((currentErrors) => ({
       ...currentErrors,
       thumbnail: undefined,
@@ -611,9 +572,7 @@ export function useSceneEditorState({
     handleSectionJump,
     handleSectionStep,
     handleTagSearchChange,
-    handleThumbnailFileChange,
-    handleThumbnailModeChange,
-    handleThumbnailUploadClick,
+    handleThumbnailCapture,
     isActionBarStuck,
     isCameraAdvancedEnabled,
     isConfirmJsonOpen,
@@ -651,10 +610,7 @@ export function useSceneEditorState({
     tagsError,
     tagsLoading,
     thumbnailFile,
-    thumbnailFileInputRef,
-    thumbnailFileName,
-    thumbnailInputId,
-    thumbnailMode,
+    thumbnailPreviewUrl,
     titleId,
     toggleTagSelection,
     updateBranch,

--- a/src/modules/scene-editor/useSceneEditorSubmission.ts
+++ b/src/modules/scene-editor/useSceneEditorSubmission.ts
@@ -12,6 +12,7 @@ import { buildEffectiveSceneData, parseCreatedSceneId, validateForm } from './ut
 
 type UseSceneEditorSubmissionArgs = SceneEditorStateSnapshot & {
   authenticatedFetch: AuthenticatedFetch
+  captureThumbnailIfMissing: () => Promise<File>
   onComplete: () => void
   setErrors: Dispatch<SetStateAction<CreateSceneFormErrors>>
   setIsSubmitting: Dispatch<SetStateAction<boolean>>
@@ -77,6 +78,7 @@ async function attachTagsToScene(
 export function useSceneEditorSubmission({
   authenticatedFetch,
   availableTags,
+  captureThumbnailIfMissing,
   isCameraAdvancedEnabled,
   isMotionAdvancedEnabled,
   name,
@@ -89,7 +91,6 @@ export function useSceneEditorSubmission({
   setIsSubmitting,
   setPendingTagAttachment,
   thumbnailFile,
-  thumbnailMode,
 }: UseSceneEditorSubmissionArgs) {
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -134,13 +135,25 @@ export function useSceneEditorSubmission({
       sceneDataText,
     )
 
-    if (thumbnailMode === 'upload' && !thumbnailFile) {
-      nextErrors.thumbnail = 'Choose an image file or skip the thumbnail.'
-    }
-
     if (Object.keys(nextErrors).length > 0) {
       setErrors(nextErrors)
       return
+    }
+
+    let effectiveThumbnailFile = thumbnailFile
+
+    if (!effectiveThumbnailFile) {
+      try {
+        effectiveThumbnailFile = await captureThumbnailIfMissing()
+      } catch (error) {
+        setErrors({
+          thumbnail:
+            error instanceof Error && error.message.trim()
+              ? error.message
+              : 'Capture a thumbnail before creating the scene.',
+        })
+        return
+      }
     }
 
     const sanitizedSceneData = buildEffectiveSceneData(
@@ -156,8 +169,8 @@ export function useSceneEditorSubmission({
 
     try {
       const thumbnailObjectKey =
-        thumbnailMode === 'upload' && thumbnailFile
-          ? await uploadNewSceneThumbnail(authenticatedFetch, thumbnailFile)
+        effectiveThumbnailFile
+          ? await uploadNewSceneThumbnail(authenticatedFetch, effectiveThumbnailFile)
           : undefined
 
       const response = await authenticatedFetch('/scenes', {

--- a/src/modules/scene-editor/utils.ts
+++ b/src/modules/scene-editor/utils.ts
@@ -148,7 +148,7 @@ export function validateForm(name: string, sceneDataText: string) {
 
 export function validateThumbnailFile(file: File | null) {
   if (!file) {
-    return 'Choose an image file or skip the thumbnail.'
+    return 'Capture a thumbnail before creating the scene.'
   }
 
   if (!ALLOWED_THUMBNAIL_CONTENT_TYPES.has(file.type)) {
@@ -160,6 +160,34 @@ export function validateThumbnailFile(file: File | null) {
   }
 
   return null
+}
+
+export function buildCapturedThumbnailFile(dataUrl: string) {
+  const matchedDataUrl = dataUrl.match(/^data:([^;,]+)?(;base64)?,(.*)$/)
+
+  if (!matchedDataUrl) {
+    throw new Error('Preview capture returned an unexpected image format.')
+  }
+
+  const [, rawContentType, base64Marker, encodedPayload] = matchedDataUrl
+  const contentType = rawContentType?.trim() || 'image/png'
+  const decodedPayload = base64Marker
+    ? window.atob(encodedPayload)
+    : decodeURIComponent(encodedPayload)
+  const payloadBytes = Uint8Array.from(decodedPayload, (character) =>
+    character.charCodeAt(0),
+  )
+
+  const extension =
+    contentType === 'image/jpeg'
+      ? 'jpg'
+      : contentType === 'image/webp'
+        ? 'webp'
+        : 'png'
+
+  return new File([payloadBytes], `scene-preview-thumbnail.${extension}`, {
+    type: contentType,
+  })
 }
 
 export function buildEffectiveSceneData(


### PR DESCRIPTION
## Summary

Closes #108.

This PR replaces manual thumbnail upload in the scene editor with live-preview capture. The create-scene flow now captures thumbnails from the current `MagePlayer` preview, shows that captured image in the editor, and automatically captures a thumbnail during submit if the user has not already done so manually.

## What Changed

- added a preview-frame capture seam to `MagePlayer`
- exposed engine-level frame capture through the player adapter
- added player test coverage for the published capture callback
- replaced scene-editor thumbnail file upload with a capture-from-preview flow
- updated the thumbnail UI to:
  - show a live-preview capture action
  - show the current thumbnail preview inline
  - reuse the existing no-thumbnail placeholder before capture
  - use the existing thumbnail hover treatment
- removed the old upload/skip thumbnail state and simplified the editor state model
- added submit-time fallback capture so scene creation automatically captures a thumbnail if one is still missing
- kept the existing presign + direct-upload backend contract for thumbnail persistence
- updated create-scene tests for:
  - manual preview capture
  - automatic capture on submit
  - capture failure handling
  - thumbnail upload failure handling
- updated scene-editor and deployment docs to describe the capture-based flow

## Notes

- thumbnail capture is driven from the current live `MagePlayer` preview rather than local file selection
- submit now validates the normal form fields first, then captures a thumbnail if needed, then uploads it before creating the scene
- failed thumbnail capture or thumbnail upload blocks scene creation, so the flow does not create scenes without thumbnails

## Testing

- `npm test -- --run src/modules/player/MagePlayer.test.tsx`
- `npm run lint`
- `npx tsc -b`
- `npm test`
