### PR TITLE
100 display scene descriptions

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1253,33 +1253,6 @@
   transform: rotate(180deg);
 }
 
-.scene-detail-note-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-  margin-top: 18px;
-}
-
-.scene-detail-note-grid__item {
-  display: grid;
-  gap: 6px;
-  padding: 14px;
-  border-radius: 16px;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-}
-
-.scene-detail-note-grid__item span {
-  color: var(--muted);
-  font-size: 0.82rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-}
-
-.scene-detail-note-grid__item strong {
-  line-height: 1.55;
-}
-
 .mage-tag-row {
   display: flex;
   flex-wrap: wrap;
@@ -1349,6 +1322,11 @@
   display: grid;
   gap: 14px;
   margin-top: 16px;
+}
+
+.scene-detail-comments-empty {
+  margin: 16px 0 0;
+  color: var(--muted);
 }
 
 .mage-comment {
@@ -3511,10 +3489,6 @@
   .scene-detail-comments-panel {
     padding: 16px;
     border-radius: 18px;
-  }
-
-  .scene-detail-note-grid {
-    grid-template-columns: 1fr;
   }
 
   .mage-watch__rail-list {

--- a/src/modules/my-scenes/MyScenesPage.test.tsx
+++ b/src/modules/my-scenes/MyScenesPage.test.tsx
@@ -121,6 +121,7 @@ describe('MyScenesPage states', () => {
 
     expect(await screen.findByTestId('mage-player')).toHaveTextContent('player-ready')
     expect(screen.getByRole('heading', { name: /aurora drift/i })).toBeInTheDocument()
+    expect(screen.getByText('Soft teal bloom with low-end drift.')).toBeInTheDocument()
   })
 
   it('shows empty and error states using simple messages', async () => {

--- a/src/modules/my-scenes/MyScenesPage.test.tsx
+++ b/src/modules/my-scenes/MyScenesPage.test.tsx
@@ -155,7 +155,7 @@ describe('MyScenesPage states', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(2)
   })
 
-  it('shows a description placeholder when no description is stored', async () => {
+  it('shows an add-description action when no description is stored', async () => {
     storeMyScenesSession()
 
     const storedUser = buildMyScenesStoredUser()

--- a/src/modules/scene-detail/README.md
+++ b/src/modules/scene-detail/README.md
@@ -23,7 +23,7 @@ Exports:
 - `recommendations.ts`
   Recommendation grouping, filter helpers, and selection logic for the sidebar rail.
 - `fixtures.ts`
-  Placeholder/sample content builders for description and comments so lorem ipsum content stays out of production transforms.
+  Placeholder/sample content builders for comments and fallback description copy so lorem ipsum content stays out of production transforms.
 - `ui/`
   Scene-detail-owned presentation for description, comments, voting, recommendations, and playlist sidebar behavior.
 
@@ -31,7 +31,7 @@ Exports:
 
 1. Route wiring should import `SceneDetailPage` from `@modules/scene-detail`.
 2. Feature code outside this module should not import `ui/*`, `loaders.ts`, or internal builders directly.
-3. Placeholder comments, creator notes, and description copy stay in `fixtures.ts`, not in DTO or loader code.
+3. Placeholder comments, creator notes, and fallback description copy stay in `fixtures.ts`, not in DTO or loader code.
 4. Recommendation filtering, description rendering, comments, and playlist-sidebar state stay owned by this module.
 
 ## Route Surface
@@ -60,7 +60,7 @@ User-facing behavior:
 
 Current limitations:
 
-- comments, creator notes, and parts of the description experience still rely on module fixtures
+- comments, creator notes, and fallback description copy still rely on module fixtures
 - vote, share, save, and follow controls are currently presentation-only
 - recommendation ranking is heuristic and frontend-owned
 

--- a/src/modules/scene-detail/README.md
+++ b/src/modules/scene-detail/README.md
@@ -19,11 +19,11 @@ Exports:
 - `dto.ts`
   Backend payload normalization for scene detail and recommendation list responses.
 - `viewModels.ts`
-  Production-facing scene detail view-model builders derived from fetched scene data.
+  Production-facing scene detail view-model builders, including stored and fallback description presentation.
 - `recommendations.ts`
   Recommendation grouping, filter helpers, and selection logic for the sidebar rail.
 - `fixtures.ts`
-  Placeholder/sample content builders for comments and fallback description copy so lorem ipsum content stays out of production transforms.
+  Placeholder/sample content builders for comments and fallback description paragraph copy.
 - `ui/`
   Scene-detail-owned presentation for description, comments, voting, recommendations, and playlist sidebar behavior.
 

--- a/src/modules/scene-detail/README.md
+++ b/src/modules/scene-detail/README.md
@@ -19,11 +19,11 @@ Exports:
 - `dto.ts`
   Backend payload normalization for scene detail and recommendation list responses.
 - `viewModels.ts`
-  Production-facing scene detail view-model builders, including stored and fallback description presentation.
+  Production-facing scene detail view-model builders derived from fetched scene data.
 - `recommendations.ts`
   Recommendation grouping, filter helpers, and selection logic for the sidebar rail.
 - `fixtures.ts`
-  Placeholder/sample content builders for comments and fallback description paragraph copy.
+  Temporary deterministic creator metadata used until the backend exposes those fields.
 - `ui/`
   Scene-detail-owned presentation for description, comments, voting, recommendations, and playlist sidebar behavior.
 
@@ -31,7 +31,7 @@ Exports:
 
 1. Route wiring should import `SceneDetailPage` from `@modules/scene-detail`.
 2. Feature code outside this module should not import `ui/*`, `loaders.ts`, or internal builders directly.
-3. Placeholder comments, creator notes, and fallback description copy stay in `fixtures.ts`, not in DTO or loader code.
+3. Missing backend fields should render clear empty states, not generated prose.
 4. Recommendation filtering, description rendering, comments, and playlist-sidebar state stay owned by this module.
 
 ## Route Surface
@@ -60,7 +60,7 @@ User-facing behavior:
 
 Current limitations:
 
-- comments, creator notes, and fallback description copy still rely on module fixtures
+- creator subscriber labels are still frontend-derived until the backend exposes them
 - vote, share, save, and follow controls are currently presentation-only
 - recommendation ranking is heuristic and frontend-owned
 

--- a/src/modules/scene-detail/SceneDetailPage.test.tsx
+++ b/src/modules/scene-detail/SceneDetailPage.test.tsx
@@ -158,6 +158,30 @@ describe('SceneDetailPage route states', () => {
     expect(screen.queryByRole('button', { name: /^show$/i })).not.toBeInTheDocument()
   })
 
+  it('does not show the description toggle when a short description has no hidden content', async () => {
+    const sceneResponse = buildSceneDetailResponse({
+      description: 'Short saved description.',
+      tags: [],
+    })
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      if (input === buildApiUrl('/scenes/12')) {
+        return Promise.resolve(jsonResponse(sceneResponse))
+      }
+
+      if (input === buildApiUrl('/scenes')) {
+        return Promise.resolve(jsonResponse([sceneResponse]))
+      }
+
+      throw new Error(`Unexpected request: ${String(input)}`)
+    })
+
+    renderSceneDetailPage()
+
+    expect(await screen.findByText('Short saved description.')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^show$/i })).not.toBeInTheDocument()
+  })
+
   it('preserves saved description line breaks on the player page', async () => {
     const sceneResponse = buildSceneDetailResponse({
       description: 'First line\nSecond line\n\nSecond paragraph',
@@ -186,6 +210,7 @@ describe('SceneDetailPage route states', () => {
     expect(descriptionParagraphs[0]?.textContent).toBe('First lineSecond line')
     expect(descriptionParagraphs[0]?.querySelectorAll('br')).toHaveLength(1)
     expect(descriptionParagraphs[1]?.textContent).toBe('Second paragraph')
+    expect(screen.getByRole('button', { name: /^show$/i })).toBeInTheDocument()
   })
 
   it('shows a clear error state for an invalid scene route id', async () => {

--- a/src/modules/scene-detail/SceneDetailPage.test.tsx
+++ b/src/modules/scene-detail/SceneDetailPage.test.tsx
@@ -158,6 +158,36 @@ describe('SceneDetailPage route states', () => {
     expect(screen.queryByRole('button', { name: /^show$/i })).not.toBeInTheDocument()
   })
 
+  it('preserves saved description line breaks on the player page', async () => {
+    const sceneResponse = buildSceneDetailResponse({
+      description: 'First line\nSecond line\n\nSecond paragraph',
+      tags: [],
+    })
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      if (input === buildApiUrl('/scenes/12')) {
+        return Promise.resolve(jsonResponse(sceneResponse))
+      }
+
+      if (input === buildApiUrl('/scenes')) {
+        return Promise.resolve(jsonResponse([sceneResponse]))
+      }
+
+      throw new Error(`Unexpected request: ${String(input)}`)
+    })
+
+    renderSceneDetailPage()
+
+    expect(await screen.findByRole('heading', { name: /aurora drift/i })).toBeInTheDocument()
+
+    const descriptionParagraphs = document.querySelectorAll('.scene-detail-description-copy p')
+
+    expect(descriptionParagraphs).toHaveLength(2)
+    expect(descriptionParagraphs[0]?.textContent).toBe('First lineSecond line')
+    expect(descriptionParagraphs[0]?.querySelectorAll('br')).toHaveLength(1)
+    expect(descriptionParagraphs[1]?.textContent).toBe('Second paragraph')
+  })
+
   it('shows a clear error state for an invalid scene route id', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch')
 

--- a/src/modules/scene-detail/SceneDetailPage.test.tsx
+++ b/src/modules/scene-detail/SceneDetailPage.test.tsx
@@ -104,6 +104,7 @@ describe('SceneDetailPage route states', () => {
     expect(screen.getByRole('heading', { name: /comments/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /upvote 416/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /^show$/i })).toBeInTheDocument()
+    expect(screen.getByText('Soft teal bloom with low-end drift.')).toBeInTheDocument()
     expect(screen.getAllByRole('button', { name: /downvote/i }).length).toBeGreaterThan(0)
     expect(screen.getByText(/add a comment as scene artist/i)).toBeInTheDocument()
     expect(screen.getAllByText('Scene Artist').length).toBeGreaterThan(0)

--- a/src/modules/scene-detail/SceneDetailPage.test.tsx
+++ b/src/modules/scene-detail/SceneDetailPage.test.tsx
@@ -133,6 +133,31 @@ describe('SceneDetailPage route states', () => {
     expect(sceneRequestHeaders.get('Authorization')).toBe('Bearer stored-auth-token')
   })
 
+  it('shows an empty description state when no description is stored', async () => {
+    const sceneResponse = buildSceneDetailResponse({
+      description: null,
+      tags: [],
+    })
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      if (input === buildApiUrl('/scenes/12')) {
+        return Promise.resolve(jsonResponse(sceneResponse))
+      }
+
+      if (input === buildApiUrl('/scenes')) {
+        return Promise.resolve(jsonResponse([sceneResponse]))
+      }
+
+      throw new Error(`Unexpected request: ${String(input)}`)
+    })
+
+    renderSceneDetailPage()
+
+    expect(await screen.findByText('No description provided.')).toBeInTheDocument()
+    expect(screen.queryByText(/lorem ipsum/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^show$/i })).not.toBeInTheDocument()
+  })
+
   it('shows a clear error state for an invalid scene route id', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch')
 

--- a/src/modules/scene-detail/SceneDetailPage.tsx
+++ b/src/modules/scene-detail/SceneDetailPage.tsx
@@ -2,14 +2,14 @@ import { useEffect, useState, type CSSProperties } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { useAuth } from '@auth'
 import { MagePlayer } from '@modules/player'
-import { buildSceneComments, buildSceneDescription } from './fixtures'
+import { buildSceneComments } from './fixtures'
 import { fetchRecommendedSceneGroups, fetchSceneDetail, SceneDetailRequestError } from './loaders'
 import { createEmptyRecommendedSceneGroups, selectRecommendedScenes } from './recommendations'
 import { readErrorCopy, readInitial, readSceneId } from './selectors'
 import type { RecommendationFilter, RecommendedSceneGroups, SceneDetail, SceneDetailErrorCode } from './types'
 import { SceneCommentsPanel, SceneDescriptionCard, SceneDetailState, SceneRecommendationRail, VoteButton } from './ui'
 import { useScenePlaylistState } from './useScenePlaylistState'
-import { buildCreatorProfile, buildSceneEngagement } from './viewModels'
+import { buildCreatorProfile, buildSceneDescription, buildSceneEngagement } from './viewModels'
 
 export function SceneDetailPage() {
   const { id } = useParams<{ id: string }>()

--- a/src/modules/scene-detail/SceneDetailPage.tsx
+++ b/src/modules/scene-detail/SceneDetailPage.tsx
@@ -201,8 +201,8 @@ export function SceneDetailPage() {
 
   const creatorProfile = buildCreatorProfile(scene, user?.displayName, user?.userId)
   const engagement = buildSceneEngagement(scene)
-  const sceneDescription = buildSceneDescription(scene, creatorProfile)
-  const sceneComments = buildSceneComments(scene)
+  const sceneDescription = buildSceneDescription(scene)
+  const sceneComments = buildSceneComments()
   const filteredRecommendedScenes = selectRecommendedScenes(
     recommendedSceneGroups,
     recommendationFilter,
@@ -284,7 +284,6 @@ export function SceneDetailPage() {
           </section>
 
           <SceneDescriptionCard
-            creatorProfile={creatorProfile}
             engagement={engagement}
             isDescriptionExpanded={isDescriptionExpanded}
             sceneDescription={sceneDescription}

--- a/src/modules/scene-detail/dto.ts
+++ b/src/modules/scene-detail/dto.ts
@@ -7,6 +7,7 @@ type SceneDetailResponse = {
   ownerUserId?: number
   creatorDisplayName?: string
   name?: string
+  description?: string | null
   sceneData?: unknown
   thumbnailRef?: string | null
   createdAt?: string
@@ -66,6 +67,10 @@ export function normalizeSceneDetail(payload: unknown): SceneDetail | null {
       typeof resolvedPayload.name === 'string' && resolvedPayload.name.trim()
         ? resolvedPayload.name.trim()
         : `Scene ${sceneId}`,
+    description:
+      typeof resolvedPayload.description === 'string' && resolvedPayload.description.trim()
+        ? resolvedPayload.description.trim()
+        : null,
     sceneData: resolvedPayload.sceneData,
     thumbnailRef:
       typeof resolvedPayload.thumbnailRef === 'string' && resolvedPayload.thumbnailRef.trim()
@@ -106,6 +111,10 @@ export function normalizeRecommendedSceneList(payload: unknown): SceneListRespon
       ownerUserId: candidate.ownerUserId,
       creatorDisplayName: candidate.creatorDisplayName.trim() || 'Unknown creator',
       name: candidate.name.trim() || `Scene ${candidate.sceneId}`,
+      description:
+        typeof candidate.description === 'string' && candidate.description.trim()
+          ? candidate.description.trim()
+          : null,
       sceneData:
         typeof candidate.sceneData === 'object' && candidate.sceneData !== null ? candidate.sceneData : {},
       thumbnailRef:

--- a/src/modules/scene-detail/fixtures.ts
+++ b/src/modules/scene-detail/fixtures.ts
@@ -1,31 +1,27 @@
-import type { CreatorProfile, SceneComment, SceneDetail } from './types'
+import type { CreatorProfile, SceneComment } from './types'
 
-type CreatorProfileBlueprint = Pick<CreatorProfile, 'displayName' | 'handle' | 'studioNote' | 'subscribersLabel'>
+type CreatorProfileBlueprint = Pick<CreatorProfile, 'displayName' | 'handle' | 'subscribersLabel'>
 
 const creatorProfileBlueprints = [
   {
     displayName: 'Mina Park',
     handle: '@mina.afterlight',
     subscribersLabel: '2.18K subscribers',
-    studioNote: 'I usually tune motion to stay readable for the first minute before the highlights wake up.',
   },
   {
     displayName: 'Jonah Reed',
     handle: '@jonahreedsignal',
     subscribersLabel: '1.42K subscribers',
-    studioNote: 'Most of my scenes start from a music-first pass, then I add texture until the frame feels alive.',
   },
   {
     displayName: 'Talia North',
     handle: '@talianorth',
     subscribersLabel: '3.84K subscribers',
-    studioNote: 'I care more about pacing than density, so the quieter parts of a track still have room to breathe.',
   },
   {
     displayName: 'Elio Mercer',
     handle: '@elio.mercer',
     subscribersLabel: '986 subscribers',
-    studioNote: 'If a scene looks loud with the volume off, I usually strip it back and start over.',
   },
 ] satisfies CreatorProfileBlueprint[]
 
@@ -33,41 +29,6 @@ export function pickCreatorProfileBlueprint(seed: number): CreatorProfileBluepri
   return creatorProfileBlueprints[Math.abs(seed) % creatorProfileBlueprints.length]
 }
 
-export function buildFallbackSceneDescriptionParagraphs(creatorProfile: CreatorProfile) {
-  return [
-    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-    `${creatorProfile.displayName} lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
-    'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
-  ]
-}
-
-export function buildSceneComments(scene: SceneDetail): SceneComment[] {
-  return [
-    {
-      author: 'Nora Vale',
-      handle: '@noravale',
-      posted: '2 days ago',
-      text: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. ${scene.name} sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
-      upvotes: '14',
-      downvotes: '1',
-    },
-    {
-      author: 'Cass Mercer',
-      handle: '@cassmercer',
-      posted: '5 days ago',
-      text:
-        'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
-      upvotes: '9',
-      downvotes: '0',
-    },
-    {
-      author: 'Jun Park',
-      handle: '@junpark',
-      posted: '1 week ago',
-      text:
-        'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
-      upvotes: '6',
-      downvotes: '0',
-    },
-  ]
+export function buildSceneComments(): SceneComment[] {
+  return []
 }

--- a/src/modules/scene-detail/fixtures.ts
+++ b/src/modules/scene-detail/fixtures.ts
@@ -37,13 +37,16 @@ export function buildSceneDescription(
   scene: SceneDetail,
   creatorProfile: CreatorProfile,
 ): SceneDescription {
+  const storedDescription = scene.description?.trim()
+
   return {
-    opening:
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-    middle:
-      `${creatorProfile.displayName} lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
-    closing:
-      'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+    paragraphs: storedDescription
+      ? [storedDescription]
+      : [
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+          `${creatorProfile.displayName} lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
+          'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+        ],
     bestFor: 'lorem ipsum, dolor sit amet, consectetur',
     builtWith: 'adipiscing elit, sed do eiusmod, tempor incididunt',
     tags: scene.tags,

--- a/src/modules/scene-detail/fixtures.ts
+++ b/src/modules/scene-detail/fixtures.ts
@@ -1,4 +1,4 @@
-import type { CreatorProfile, SceneComment, SceneDescription, SceneDetail } from './types'
+import type { CreatorProfile, SceneComment, SceneDetail } from './types'
 
 type CreatorProfileBlueprint = Pick<CreatorProfile, 'displayName' | 'handle' | 'studioNote' | 'subscribersLabel'>
 
@@ -33,24 +33,12 @@ export function pickCreatorProfileBlueprint(seed: number): CreatorProfileBluepri
   return creatorProfileBlueprints[Math.abs(seed) % creatorProfileBlueprints.length]
 }
 
-export function buildSceneDescription(
-  scene: SceneDetail,
-  creatorProfile: CreatorProfile,
-): SceneDescription {
-  const storedDescription = scene.description?.trim()
-
-  return {
-    paragraphs: storedDescription
-      ? [storedDescription]
-      : [
-          'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-          `${creatorProfile.displayName} lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
-          'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
-        ],
-    bestFor: 'lorem ipsum, dolor sit amet, consectetur',
-    builtWith: 'adipiscing elit, sed do eiusmod, tempor incididunt',
-    tags: scene.tags,
-  }
+export function buildFallbackSceneDescriptionParagraphs(creatorProfile: CreatorProfile) {
+  return [
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+    `${creatorProfile.displayName} lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
+    'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+  ]
 }
 
 export function buildSceneComments(scene: SceneDetail): SceneComment[] {

--- a/src/modules/scene-detail/test-fixtures.tsx
+++ b/src/modules/scene-detail/test-fixtures.tsx
@@ -27,6 +27,7 @@ export function buildSceneDetailResponse(
   return {
     createdAt: '2026-04-06T14:00:00Z',
     creatorDisplayName: 'Scene Artist',
+    description: 'Soft teal bloom with low-end drift.',
     name: 'Aurora Drift',
     ownerUserId: 8,
     sceneData: {

--- a/src/modules/scene-detail/types.ts
+++ b/src/modules/scene-detail/types.ts
@@ -7,6 +7,7 @@ export type SceneDetail = {
   ownerUserId: number | null
   creatorDisplayName: string | null
   name: string
+  description: string | null
   sceneData: MageSceneBlob
   thumbnailRef: string | null
   createdAt: string | null
@@ -47,9 +48,7 @@ export type SceneEngagement = {
 }
 
 export type SceneDescription = {
-  opening: string
-  middle: string
-  closing: string
+  paragraphs: string[]
   bestFor: string
   builtWith: string
   tags: string[]

--- a/src/modules/scene-detail/types.ts
+++ b/src/modules/scene-detail/types.ts
@@ -34,7 +34,6 @@ export type CreatorProfile = {
   displayName: string
   handle: string
   subscribersLabel: string
-  studioNote: string
   primaryActionLabel?: string
 }
 
@@ -49,8 +48,6 @@ export type SceneEngagement = {
 
 export type SceneDescription = {
   paragraphs: string[]
-  bestFor: string
-  builtWith: string
   tags: string[]
 }
 

--- a/src/modules/scene-detail/ui/SceneCommentsPanel.tsx
+++ b/src/modules/scene-detail/ui/SceneCommentsPanel.tsx
@@ -34,38 +34,42 @@ export function SceneCommentsPanel({
         </div>
       </div>
 
-      <div className="mage-comments__list">
-        {comments.map((comment) => (
-          <article key={`${comment.author}-${comment.posted}`} className="mage-comment">
-            <div className="mage-comment__avatar" aria-hidden="true">
-              {readInitial(comment.author)}
-            </div>
-            <div className="mage-comment__body">
-              <div className="scene-detail-comment__header">
-                <strong>{comment.author}</strong>
-                <span>{comment.handle}</span>
-                <span>{comment.posted}</span>
+      {comments.length > 0 ? (
+        <div className="mage-comments__list">
+          {comments.map((comment) => (
+            <article key={`${comment.author}-${comment.posted}`} className="mage-comment">
+              <div className="mage-comment__avatar" aria-hidden="true">
+                {readInitial(comment.author)}
               </div>
-              <p>{comment.text}</p>
-              <div className="scene-detail-comment__actions">
-                <VoteButton
-                  className="scene-detail-comment__action"
-                  count={comment.upvotes}
-                  direction="up"
-                />
-                <VoteButton
-                  className="scene-detail-comment__action"
-                  count={comment.downvotes}
-                  direction="down"
-                />
-                <button className="scene-detail-comment__action" type="button">
-                  Reply
-                </button>
+              <div className="mage-comment__body">
+                <div className="scene-detail-comment__header">
+                  <strong>{comment.author}</strong>
+                  <span>{comment.handle}</span>
+                  <span>{comment.posted}</span>
+                </div>
+                <p>{comment.text}</p>
+                <div className="scene-detail-comment__actions">
+                  <VoteButton
+                    className="scene-detail-comment__action"
+                    count={comment.upvotes}
+                    direction="up"
+                  />
+                  <VoteButton
+                    className="scene-detail-comment__action"
+                    count={comment.downvotes}
+                    direction="down"
+                  />
+                  <button className="scene-detail-comment__action" type="button">
+                    Reply
+                  </button>
+                </div>
               </div>
-            </div>
-          </article>
-        ))}
-      </div>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <p className="scene-detail-comments-empty">No comments yet.</p>
+      )}
     </section>
   )
 }

--- a/src/modules/scene-detail/ui/SceneDescriptionCard.tsx
+++ b/src/modules/scene-detail/ui/SceneDescriptionCard.tsx
@@ -26,7 +26,9 @@ export function SceneDescriptionCard({
 }: SceneDescriptionCardProps) {
   const hasDescription = sceneDescription.paragraphs.length > 0
   const hasTags = sceneDescription.tags.length > 0
-  const shouldShowToggle = hasDescription || hasTags
+  const hasHiddenDescriptionParagraphs = sceneDescription.paragraphs.length > 1
+  const shouldShowToggle = hasHiddenDescriptionParagraphs || hasTags
+  const isDescriptionCopyExpanded = shouldShowToggle ? isDescriptionExpanded : true
   const descriptionToggle = (
     <button
       className="scene-detail-description-toggle"
@@ -60,7 +62,7 @@ export function SceneDescriptionCard({
         <strong>{engagement.viewsLabel}</strong>
         <span>{engagement.publishedLabel}</span>
       </div>
-      <div className="scene-detail-description-copy" data-expanded={isDescriptionExpanded}>
+      <div className="scene-detail-description-copy" data-expanded={isDescriptionCopyExpanded}>
         {hasDescription ? (
           sceneDescription.paragraphs.map((paragraph, index) => (
             <p key={`${index}-${paragraph}`}>{renderParagraphWithLineBreaks(paragraph)}</p>

--- a/src/modules/scene-detail/ui/SceneDescriptionCard.tsx
+++ b/src/modules/scene-detail/ui/SceneDescriptionCard.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'react'
 import { Link } from 'react-router-dom'
 import type { SceneDescription, SceneEngagement } from '../types'
 
@@ -6,6 +7,15 @@ type SceneDescriptionCardProps = {
   isDescriptionExpanded: boolean
   sceneDescription: SceneDescription
   onToggleDescription: () => void
+}
+
+function renderParagraphWithLineBreaks(paragraph: string) {
+  return paragraph.split('\n').map((line, index) => (
+    <Fragment key={`${index}-${line}`}>
+      {index > 0 ? <br /> : null}
+      {line}
+    </Fragment>
+  ))
 }
 
 export function SceneDescriptionCard({
@@ -53,7 +63,7 @@ export function SceneDescriptionCard({
       <div className="scene-detail-description-copy" data-expanded={isDescriptionExpanded}>
         {hasDescription ? (
           sceneDescription.paragraphs.map((paragraph, index) => (
-            <p key={`${index}-${paragraph}`}>{paragraph}</p>
+            <p key={`${index}-${paragraph}`}>{renderParagraphWithLineBreaks(paragraph)}</p>
           ))
         ) : (
           <p>No description provided.</p>

--- a/src/modules/scene-detail/ui/SceneDescriptionCard.tsx
+++ b/src/modules/scene-detail/ui/SceneDescriptionCard.tsx
@@ -50,9 +50,9 @@ export function SceneDescriptionCard({
         <span>{engagement.publishedLabel}</span>
       </div>
       <div className="scene-detail-description-copy" data-expanded={isDescriptionExpanded}>
-        <p>{sceneDescription.opening}</p>
-        <p>{sceneDescription.middle}</p>
-        <p>{sceneDescription.closing}</p>
+        {sceneDescription.paragraphs.map((paragraph, index) => (
+          <p key={`${index}-${paragraph}`}>{paragraph}</p>
+        ))}
       </div>
 
       {isDescriptionExpanded ? (

--- a/src/modules/scene-detail/ui/SceneDescriptionCard.tsx
+++ b/src/modules/scene-detail/ui/SceneDescriptionCard.tsx
@@ -1,8 +1,7 @@
 import { Link } from 'react-router-dom'
-import type { CreatorProfile, SceneDescription, SceneEngagement } from '../types'
+import type { SceneDescription, SceneEngagement } from '../types'
 
 type SceneDescriptionCardProps = {
-  creatorProfile: CreatorProfile
   engagement: SceneEngagement
   isDescriptionExpanded: boolean
   sceneDescription: SceneDescription
@@ -10,12 +9,14 @@ type SceneDescriptionCardProps = {
 }
 
 export function SceneDescriptionCard({
-  creatorProfile,
   engagement,
   isDescriptionExpanded,
   sceneDescription,
   onToggleDescription,
 }: SceneDescriptionCardProps) {
+  const hasDescription = sceneDescription.paragraphs.length > 0
+  const hasTags = sceneDescription.tags.length > 0
+  const shouldShowToggle = hasDescription || hasTags
   const descriptionToggle = (
     <button
       className="scene-detail-description-toggle"
@@ -50,33 +51,18 @@ export function SceneDescriptionCard({
         <span>{engagement.publishedLabel}</span>
       </div>
       <div className="scene-detail-description-copy" data-expanded={isDescriptionExpanded}>
-        {sceneDescription.paragraphs.map((paragraph, index) => (
-          <p key={`${index}-${paragraph}`}>{paragraph}</p>
-        ))}
+        {hasDescription ? (
+          sceneDescription.paragraphs.map((paragraph, index) => (
+            <p key={`${index}-${paragraph}`}>{paragraph}</p>
+          ))
+        ) : (
+          <p>No description provided.</p>
+        )}
       </div>
 
       {isDescriptionExpanded ? (
         <>
-          <div className="scene-detail-note-grid">
-            <div className="scene-detail-note-grid__item">
-              <span>Studio note</span>
-              <strong>{creatorProfile.studioNote}</strong>
-            </div>
-            <div className="scene-detail-note-grid__item">
-              <span>Best for</span>
-              <strong>{sceneDescription.bestFor}</strong>
-            </div>
-            <div className="scene-detail-note-grid__item">
-              <span>Built with</span>
-              <strong>{sceneDescription.builtWith}</strong>
-            </div>
-            <div className="scene-detail-note-grid__item">
-              <span>Saves</span>
-              <strong>{engagement.savesLabel}</strong>
-            </div>
-          </div>
-
-          {sceneDescription.tags.length > 0 ? (
+          {hasTags ? (
             <div className="tag-filter-bar scene-detail-description-tags" role="toolbar" aria-label="Scene tags">
               {sceneDescription.tags.map((tag) => (
                 <Link key={tag} className="tag-pill" to={`/scenes?tag=${encodeURIComponent(tag)}`}>
@@ -86,10 +72,10 @@ export function SceneDescriptionCard({
             </div>
           ) : null}
 
-          {descriptionToggle}
+          {shouldShowToggle ? descriptionToggle : null}
         </>
       ) : (
-        descriptionToggle
+        shouldShowToggle ? descriptionToggle : null
       )}
     </section>
   )

--- a/src/modules/scene-detail/viewModels.ts
+++ b/src/modules/scene-detail/viewModels.ts
@@ -36,6 +36,19 @@ function slugify(value: string) {
     .replace(/[^a-z0-9]+/g, '')
 }
 
+function buildDescriptionParagraphs(description: string | null) {
+  const normalizedDescription = description?.replace(/\r\n/g, '\n').trim()
+
+  if (!normalizedDescription) {
+    return []
+  }
+
+  return normalizedDescription
+    .split(/\n[ \t]*\n/g)
+    .map((paragraph) => paragraph.trim())
+    .filter(Boolean)
+}
+
 export function buildSceneEngagement(scene: SceneDetail): SceneEngagement {
   const views = 1559 + scene.id * 120
   const upvotes = 56 + scene.id * 30
@@ -53,10 +66,8 @@ export function buildSceneEngagement(scene: SceneDetail): SceneEngagement {
 }
 
 export function buildSceneDescription(scene: SceneDetail): SceneDescription {
-  const storedDescription = scene.description?.trim()
-
   return {
-    paragraphs: storedDescription ? [storedDescription] : [],
+    paragraphs: buildDescriptionParagraphs(scene.description),
     tags: scene.tags,
   }
 }

--- a/src/modules/scene-detail/viewModels.ts
+++ b/src/modules/scene-detail/viewModels.ts
@@ -1,4 +1,4 @@
-import { buildFallbackSceneDescriptionParagraphs, pickCreatorProfileBlueprint } from './fixtures'
+import { pickCreatorProfileBlueprint } from './fixtures'
 import type { CreatorProfile, SceneDescription, SceneDetail, SceneEngagement } from './types'
 
 function formatCreatedAt(createdAt: string | null) {
@@ -52,18 +52,11 @@ export function buildSceneEngagement(scene: SceneDetail): SceneEngagement {
   }
 }
 
-export function buildSceneDescription(
-  scene: SceneDetail,
-  creatorProfile: CreatorProfile,
-): SceneDescription {
+export function buildSceneDescription(scene: SceneDetail): SceneDescription {
   const storedDescription = scene.description?.trim()
 
   return {
-    paragraphs: storedDescription
-      ? [storedDescription]
-      : buildFallbackSceneDescriptionParagraphs(creatorProfile),
-    bestFor: 'lorem ipsum, dolor sit amet, consectetur',
-    builtWith: 'adipiscing elit, sed do eiusmod, tempor incididunt',
+    paragraphs: storedDescription ? [storedDescription] : [],
     tags: scene.tags,
   }
 }
@@ -80,8 +73,6 @@ export function buildCreatorProfile(
       displayName: resolvedDisplayName,
       handle: `@${slugify(resolvedDisplayName) || 'magecreator'}`,
       subscribersLabel: buildSubscriberLabel(scene.id),
-      studioNote:
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
       primaryActionLabel: 'Subscribe',
     }
   }

--- a/src/modules/scene-detail/viewModels.ts
+++ b/src/modules/scene-detail/viewModels.ts
@@ -1,5 +1,5 @@
-import { pickCreatorProfileBlueprint } from './fixtures'
-import type { CreatorProfile, SceneDetail, SceneEngagement } from './types'
+import { buildFallbackSceneDescriptionParagraphs, pickCreatorProfileBlueprint } from './fixtures'
+import type { CreatorProfile, SceneDescription, SceneDetail, SceneEngagement } from './types'
 
 function formatCreatedAt(createdAt: string | null) {
   if (!createdAt) {
@@ -49,6 +49,22 @@ export function buildSceneEngagement(scene: SceneDetail): SceneEngagement {
     savesLabel: saves.toLocaleString(),
     publishedLabel: `Published ${formatCreatedAt(scene.createdAt)}`,
     topicLabel: 'Audio-reactive scene',
+  }
+}
+
+export function buildSceneDescription(
+  scene: SceneDetail,
+  creatorProfile: CreatorProfile,
+): SceneDescription {
+  const storedDescription = scene.description?.trim()
+
+  return {
+    paragraphs: storedDescription
+      ? [storedDescription]
+      : buildFallbackSceneDescriptionParagraphs(creatorProfile),
+    bestFor: 'lorem ipsum, dolor sit amet, consectetur',
+    builtWith: 'adipiscing elit, sed do eiusmod, tempor incididunt',
+    tags: scene.tags,
   }
 }
 

--- a/src/modules/scene-editor/CreateScenePage.submission.test.tsx
+++ b/src/modules/scene-editor/CreateScenePage.submission.test.tsx
@@ -82,6 +82,7 @@ describe('CreateScenePage submission', () => {
     renderCreateScenePage()
 
     await user.type(screen.getByLabelText(/scene name/i), 'Aurora Drift')
+    await user.type(screen.getByLabelText(/description/i), 'Soft teal bloom with low-end drift.')
     await user.click(screen.getByRole('button', { name: /^camera$/i }))
     expect(screen.getByRole('heading', { name: /^camera$/i })).toBeInTheDocument()
     fireEvent.change(screen.getByLabelText(/camera orientation/i), {
@@ -102,6 +103,7 @@ describe('CreateScenePage submission', () => {
     const passOrder = fx.passOrder as string[]
 
     expect(responseBody).toMatchObject({
+      description: 'Soft teal bloom with low-end drift.',
       name: 'Aurora Drift',
     })
     expect(intent.camTilt).toBeCloseTo(Math.PI / 2, 5)

--- a/src/modules/scene-editor/README.md
+++ b/src/modules/scene-editor/README.md
@@ -72,7 +72,7 @@ User-facing behavior:
 
 Current limitations:
 
-- `name` and `sceneData` are submitted, but description and playlist are still UI-only
+- `name`, `description`, and `sceneData` are submitted, but playlist is still UI-only
 - selected tags are persisted in a follow-up attach step after the scene is created
 - some engine passes still lack full persisted boolean support in the compact scene schema
 

--- a/src/modules/scene-editor/SceneEditorShell.tsx
+++ b/src/modules/scene-editor/SceneEditorShell.tsx
@@ -355,6 +355,38 @@ export function SceneEditorShell({
     );
   }
 
+  function handleDescriptionChange(nextDescription: string) {
+    setDescription(nextDescription);
+    setErrors((currentErrors) => ({
+      ...currentErrors,
+      description: undefined,
+      form: undefined,
+    }));
+  }
+
+  function renderSceneDescriptionField() {
+    return (
+      <div className="field-group">
+        <FieldGroupLabel htmlFor="description" label="Description" />
+        <textarea
+          aria-describedby={errors.description ? "description-error" : undefined}
+          aria-invalid={Boolean(errors.description)}
+          id="description"
+          maxLength={1000}
+          onChange={(event) => handleDescriptionChange(event.currentTarget.value)}
+          placeholder="Describe the mood, motion, or moment this scene is built for."
+          rows={5}
+          value={description}
+        />
+        {errors.description ? (
+          <p className="field-error" id="description-error" role="alert">
+            {errors.description}
+          </p>
+        ) : null}
+      </div>
+    );
+  }
+
   function renderTagEditor() {
     return (
       <div className="field-group">
@@ -938,34 +970,7 @@ export function SceneEditorShell({
               >
                 <div className="scene-editor-stack">
                   {renderSceneNameField()}
-
-                  <div className="field-group">
-                    <FieldGroupLabel htmlFor="description" label="Description" />
-                    <textarea
-                      aria-describedby={
-                        errors.description ? "description-error" : undefined
-                      }
-                      aria-invalid={Boolean(errors.description)}
-                      id="description"
-                      maxLength={1000}
-                      onChange={(event) => {
-                        setDescription(event.currentTarget.value);
-                        setErrors((currentErrors) => ({
-                          ...currentErrors,
-                          description: undefined,
-                          form: undefined,
-                        }));
-                      }}
-                      placeholder="Describe the mood, motion, or moment this scene is built for."
-                      rows={5}
-                      value={description}
-                    />
-                    {errors.description ? (
-                      <p className="field-error" id="description-error" role="alert">
-                        {errors.description}
-                      </p>
-                    ) : null}
-                  </div>
+                  {renderSceneDescriptionField()}
 
                   <div className="field-group">
                     <FieldGroupLabel htmlFor="playlists" label="Playlists" />

--- a/src/modules/scene-editor/SceneEditorShell.tsx
+++ b/src/modules/scene-editor/SceneEditorShell.tsx
@@ -828,6 +828,7 @@ export function SceneEditorShell({
     authenticatedFetch,
     availableTags,
     captureThumbnailIfMissing: captureThumbnailFromPreview,
+    description,
     isCameraAdvancedEnabled,
     isMotionAdvancedEnabled,
     name,
@@ -941,14 +942,29 @@ export function SceneEditorShell({
                   <div className="field-group">
                     <FieldGroupLabel htmlFor="description" label="Description" />
                     <textarea
-                      id="description"
-                      onChange={(event) =>
-                        setDescription(event.currentTarget.value)
+                      aria-describedby={
+                        errors.description ? "description-error" : undefined
                       }
+                      aria-invalid={Boolean(errors.description)}
+                      id="description"
+                      maxLength={1000}
+                      onChange={(event) => {
+                        setDescription(event.currentTarget.value);
+                        setErrors((currentErrors) => ({
+                          ...currentErrors,
+                          description: undefined,
+                          form: undefined,
+                        }));
+                      }}
                       placeholder="Describe the mood, motion, or moment this scene is built for."
                       rows={5}
                       value={description}
                     />
+                    {errors.description ? (
+                      <p className="field-error" id="description-error" role="alert">
+                        {errors.description}
+                      </p>
+                    ) : null}
                   </div>
 
                   <div className="field-group">

--- a/src/modules/scene-editor/types.ts
+++ b/src/modules/scene-editor/types.ts
@@ -1,7 +1,7 @@
 import type { PersistedPassFlag, SceneData, SceneEditorModel, ScenePassId } from './sceneEditor'
 
 export type CreateSceneFormErrors = Partial<
-  Record<'form' | 'name' | 'newTag' | 'sceneData' | 'tags' | 'thumbnail', string>
+  Record<'description' | 'form' | 'name' | 'newTag' | 'sceneData' | 'tags' | 'thumbnail', string>
 >
 
 export type EditorSectionId =
@@ -39,6 +39,7 @@ export type EditorSectionConfig = {
 
 export type SceneEditorStateSnapshot = {
   availableTags: Array<{ tagId: number; name: string }>
+  description: string
   isCameraAdvancedEnabled: boolean
   isMotionAdvancedEnabled: boolean
   name: string

--- a/src/modules/scene-editor/useSceneEditorSubmission.ts
+++ b/src/modules/scene-editor/useSceneEditorSubmission.ts
@@ -79,6 +79,7 @@ export function useSceneEditorSubmission({
   authenticatedFetch,
   availableTags,
   captureThumbnailIfMissing,
+  description,
   isCameraAdvancedEnabled,
   isMotionAdvancedEnabled,
   name,
@@ -130,6 +131,7 @@ export function useSceneEditorSubmission({
     }
 
     const trimmedName = name.trim()
+    const trimmedDescription = description.trim()
     const { errors: nextErrors, parsedSceneData } = validateForm(
       trimmedName,
       sceneDataText,
@@ -178,6 +180,7 @@ export function useSceneEditorSubmission({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           name: trimmedName,
+          description: trimmedDescription || undefined,
           sceneData: sanitizedSceneData,
           thumbnailObjectKey,
         }),
@@ -187,6 +190,7 @@ export function useSceneEditorSubmission({
         const apiError = await parseApiError(response)
         const backendDetails = apiError?.details ?? {}
         setErrors({
+          description: backendDetails.description,
           name: backendDetails.name,
           sceneData: backendDetails.sceneData,
           form:

--- a/src/shared/lib/api.ts
+++ b/src/shared/lib/api.ts
@@ -31,6 +31,7 @@ export type SceneListResponse = {
   ownerUserId: number
   creatorDisplayName: string
   name: string
+  description?: string | null
   sceneData: Record<string, unknown>
   thumbnailRef: string | null
   createdAt: string

--- a/src/theme/themes/classic-facebook/player.css
+++ b/src/theme/themes/classic-facebook/player.css
@@ -110,14 +110,13 @@ html[data-theme='classic-facebook'] .scene-detail-comments-panel {
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
 }
 
-html[data-theme='classic-facebook'] .scene-detail-description-card__meta strong,
-html[data-theme='classic-facebook'] .scene-detail-note-grid__item strong {
+html[data-theme='classic-facebook'] .scene-detail-description-card__meta strong {
   color: #1d2a44;
 }
 
 html[data-theme='classic-facebook'] .scene-detail-description-card__meta span,
 html[data-theme='classic-facebook'] .scene-detail-description-card p,
-html[data-theme='classic-facebook'] .scene-detail-note-grid__item span,
+html[data-theme='classic-facebook'] .scene-detail-comments-empty,
 html[data-theme='classic-facebook'] .scene-detail-comment-composer__field {
   color: #596b93;
 }
@@ -128,12 +127,6 @@ html[data-theme='classic-facebook'] .scene-detail-description-toggle {
 
 html[data-theme='classic-facebook'] .scene-detail-description-toggle:hover {
   color: #2d4373;
-}
-
-html[data-theme='classic-facebook'] .scene-detail-note-grid__item {
-  border-radius: 4px;
-  border-color: #d8dfea;
-  background: #f7f8fb;
 }
 
 html[data-theme='classic-facebook'] .scene-detail-comment-composer__field {


### PR DESCRIPTION
## Summary
- Show persisted scene descriptions on the player/detail page.
- Preserve the existing My Scenes description slot and add coverage for backend descriptions flowing into detail navigation.
- Submit the Create Scene description field to the backend.
- Surface backend description validation errors in the create form.
- Update scene detail/editor module docs to reflect persisted descriptions.

## Testing
- `npm test`
- `npm run build`
- `npm run lint`
- `git diff --check`

## Notes
- Discovery cards were checked and left unchanged because they currently use a compact title/creator/stats/thumbnail layout.
