### PR TITLE
Enforce png thumbnail captures

### DIFF
--- a/src/modules/scene-editor/CreateScenePage.submission.test.tsx
+++ b/src/modules/scene-editor/CreateScenePage.submission.test.tsx
@@ -338,6 +338,37 @@ describe('CreateScenePage submission', () => {
     expect(createAttempted).toBe(false)
   })
 
+  it('does not create the scene when the live preview returns a non-png thumbnail', async () => {
+    storeSceneEditorSession()
+
+    let createAttempted = false
+    mockCaptureFramePreview.mockResolvedValueOnce('data:image/webp;base64,AAAA')
+
+    mockCreateScenePageFetch((input) => {
+      if (input === buildApiUrl('/scenes')) {
+        createAttempted = true
+        return Promise.resolve(
+          new Response(JSON.stringify({ sceneId: 18 }), {
+            status: 201,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        )
+      }
+    })
+
+    const user = userEvent.setup()
+
+    renderCreateScenePage()
+
+    await user.type(screen.getByLabelText(/scene name/i), 'Aurora Drift')
+    await user.click(screen.getByRole('button', { name: /create scene/i }))
+
+    expect(
+      await screen.findByText(/preview capture returned an unsupported image format\./i),
+    ).toBeInTheDocument()
+    expect(createAttempted).toBe(false)
+  })
+
   it('does not create the scene when thumbnail upload preparation fails', async () => {
     storeSceneEditorSession()
 

--- a/src/modules/scene-editor/utils.ts
+++ b/src/modules/scene-editor/utils.ts
@@ -13,6 +13,9 @@ import {
 import { ALLOWED_THUMBNAIL_CONTENT_TYPES, MAX_THUMBNAIL_BYTES, initialSceneModel, passFlagsById } from './fixtures'
 import type { CreateSceneFormErrors } from './types'
 
+const CAPTURED_THUMBNAIL_CONTENT_TYPE = 'image/png'
+const CAPTURED_THUMBNAIL_FILENAME = 'scene-preview-thumbnail.png'
+
 export function normalizeTagName(name: string) {
   return name.trim().toLowerCase()
 }
@@ -170,7 +173,12 @@ export function buildCapturedThumbnailFile(dataUrl: string) {
   }
 
   const [, rawContentType, base64Marker, encodedPayload] = matchedDataUrl
-  const contentType = rawContentType?.trim() || 'image/png'
+  const contentType = rawContentType?.trim().toLowerCase()
+
+  if (contentType !== CAPTURED_THUMBNAIL_CONTENT_TYPE) {
+    throw new Error('Preview capture returned an unsupported image format.')
+  }
+
   const decodedPayload = base64Marker
     ? window.atob(encodedPayload)
     : decodeURIComponent(encodedPayload)
@@ -178,15 +186,8 @@ export function buildCapturedThumbnailFile(dataUrl: string) {
     character.charCodeAt(0),
   )
 
-  const extension =
-    contentType === 'image/jpeg'
-      ? 'jpg'
-      : contentType === 'image/webp'
-        ? 'webp'
-        : 'png'
-
-  return new File([payloadBytes], `scene-preview-thumbnail.${extension}`, {
-    type: contentType,
+  return new File([payloadBytes], CAPTURED_THUMBNAIL_FILENAME, {
+    type: CAPTURED_THUMBNAIL_CONTENT_TYPE,
   })
 }
 


### PR DESCRIPTION
## Summary

- Simplifies captured thumbnail handling to match the current capture contract: live preview screenshots are PNG-only.
- Always creates captured thumbnail files as `scene-preview-thumbnail.png` with `image/png`.
- Rejects unexpected non-PNG capture data before creating a scene.

## Testing

- `npm run lint`
- `npm test -- src/modules/scene-editor/CreateScenePage.submission.test.tsx src/modules/player/MagePlayer.test.tsx`
- `npm test -- --run`
- `npm run build`
