### PR TITLE
105 real engagement summary frontend

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1119,6 +1119,14 @@
   gap: 10px;
 }
 
+.scene-detail-action-error {
+  flex-basis: 100%;
+  margin: 0;
+  color: #ffb4a8;
+  font-size: 0.86rem;
+  text-align: right;
+}
+
 .scene-detail-action-chip,
 .scene-detail-sort-chip,
 .scene-detail-comment__action {
@@ -1148,6 +1156,13 @@
   background: rgba(255, 255, 255, 0.08);
 }
 
+.scene-detail-action-chip[aria-pressed='true'],
+.scene-detail-action-chip.is-selected {
+  border-color: rgba(99, 240, 214, 0.48);
+  background: rgba(99, 240, 214, 0.14);
+  color: #e9fffb;
+}
+
 .scene-detail-vote-button__icon {
   display: inline-flex;
   align-items: center;
@@ -1155,6 +1170,11 @@
   width: 1rem;
   height: 1rem;
   color: var(--muted);
+}
+
+.scene-detail-action-chip[aria-pressed='true'] .scene-detail-vote-button__icon,
+.scene-detail-action-chip.is-selected .scene-detail-vote-button__icon {
+  color: #63f0d6;
 }
 
 .scene-detail-vote-button__icon svg {

--- a/src/modules/discovery/ScenesPage.test.tsx
+++ b/src/modules/discovery/ScenesPage.test.tsx
@@ -14,6 +14,14 @@ const mockScenes = [
     sceneId: 1,
     ownerUserId: 10,
     creatorDisplayName: 'Sunset Artist',
+    engagement: {
+      currentUserSaved: false,
+      currentUserVote: null,
+      downvotes: 2,
+      saves: 4,
+      upvotes: 10,
+      views: 42,
+    },
     name: 'Sunset Scene',
     sceneData: {},
     thumbnailRef: null,
@@ -23,6 +31,14 @@ const mockScenes = [
     sceneId: 2,
     ownerUserId: 10,
     creatorDisplayName: 'Ocean Artist',
+    engagement: {
+      currentUserSaved: false,
+      currentUserVote: null,
+      downvotes: 8,
+      saves: 9,
+      upvotes: 20,
+      views: 1500,
+    },
     name: 'Ocean Breeze',
     sceneData: {},
     thumbnailRef: 'https://example.com/thumb.png',
@@ -85,6 +101,8 @@ describe('ScenesPage', () => {
     expect(screen.getByText('Ocean Breeze')).toBeInTheDocument()
     expect(screen.getByText('Sunset Artist')).toBeInTheDocument()
     expect(screen.getByText('Ocean Artist')).toBeInTheDocument()
+    expect(screen.getByText('42 views')).toBeInTheDocument()
+    expect(screen.getByText('1.5K views')).toBeInTheDocument()
   })
 
   it('renders tag filter pills after loading', async () => {

--- a/src/modules/discovery/ui/DiscoverySceneCard.tsx
+++ b/src/modules/discovery/ui/DiscoverySceneCard.tsx
@@ -6,11 +6,6 @@ type DiscoverySceneCardProps = {
   scene: DiscoveryScene
 }
 
-function formatViewLabel(sceneId: number) {
-  const syntheticViews = 1200 + sceneId * 183
-  return formatMetricLabel(syntheticViews, 'view')
-}
-
 function buildCreatorInitials(name: string) {
   const words = name.split(/\s+/).filter(Boolean)
   const initials = words
@@ -25,7 +20,7 @@ export function DiscoverySceneCard({ scene }: DiscoverySceneCardProps) {
   const creatorName = scene.creatorDisplayName
   const creatorInitials = buildCreatorInitials(creatorName)
   const relativeTime = formatRelativeTime(scene.createdAt)
-  const viewLabel = formatViewLabel(scene.sceneId)
+  const viewLabel = formatMetricLabel(scene.engagement.views, 'view')
 
   return (
     <Link className="scene-card-link" to={`/scenes/${scene.sceneId}`}>

--- a/src/modules/my-scenes/MyScenesPage.table.test.tsx
+++ b/src/modules/my-scenes/MyScenesPage.table.test.tsx
@@ -37,7 +37,16 @@ describe('MyScenesPage table behavior', () => {
 
     const storedUser = buildMyScenesStoredUser()
     const mockScenes = [
-      buildMyScenesApiScene(),
+      buildMyScenesApiScene({
+        engagement: {
+          currentUserSaved: false,
+          currentUserVote: null,
+          downvotes: 1,
+          saves: 0,
+          upvotes: 3,
+          views: 1200,
+        },
+      }),
       buildMyScenesApiScene({
         createdAt: '2026-04-06T14:10:00Z',
         description: undefined,
@@ -92,6 +101,8 @@ describe('MyScenesPage table behavior', () => {
     ).toBeInTheDocument()
     expect(screen.getAllByRole('button', { name: /add description/i })).toHaveLength(2)
     expect(screen.getByAltText('Aurora Drift thumbnail')).toBeInTheDocument()
+    expect(screen.getByText('1.2K')).toBeInTheDocument()
+    expect(screen.getByText('75%')).toBeInTheDocument()
     expect(
       screen.getByAltText('Very Long Scene Name To Test Wrapping In The Card Layout thumbnail'),
     ).toBeInTheDocument()

--- a/src/modules/my-scenes/MyScenesPage.test.tsx
+++ b/src/modules/my-scenes/MyScenesPage.test.tsx
@@ -76,7 +76,18 @@ describe('MyScenesPage states', () => {
     storeMyScenesSession()
 
     const storedUser = buildMyScenesStoredUser()
-    const auroraScene = buildMyScenesApiScene({ id: 12, sceneId: 12 })
+    const auroraScene = buildMyScenesApiScene({
+      engagement: {
+        currentUserSaved: false,
+        currentUserVote: null,
+        downvotes: 1,
+        saves: 2,
+        upvotes: 3,
+        views: 777,
+      },
+      id: 12,
+      sceneId: 12,
+    })
     const signalScene = buildMyScenesApiScene({
       id: 13,
       name: 'Signal Bloom',
@@ -116,6 +127,8 @@ describe('MyScenesPage states', () => {
     const sceneLink = await screen.findByRole('link', { name: /aurora drift/i })
 
     expect(screen.getByRole('link', { name: /signal bloom/i })).toBeInTheDocument()
+    expect(screen.getByText('777')).toBeInTheDocument()
+    expect(screen.getByText('75%')).toBeInTheDocument()
 
     await user.click(sceneLink)
 

--- a/src/modules/my-scenes/loaders.ts
+++ b/src/modules/my-scenes/loaders.ts
@@ -1,16 +1,18 @@
 import { normalizeSceneList } from '@shared/lib'
 import type { AuthenticatedFetch, SceneVisibility } from './types'
 
-function buildViewsCount(sceneId: number) {
-  return 18 + sceneId * 37
-}
-
 function buildCommentsCount(sceneId: number) {
   return (sceneId * 3) % 17
 }
 
-function buildLikesRatio(sceneId: number) {
-  return 92 + (sceneId % 7)
+function buildLikesRatio(upvotes: number, downvotes: number) {
+  const totalVotes = upvotes + downvotes
+
+  if (totalVotes === 0) {
+    return 0
+  }
+
+  return Math.round((upvotes / totalVotes) * 100)
 }
 
 function buildStatusLabel(): SceneVisibility {
@@ -25,9 +27,9 @@ export function normalizeUserScenes(payload: unknown) {
     createdAt: scene.createdAt,
     description: scene.description ?? null,
     statusLabel: buildStatusLabel(),
-    viewsCount: buildViewsCount(scene.sceneId),
+    viewsCount: scene.engagement.views,
     commentsCount: buildCommentsCount(scene.sceneId),
-    likesRatio: buildLikesRatio(scene.sceneId),
+    likesRatio: buildLikesRatio(scene.engagement.upvotes, scene.engagement.downvotes),
   }))
 }
 

--- a/src/modules/my-scenes/test-fixtures.tsx
+++ b/src/modules/my-scenes/test-fixtures.tsx
@@ -22,6 +22,7 @@ export function buildMyScenesApiScene(
   overrides: Partial<Record<string, unknown>> = {},
 ) {
   const sceneId = typeof overrides.sceneId === 'number' ? overrides.sceneId : 1
+  const likesRatio = 92 + (sceneId % 7)
 
   return {
     createdAt: '2026-04-06T14:00:00Z',
@@ -31,6 +32,14 @@ export function buildMyScenesApiScene(
     ownerUserId: 42,
     sceneData: {
       visualizer: { shader: 'nebula' },
+    },
+    engagement: {
+      currentUserSaved: false,
+      currentUserVote: null,
+      downvotes: 100 - likesRatio,
+      saves: 0,
+      upvotes: likesRatio,
+      views: 18 + sceneId * 37,
     },
     sceneId,
     thumbnailRef: `thumbnails/scene-${sceneId}.png`,

--- a/src/modules/scene-detail/README.md
+++ b/src/modules/scene-detail/README.md
@@ -46,6 +46,11 @@ Access:
 Request flow:
 
 - `GET /api/scenes/:id`
+- `POST /api/scenes/:id/views`
+- `PUT /api/scenes/:id/vote`
+- `DELETE /api/scenes/:id/vote`
+- `POST /api/scenes/:id/save`
+- `DELETE /api/scenes/:id/save`
 - `GET /api/scenes`
 - `GET /api/scenes?tag=<tag>` for recommendation loading
 
@@ -55,13 +60,14 @@ User-facing behavior:
 - shows explicit restoring, loading, not-found, auth-required, and unavailable states
 - embeds the shared `MagePlayer` with route-owned playlist state
 - resets description expansion and recommendation filter state when the scene changes
-- derives creator profile and engagement labels locally from fetched scene data plus module fixtures
+- derives creator profile labels locally from fetched scene data plus module fixtures
+- renders engagement counts and current-user vote/save state from the scene detail response
 - lets the user filter the recommendation rail by creator or by scene tag
 
 Current limitations:
 
 - creator subscriber labels are still frontend-derived until the backend exposes them
-- vote, share, save, and follow controls are currently presentation-only
+- share and follow controls are currently presentation-only
 - recommendation ranking is heuristic and frontend-owned
 
 ## Tests

--- a/src/modules/scene-detail/SceneDetailPage.recommendations.test.tsx
+++ b/src/modules/scene-detail/SceneDetailPage.recommendations.test.tsx
@@ -39,6 +39,14 @@ describe('SceneDetailPage recommendations', () => {
     const sceneResponse = buildSceneDetailResponse()
     const creatorSceneResponse = buildSceneDetailResponse({
       createdAt: '2026-04-08T14:00:00Z',
+      engagement: {
+        currentUserSaved: false,
+        currentUserVote: null,
+        downvotes: 4,
+        saves: 8,
+        upvotes: 50,
+        views: 4321,
+      },
       name: 'Signal Bloom',
       sceneId: 16,
       tags: [],
@@ -47,6 +55,14 @@ describe('SceneDetailPage recommendations', () => {
     const tagSceneResponse = buildSceneDetailResponse({
       createdAt: '2026-04-09T14:00:00Z',
       creatorDisplayName: 'Night Archive',
+      engagement: {
+        currentUserSaved: false,
+        currentUserVote: null,
+        downvotes: 0,
+        saves: 0,
+        upvotes: 1,
+        views: 5,
+      },
       name: 'Afterglow Static',
       ownerUserId: 42,
       sceneId: 21,
@@ -97,6 +113,8 @@ describe('SceneDetailPage recommendations', () => {
 
     expect(await screen.findByRole('link', { name: /signal bloom/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /afterglow static/i })).toBeInTheDocument()
+    expect(screen.getByText(/4\.3K views/i)).toBeInTheDocument()
+    expect(screen.getByText(/5 views/i)).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: /from scene artist/i }))
 

--- a/src/modules/scene-detail/SceneDetailPage.test.tsx
+++ b/src/modules/scene-detail/SceneDetailPage.test.tsx
@@ -1,4 +1,5 @@
 import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { buildApiUrl } from '@shared/lib'
 import { jsonResponse } from '@shared/test/http'
@@ -109,6 +110,7 @@ describe('SceneDetailPage route states', () => {
     expect(screen.getByText(/add a comment as scene artist/i)).toBeInTheDocument()
     expect(screen.getAllByText('Scene Artist').length).toBeGreaterThan(0)
     expect(screen.getAllByText(/2,999 views/i).length).toBeGreaterThan(0)
+    expect(screen.getByRole('button', { name: /save 150/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /from scene artist/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /^ambient$/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /^focus-friendly$/i })).toBeInTheDocument()
@@ -131,6 +133,121 @@ describe('SceneDetailPage route states', () => {
     const sceneRequestHeaders = fetchSpy.mock.calls[1][1]?.headers as Headers
 
     expect(sceneRequestHeaders.get('Authorization')).toBe('Bearer stored-auth-token')
+  })
+
+  it('renders backend engagement counts and current-user state', async () => {
+    storeSceneDetailSession()
+
+    const storedUser = buildSceneDetailStoredUser()
+    const sceneResponse = buildSceneDetailResponse({
+      engagement: {
+        currentUserSaved: true,
+        currentUserVote: 'up',
+        downvotes: 3,
+        saves: 45,
+        upvotes: 123,
+        views: 9876,
+      },
+      tags: [],
+    })
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      if (input === buildApiUrl('/users/me')) {
+        return Promise.resolve(jsonResponse(storedUser))
+      }
+
+      if (input === buildApiUrl('/scenes/12')) {
+        return Promise.resolve(jsonResponse(sceneResponse))
+      }
+
+      if (input === buildApiUrl('/scenes')) {
+        return Promise.resolve(jsonResponse([sceneResponse]))
+      }
+
+      throw new Error(`Unexpected request: ${String(input)}`)
+    })
+
+    renderSceneDetailPage()
+
+    expect(await screen.findByText(/9,876 views/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /upvote 123/i })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: /downvote 3/i })).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByRole('button', { name: /saved 45/i })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('records a view and updates vote and save state through the backend', async () => {
+    storeSceneDetailSession()
+
+    const user = userEvent.setup()
+    const storedUser = buildSceneDetailStoredUser()
+    const sceneResponse = buildSceneDetailResponse()
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      if (input === buildApiUrl('/users/me')) {
+        return jsonResponse(storedUser)
+      }
+
+      if (input === buildApiUrl('/scenes/12')) {
+        return jsonResponse(sceneResponse)
+      }
+
+      if (input === buildApiUrl('/scenes/12/views')) {
+        expect(init?.method).toBe('POST')
+        return jsonResponse({
+          ...sceneResponse.engagement,
+          views: 3000,
+        })
+      }
+
+      if (input === buildApiUrl('/scenes')) {
+        return jsonResponse([sceneResponse])
+      }
+
+      if (input === buildApiUrl('/scenes/12/vote')) {
+        expect(init?.method).toBe('PUT')
+        expect(init?.body).toBe(JSON.stringify({ vote: 'up' }))
+
+        return jsonResponse({
+          ...sceneResponse.engagement,
+          currentUserVote: 'up',
+          upvotes: 417,
+          views: 3000,
+        })
+      }
+
+      if (input === buildApiUrl('/scenes/12/save')) {
+        expect(init?.method).toBe('POST')
+
+        return jsonResponse({
+          ...sceneResponse.engagement,
+          currentUserSaved: true,
+          currentUserVote: 'up',
+          saves: 151,
+          upvotes: 417,
+          views: 3000,
+        })
+      }
+
+      throw new Error(`Unexpected request: ${String(input)}`)
+    })
+
+    renderSceneDetailPage()
+
+    expect(await screen.findByText(/3,000 views/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /upvote 416/i }))
+    expect(await screen.findByRole('button', { name: /upvote 417/i })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+
+    await user.click(screen.getByRole('button', { name: /save 150/i }))
+    expect(await screen.findByRole('button', { name: /saved 151/i })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledWith(buildApiUrl('/scenes/12/views'), expect.any(Object)))
   })
 
   it('shows an empty description state when no description is stored', async () => {

--- a/src/modules/scene-detail/SceneDetailPage.tsx
+++ b/src/modules/scene-detail/SceneDetailPage.tsx
@@ -1,28 +1,46 @@
-import { useEffect, useState, type CSSProperties } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { useEffect, useRef, useState, type CSSProperties } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useAuth } from '@auth'
 import { MagePlayer } from '@modules/player'
 import { buildSceneComments } from './fixtures'
-import { fetchRecommendedSceneGroups, fetchSceneDetail, SceneDetailRequestError } from './loaders'
+import {
+  clearSceneVote,
+  fetchRecommendedSceneGroups,
+  fetchSceneDetail,
+  recordSceneView,
+  SceneDetailRequestError,
+  updateSceneSave,
+  updateSceneVote,
+} from './loaders'
 import { createEmptyRecommendedSceneGroups, selectRecommendedScenes } from './recommendations'
 import { readErrorCopy, readInitial, readSceneId } from './selectors'
-import type { RecommendationFilter, RecommendedSceneGroups, SceneDetail, SceneDetailErrorCode } from './types'
+import type {
+  RecommendationFilter,
+  RecommendedSceneGroups,
+  SceneDetail,
+  SceneDetailErrorCode,
+  SceneEngagementSummary,
+  SceneVoteState,
+} from './types'
 import { SceneCommentsPanel, SceneDescriptionCard, SceneDetailState, SceneRecommendationRail, VoteButton } from './ui'
 import { useScenePlaylistState } from './useScenePlaylistState'
 import { buildCreatorProfile, buildSceneDescription, buildSceneEngagement } from './viewModels'
 
 export function SceneDetailPage() {
   const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
   const { authenticatedFetch, isAuthenticated, isRestoringSession, user } = useAuth()
   const [scene, setScene] = useState<SceneDetail | null>(null)
   const [errorCode, setErrorCode] = useState<SceneDetailErrorCode | null>(null)
   const [isLoading, setIsLoading] = useState(true)
+  const [engagementActionError, setEngagementActionError] = useState<string | null>(null)
   const [recommendedSceneGroups, setRecommendedSceneGroups] = useState<RecommendedSceneGroups>(
     createEmptyRecommendedSceneGroups(),
   )
   const [isRecommendationsLoading, setIsRecommendationsLoading] = useState(false)
   const [recommendationFilter, setRecommendationFilter] = useState<RecommendationFilter>('all')
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
+  const recordedViewSceneIds = useRef<Set<number>>(new Set())
   const sceneId = readSceneId(id)
   const {
     handlePlaylistChange,
@@ -87,7 +105,47 @@ export function SceneDetailPage() {
   useEffect(() => {
     setIsDescriptionExpanded(false)
     setRecommendationFilter('all')
+    setEngagementActionError(null)
   }, [scene?.id])
+
+  useEffect(() => {
+    if (!scene || recordedViewSceneIds.current.has(scene.id)) {
+      return
+    }
+
+    const currentSceneId = scene.id
+    let isCurrent = true
+    recordedViewSceneIds.current.add(currentSceneId)
+
+    async function recordLoadedSceneView() {
+      try {
+        const nextEngagement = await recordSceneView(authenticatedFetch, isAuthenticated, currentSceneId)
+
+        if (!isCurrent) {
+          return
+        }
+
+        setScene((currentScene) =>
+          currentScene?.id === currentSceneId
+            ? {
+                ...currentScene,
+                engagement: nextEngagement,
+              }
+            : currentScene,
+        )
+      } catch {
+        if (isCurrent) {
+          recordedViewSceneIds.current.delete(currentSceneId)
+        }
+      }
+    }
+
+    void recordLoadedSceneView()
+
+    return () => {
+      isCurrent = false
+    }
+  }, [authenticatedFetch, isAuthenticated, scene])
 
   useEffect(() => {
     if (!scene) {
@@ -199,9 +257,10 @@ export function SceneDetailPage() {
     )
   }
 
-  const creatorProfile = buildCreatorProfile(scene, user?.displayName, user?.userId)
-  const engagement = buildSceneEngagement(scene)
-  const sceneDescription = buildSceneDescription(scene)
+  const loadedScene = scene
+  const creatorProfile = buildCreatorProfile(loadedScene, user?.displayName, user?.userId)
+  const engagement = buildSceneEngagement(loadedScene)
+  const sceneDescription = buildSceneDescription(loadedScene)
   const sceneComments = buildSceneComments()
   const filteredRecommendedScenes = selectRecommendedScenes(
     recommendedSceneGroups,
@@ -211,6 +270,51 @@ export function SceneDetailPage() {
   const composerPrompt = user?.displayName
     ? `Add a comment as ${user.displayName}...`
     : 'Sign in to join the conversation'
+
+  function applySceneEngagement(nextEngagement: SceneEngagementSummary) {
+    setScene((currentScene) =>
+      currentScene?.id === loadedScene.id
+        ? {
+            ...currentScene,
+            engagement: nextEngagement,
+          }
+        : currentScene,
+    )
+  }
+
+  async function runAuthenticatedEngagementAction(action: () => Promise<SceneEngagementSummary>) {
+    if (!isAuthenticated) {
+      navigate('/login')
+      return
+    }
+
+    setEngagementActionError(null)
+
+    try {
+      applySceneEngagement(await action())
+    } catch (error) {
+      if (error instanceof SceneDetailRequestError && error.code === 'auth-required') {
+        navigate('/login')
+        return
+      }
+
+      setEngagementActionError('Unable to update this interaction right now.')
+    }
+  }
+
+  function handleVoteClick(vote: SceneVoteState) {
+    void runAuthenticatedEngagementAction(() =>
+      engagement.currentUserVote === vote
+        ? clearSceneVote(authenticatedFetch, loadedScene.id)
+        : updateSceneVote(authenticatedFetch, loadedScene.id, vote),
+    )
+  }
+
+  function handleSaveClick() {
+    void runAuthenticatedEngagementAction(() =>
+      updateSceneSave(authenticatedFetch, loadedScene.id, !engagement.currentUserSaved),
+    )
+  }
 
   return (
     <main className="scene-detail-page">
@@ -268,19 +372,39 @@ export function SceneDetailPage() {
                 className="scene-detail-action-chip"
                 count={engagement.upvotesLabel}
                 direction="up"
+                isSelected={engagement.currentUserVote === 'up'}
+                onClick={() => {
+                  handleVoteClick('up')
+                }}
               />
               <VoteButton
                 className="scene-detail-action-chip"
                 count={engagement.downvotesLabel}
                 direction="down"
+                isSelected={engagement.currentUserVote === 'down'}
+                onClick={() => {
+                  handleVoteClick('down')
+                }}
               />
               <button className="scene-detail-action-chip" type="button">
                 Share
               </button>
-              <button className="scene-detail-action-chip" type="button">
-                Save
+              <button
+                aria-label={`${engagement.currentUserSaved ? 'Saved' : 'Save'} ${engagement.savesLabel}`}
+                aria-pressed={engagement.currentUserSaved}
+                className={`scene-detail-action-chip${engagement.currentUserSaved ? ' is-selected' : ''}`}
+                onClick={handleSaveClick}
+                type="button"
+              >
+                <span>{engagement.currentUserSaved ? 'Saved' : 'Save'}</span>
+                <span>{engagement.savesLabel}</span>
               </button>
             </div>
+            {engagementActionError ? (
+              <p className="scene-detail-action-error" role="status">
+                {engagementActionError}
+              </p>
+            ) : null}
           </section>
 
           <SceneDescriptionCard

--- a/src/modules/scene-detail/dto.ts
+++ b/src/modules/scene-detail/dto.ts
@@ -1,4 +1,5 @@
-import type { SceneDetail } from './types'
+import { normalizeSceneListEngagement } from '@shared/lib'
+import type { SceneDetail, SceneEngagementSummary, SceneVoteState } from './types'
 
 type SceneDetailResponse = {
   sceneId?: number
@@ -10,6 +11,16 @@ type SceneDetailResponse = {
   thumbnailRef?: string | null
   createdAt?: string
   tags?: unknown
+  engagement?: unknown
+}
+
+type SceneEngagementResponse = {
+  views?: unknown
+  upvotes?: unknown
+  downvotes?: unknown
+  saves?: unknown
+  currentUserVote?: unknown
+  currentUserSaved?: unknown
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -35,6 +46,35 @@ function normalizeSceneTags(tags: unknown) {
   }, [])
 
   return normalizedTags.filter((tagName, index) => normalizedTags.indexOf(tagName) === index)
+}
+
+function normalizeCurrentUserVote(value: unknown): SceneVoteState | null {
+  return value === 'up' || value === 'down' ? value : null
+}
+
+export function normalizeSceneEngagement(engagement: unknown): SceneEngagementSummary {
+  if (!isRecord(engagement)) {
+    return {
+      views: 0,
+      upvotes: 0,
+      downvotes: 0,
+      saves: 0,
+      currentUserVote: null,
+      currentUserSaved: false,
+    }
+  }
+
+  const resolvedEngagement = engagement as SceneEngagementResponse
+  const sharedEngagement = normalizeSceneListEngagement(resolvedEngagement)
+
+  return {
+    views: sharedEngagement.views,
+    upvotes: sharedEngagement.upvotes,
+    downvotes: sharedEngagement.downvotes,
+    saves: sharedEngagement.saves,
+    currentUserVote: normalizeCurrentUserVote(resolvedEngagement.currentUserVote),
+    currentUserSaved: sharedEngagement.currentUserSaved,
+  }
 }
 
 export function normalizeSceneDetail(payload: unknown): SceneDetail | null {
@@ -74,5 +114,6 @@ export function normalizeSceneDetail(payload: unknown): SceneDetail | null {
         ? resolvedPayload.createdAt
         : null,
     tags: normalizeSceneTags(resolvedPayload.tags),
+    engagement: normalizeSceneEngagement(resolvedPayload.engagement),
   }
 }

--- a/src/modules/scene-detail/loaders.ts
+++ b/src/modules/scene-detail/loaders.ts
@@ -1,7 +1,14 @@
 import { buildApiUrl, fetchScenes } from '@shared/lib'
-import { normalizeSceneDetail } from './dto'
+import { normalizeSceneDetail, normalizeSceneEngagement } from './dto'
 import { buildRecommendedSceneGroups } from './recommendations'
-import type { AuthenticatedFetch, RecommendedSceneGroups, SceneDetail, SceneDetailErrorCode } from './types'
+import type {
+  AuthenticatedFetch,
+  RecommendedSceneGroups,
+  SceneDetail,
+  SceneDetailErrorCode,
+  SceneEngagementSummary,
+  SceneVoteState,
+} from './types'
 
 export class SceneDetailRequestError extends Error {
   code: SceneDetailErrorCode
@@ -51,6 +58,63 @@ export async function fetchSceneDetail(
   }
 
   return scene
+}
+
+async function readSceneEngagementResponse(response: Response): Promise<SceneEngagementSummary> {
+  if (!response.ok) {
+    throw new SceneDetailRequestError(
+      readErrorCode(response.status),
+      `Scene engagement request failed with status ${response.status}.`,
+    )
+  }
+
+  const payload = await response.json().catch(() => null)
+  return normalizeSceneEngagement(payload)
+}
+
+export async function recordSceneView(
+  authenticatedFetch: AuthenticatedFetch,
+  isAuthenticated: boolean,
+  sceneId: number,
+) {
+  const response = isAuthenticated
+    ? await authenticatedFetch(`/scenes/${sceneId}/views`, { method: 'POST' })
+    : await fetch(buildApiUrl(`/scenes/${sceneId}/views`), { method: 'POST' })
+
+  return readSceneEngagementResponse(response)
+}
+
+export async function updateSceneVote(
+  authenticatedFetch: AuthenticatedFetch,
+  sceneId: number,
+  vote: SceneVoteState,
+) {
+  const response = await authenticatedFetch(`/scenes/${sceneId}/vote`, {
+    body: JSON.stringify({ vote }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    method: 'PUT',
+  })
+
+  return readSceneEngagementResponse(response)
+}
+
+export async function clearSceneVote(authenticatedFetch: AuthenticatedFetch, sceneId: number) {
+  const response = await authenticatedFetch(`/scenes/${sceneId}/vote`, { method: 'DELETE' })
+  return readSceneEngagementResponse(response)
+}
+
+export async function updateSceneSave(
+  authenticatedFetch: AuthenticatedFetch,
+  sceneId: number,
+  shouldSave: boolean,
+) {
+  const response = await authenticatedFetch(`/scenes/${sceneId}/save`, {
+    method: shouldSave ? 'POST' : 'DELETE',
+  })
+
+  return readSceneEngagementResponse(response)
 }
 
 export async function fetchRecommendedSceneGroups(

--- a/src/modules/scene-detail/recommendations.ts
+++ b/src/modules/scene-detail/recommendations.ts
@@ -1,10 +1,5 @@
-import { formatRelativeTime, type SceneListResponse } from '@shared/lib'
+import { formatMetricLabel, formatRelativeTime, type SceneListResponse } from '@shared/lib'
 import type { RecommendationFilter, RecommendedSceneCard, RecommendedSceneGroups, SceneDetail } from './types'
-
-function buildRecommendedViewsLabel(sceneId: number) {
-  const views = 1559 + sceneId * 120
-  return `${views.toLocaleString()} views`
-}
 
 function buildRecommendationAccent(sceneId: number) {
   const accents = ['#63f0d6', '#9fd9ff', '#ffb26b', '#7ef0c0', '#7f9bff']
@@ -28,7 +23,7 @@ function buildRecommendedScenesFromList(
         id: scene.sceneId,
         title: scene.name,
         creator: scene.creatorDisplayName,
-        meta: `${buildRecommendedViewsLabel(scene.sceneId)} | ${formatRelativeTime(scene.createdAt)}`,
+        meta: `${formatMetricLabel(scene.engagement.views, 'view')} | ${formatRelativeTime(scene.createdAt)}`,
         accent: buildRecommendationAccent(scene.sceneId),
         thumbnailRef: scene.thumbnailRef,
         ownerUserId: scene.ownerUserId,

--- a/src/modules/scene-detail/test-fixtures.tsx
+++ b/src/modules/scene-detail/test-fixtures.tsx
@@ -30,6 +30,14 @@ export function buildSceneDetailResponse(
     description: 'Soft teal bloom with low-end drift.',
     name: 'Aurora Drift',
     ownerUserId: 8,
+    engagement: {
+      currentUserSaved: false,
+      currentUserVote: null,
+      downvotes: 32,
+      saves: 150,
+      upvotes: 416,
+      views: 2999,
+    },
     sceneData: {
       visualizer: {
         shader: 'nebula',

--- a/src/modules/scene-detail/types.ts
+++ b/src/modules/scene-detail/types.ts
@@ -12,6 +12,7 @@ export type SceneDetail = {
   thumbnailRef: string | null
   createdAt: string | null
   tags: string[]
+  engagement: SceneEngagementSummary
 }
 
 export type SceneDetailErrorCode =
@@ -37,11 +38,24 @@ export type CreatorProfile = {
   primaryActionLabel?: string
 }
 
+export type SceneVoteState = 'up' | 'down'
+
+export type SceneEngagementSummary = {
+  views: number
+  upvotes: number
+  downvotes: number
+  saves: number
+  currentUserVote: SceneVoteState | null
+  currentUserSaved: boolean
+}
+
 export type SceneEngagement = {
   viewsLabel: string
   upvotesLabel: string
   downvotesLabel: string
   savesLabel: string
+  currentUserVote: SceneVoteState | null
+  currentUserSaved: boolean
   publishedLabel: string
   topicLabel: string
 }

--- a/src/modules/scene-detail/ui/VoteButton.tsx
+++ b/src/modules/scene-detail/ui/VoteButton.tsx
@@ -24,16 +24,26 @@ export function VoteButton({
   className,
   count,
   direction,
+  isSelected = false,
+  onClick,
 }: {
   className: string
   count: string
   direction: 'up' | 'down'
+  isSelected?: boolean
+  onClick?: () => void
 }) {
   const label = direction === 'up' ? 'Upvote' : 'Downvote'
   const Icon = direction === 'up' ? UpvoteIcon : DownvoteIcon
 
   return (
-    <button aria-label={`${label} ${count}`} className={className} type="button">
+    <button
+      aria-label={`${label} ${count}`}
+      aria-pressed={isSelected}
+      className={`${className}${isSelected ? ' is-selected' : ''}`}
+      onClick={onClick}
+      type="button"
+    >
       <span className="scene-detail-vote-button__icon" aria-hidden="true">
         <Icon />
       </span>

--- a/src/modules/scene-detail/viewModels.ts
+++ b/src/modules/scene-detail/viewModels.ts
@@ -33,16 +33,15 @@ function buildDescriptionParagraphs(description: string | null) {
 }
 
 export function buildSceneEngagement(scene: SceneDetail): SceneEngagement {
-  const views = 1559 + scene.id * 120
-  const upvotes = 56 + scene.id * 30
-  const downvotes = 8 + scene.id * 2
-  const saves = 18 + scene.id * 11
-
   return {
-    viewsLabel: `${views.toLocaleString()} views`,
-    upvotesLabel: upvotes.toLocaleString(),
-    downvotesLabel: downvotes.toLocaleString(),
-    savesLabel: saves.toLocaleString(),
+    viewsLabel: `${scene.engagement.views.toLocaleString()} ${
+      scene.engagement.views === 1 ? 'view' : 'views'
+    }`,
+    upvotesLabel: scene.engagement.upvotes.toLocaleString(),
+    downvotesLabel: scene.engagement.downvotes.toLocaleString(),
+    savesLabel: scene.engagement.saves.toLocaleString(),
+    currentUserVote: scene.engagement.currentUserVote,
+    currentUserSaved: scene.engagement.currentUserSaved,
     publishedLabel: `Published ${formatCalendarDate(scene.createdAt, 'Unavailable')}`,
     topicLabel: 'Audio-reactive scene',
   }

--- a/src/shared/lib/api.ts
+++ b/src/shared/lib/api.ts
@@ -35,11 +35,23 @@ export type SceneListResponse = {
   sceneData: Record<string, unknown>
   thumbnailRef: string | null
   createdAt: string
+  engagement: SceneListEngagement
 }
 
 export type TagResponse = {
   tagId: number
   name: string
+}
+
+export type SceneEngagementVoteState = 'up' | 'down'
+
+export type SceneListEngagement = {
+  views: number
+  upvotes: number
+  downvotes: number
+  saves: number
+  currentUserVote: SceneEngagementVoteState | null
+  currentUserSaved: boolean
 }
 
 export type FetchTagsOptions = {
@@ -48,6 +60,40 @@ export type FetchTagsOptions = {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function normalizeCount(value: unknown) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    return 0
+  }
+
+  return Math.trunc(value)
+}
+
+function normalizeCurrentUserVote(value: unknown): SceneEngagementVoteState | null {
+  return value === 'up' || value === 'down' ? value : null
+}
+
+export function normalizeSceneListEngagement(engagement: unknown): SceneListEngagement {
+  if (!isRecord(engagement)) {
+    return {
+      views: 0,
+      upvotes: 0,
+      downvotes: 0,
+      saves: 0,
+      currentUserVote: null,
+      currentUserSaved: false,
+    }
+  }
+
+  return {
+    views: normalizeCount(engagement.views),
+    upvotes: normalizeCount(engagement.upvotes),
+    downvotes: normalizeCount(engagement.downvotes),
+    saves: normalizeCount(engagement.saves),
+    currentUserVote: normalizeCurrentUserVote(engagement.currentUserVote),
+    currentUserSaved: engagement.currentUserSaved === true,
+  }
 }
 
 export function normalizeSceneListItem(item: unknown): SceneListResponse | null {
@@ -80,6 +126,7 @@ export function normalizeSceneListItem(item: unknown): SceneListResponse | null 
         ? item.thumbnailRef
         : null,
     createdAt: item.createdAt,
+    engagement: normalizeSceneListEngagement(item.engagement),
   }
 }
 

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -3,10 +3,17 @@ export {
   fetchAvailableTags,
   fetchScenes,
   fetchTags,
+  normalizeSceneListEngagement,
   normalizeSceneList,
   normalizeSceneListItem,
 } from './api'
-export type { FetchTagsOptions, SceneListResponse, TagResponse } from './api'
+export type {
+  FetchTagsOptions,
+  SceneEngagementVoteState,
+  SceneListEngagement,
+  SceneListResponse,
+  TagResponse,
+} from './api'
 export { parseApiError } from './apiErrors'
 export type { ApiErrorResponse } from './apiErrors'
 export { joinClassNames } from './classNames'


### PR DESCRIPTION
## Summary
- Wire scene detail to record views and update vote/save state through the backend.
- Rename engagement language from plays to views across the UI.
- Use backend engagement metrics in the discovery grid, recommended sidebar, and my-scenes page.
- Derive my-scenes like ratio from real upvote/downvote counts.

## Tests
- `npm test`
- `npm run build`
