### PR TITLE
109 comments replies votes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1315,7 +1315,7 @@
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
   gap: 14px;
-  align-items: center;
+  align-items: flex-start;
   margin-top: 18px;
 }
 
@@ -1338,12 +1338,98 @@
   color: var(--muted);
 }
 
+.scene-detail-comment-composer__field--button {
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  cursor: pointer;
+}
+
+.scene-detail-comment-form,
+.scene-detail-reply-composer {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+}
+
+.scene-detail-reply-composer {
+  margin-top: 12px;
+}
+
+.scene-detail-comment-composer__textarea {
+  width: 100%;
+  min-height: 44px;
+  padding: 12px 0;
+  border: 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  line-height: 1.5;
+  resize: vertical;
+}
+
+.scene-detail-comment-composer__textarea::placeholder {
+  color: var(--muted);
+}
+
+.scene-detail-comment-composer__textarea:focus {
+  outline: none;
+  border-bottom-color: rgba(99, 240, 214, 0.52);
+}
+
+.scene-detail-comment-form__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.scene-detail-comment-submit-button,
+.scene-detail-comment-cancel-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 36px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text);
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    border-color 0.18s ease,
+    background 0.18s ease,
+    color 0.18s ease;
+}
+
+.scene-detail-comment-submit-button {
+  background: rgba(99, 240, 214, 0.18);
+  border-color: rgba(99, 240, 214, 0.36);
+}
+
+.scene-detail-comment-cancel-button {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.scene-detail-comment-submit-button:hover,
+.scene-detail-comment-cancel-button:hover {
+  border-color: rgba(99, 240, 214, 0.48);
+}
+
+.scene-detail-comment-submit-button:disabled,
+.scene-detail-comment-cancel-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.52;
+}
+
 .mage-comments__list {
   display: grid;
   gap: 14px;
   margin-top: 16px;
 }
 
+.scene-detail-comments-status,
 .scene-detail-comments-empty {
   margin: 16px 0 0;
   color: var(--muted);
@@ -1393,6 +1479,37 @@
   min-height: 34px;
   padding: 8px 12px;
   font-size: 0.86rem;
+}
+
+.scene-detail-comment__action[aria-pressed='true'],
+.scene-detail-comment__action.is-selected {
+  border-color: rgba(99, 240, 214, 0.46);
+  background: rgba(99, 240, 214, 0.13);
+  color: #e9fffb;
+}
+
+.scene-detail-comment__action[aria-pressed='true'] .scene-detail-vote-button__icon,
+.scene-detail-comment__action.is-selected .scene-detail-vote-button__icon {
+  color: #63f0d6;
+}
+
+.scene-detail-action-chip:disabled,
+.scene-detail-sort-chip:disabled,
+.scene-detail-comment__action:disabled {
+  cursor: not-allowed;
+  opacity: 0.56;
+}
+
+.mage-comment__replies {
+  display: grid;
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.mage-comment--reply .mage-comment__avatar {
+  width: 34px;
+  height: 34px;
+  font-size: 0.82rem;
 }
 
 .mage-watch__rail {

--- a/src/modules/my-scenes/MyScenesPage.test.tsx
+++ b/src/modules/my-scenes/MyScenesPage.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react'
+import { screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { buildApiUrl } from '@shared/lib'
@@ -105,6 +105,41 @@ describe('MyScenesPage states', () => {
         return Promise.resolve(jsonResponse([auroraScene, signalScene]))
       }
 
+      if (input === buildApiUrl('/scenes/12/comments')) {
+        return Promise.resolve(
+          jsonResponse([
+            {
+              commentId: 101,
+              replies: [
+                {
+                  commentId: 102,
+                  replies: [],
+                  replyCount: 0,
+                },
+              ],
+              replyCount: 1,
+            },
+            {
+              commentId: 103,
+              replies: [],
+              replyCount: 0,
+            },
+          ]),
+        )
+      }
+
+      if (input === buildApiUrl('/scenes/13/comments')) {
+        return Promise.resolve(
+          jsonResponse([
+            {
+              commentId: 201,
+              replies: [],
+              replyCount: 0,
+            },
+          ]),
+        )
+      }
+
       if (input === buildApiUrl('/scenes/12')) {
         return Promise.resolve(jsonResponse(auroraScene))
       }
@@ -129,6 +164,14 @@ describe('MyScenesPage states', () => {
     expect(screen.getByRole('link', { name: /signal bloom/i })).toBeInTheDocument()
     expect(screen.getByText('777')).toBeInTheDocument()
     expect(screen.getByText('75%')).toBeInTheDocument()
+
+    const auroraRow = sceneLink.closest('article')
+    const signalRow = screen.getByRole('link', { name: /signal bloom/i }).closest('article')
+
+    expect(auroraRow).not.toBeNull()
+    expect(signalRow).not.toBeNull()
+    expect(within(auroraRow as HTMLElement).getByText('3')).toBeInTheDocument()
+    expect(within(signalRow as HTMLElement).getByText('1')).toBeInTheDocument()
 
     await user.click(sceneLink)
 

--- a/src/modules/my-scenes/loaders.ts
+++ b/src/modules/my-scenes/loaders.ts
@@ -1,8 +1,36 @@
 import { normalizeSceneList } from '@shared/lib'
 import type { AuthenticatedFetch, SceneVisibility } from './types'
 
-function buildCommentsCount(sceneId: number) {
-  return (sceneId * 3) % 17
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function normalizeCount(value: unknown) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    return 0
+  }
+
+  return Math.trunc(value)
+}
+
+function countSceneComment(comment: unknown): number {
+  if (!isRecord(comment)) {
+    return 0
+  }
+
+  const repliesCount = Array.isArray(comment.replies)
+    ? comment.replies.reduce((count, reply) => count + countSceneComment(reply), 0)
+    : 0
+
+  return 1 + Math.max(normalizeCount(comment.replyCount), repliesCount)
+}
+
+function countSceneComments(payload: unknown) {
+  if (!Array.isArray(payload)) {
+    return 0
+  }
+
+  return payload.reduce((count, comment) => count + countSceneComment(comment), 0)
 }
 
 function buildLikesRatio(upvotes: number, downvotes: number) {
@@ -19,7 +47,10 @@ function buildStatusLabel(): SceneVisibility {
   return 'Public'
 }
 
-export function normalizeUserScenes(payload: unknown) {
+export function normalizeUserScenes(
+  payload: unknown,
+  commentsCountBySceneId: ReadonlyMap<number, number> = new Map(),
+) {
   return normalizeSceneList(payload).map((scene) => ({
     id: scene.sceneId,
     name: scene.name,
@@ -28,9 +59,19 @@ export function normalizeUserScenes(payload: unknown) {
     description: scene.description ?? null,
     statusLabel: buildStatusLabel(),
     viewsCount: scene.engagement.views,
-    commentsCount: buildCommentsCount(scene.sceneId),
+    commentsCount: commentsCountBySceneId.get(scene.sceneId) ?? 0,
     likesRatio: buildLikesRatio(scene.engagement.upvotes, scene.engagement.downvotes),
   }))
+}
+
+async function fetchSceneCommentsCount(authenticatedFetch: AuthenticatedFetch, sceneId: number) {
+  const response = await authenticatedFetch(`/scenes/${sceneId}/comments`)
+
+  if (!response.ok) {
+    throw new Error(`Unable to load comment count for scene ${sceneId}.`)
+  }
+
+  return countSceneComments(await response.json().catch(() => []))
 }
 
 export async function fetchUserScenes(authenticatedFetch: AuthenticatedFetch, userId: number) {
@@ -41,5 +82,20 @@ export async function fetchUserScenes(authenticatedFetch: AuthenticatedFetch, us
   }
 
   const payload = (await response.json().catch(() => [])) as unknown
-  return normalizeUserScenes(payload)
+  const scenesWithoutCommentCounts = normalizeUserScenes(payload)
+  const commentCountResults = await Promise.allSettled(
+    scenesWithoutCommentCounts.map(async (scene) => [
+      scene.id,
+      await fetchSceneCommentsCount(authenticatedFetch, scene.id),
+    ] as const),
+  )
+  const commentCounts = new Map<number, number>()
+
+  commentCountResults.forEach((result) => {
+    if (result.status === 'fulfilled') {
+      commentCounts.set(result.value[0], result.value[1])
+    }
+  })
+
+  return normalizeUserScenes(payload, commentCounts)
 }

--- a/src/modules/scene-detail/SceneDetailPage.test.tsx
+++ b/src/modules/scene-detail/SceneDetailPage.test.tsx
@@ -1,10 +1,11 @@
-import { screen, waitFor } from '@testing-library/react'
+import { screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { buildApiUrl } from '@shared/lib'
 import { jsonResponse } from '@shared/test/http'
 import {
   buildSceneDetailResponse,
+  buildSceneCommentResponse,
   buildSceneDetailStoredUser,
   renderSceneDetailPage,
   storeSceneDetailSession,
@@ -107,7 +108,9 @@ describe('SceneDetailPage route states', () => {
     expect(screen.getByRole('button', { name: /^show$/i })).toBeInTheDocument()
     expect(screen.getByText('Soft teal bloom with low-end drift.')).toBeInTheDocument()
     expect(screen.getAllByRole('button', { name: /downvote/i }).length).toBeGreaterThan(0)
-    expect(screen.getByText(/add a comment as scene artist/i)).toBeInTheDocument()
+    expect(
+      screen.getByRole('textbox', { name: /add a public comment/i }),
+    ).toHaveAttribute('placeholder', 'Add a comment as Scene Artist...')
     expect(screen.getAllByText('Scene Artist').length).toBeGreaterThan(0)
     expect(screen.getAllByText(/2,999 views/i).length).toBeGreaterThan(0)
     expect(screen.getByRole('button', { name: /save 150/i })).toBeInTheDocument()
@@ -248,6 +251,113 @@ describe('SceneDetailPage route states', () => {
     )
 
     await waitFor(() => expect(fetchSpy).toHaveBeenCalledWith(buildApiUrl('/scenes/12/views'), expect.any(Object)))
+  })
+
+  it('loads comments and supports replies and comment voting', async () => {
+    storeSceneDetailSession()
+
+    const user = userEvent.setup()
+    const storedUser = buildSceneDetailStoredUser()
+    const sceneResponse = buildSceneDetailResponse({
+      tags: [],
+    })
+    const replyResponse = buildSceneCommentResponse({
+      authorDisplayName: 'Reply Artist',
+      authorUserId: 32,
+      commentId: 502,
+      parentCommentId: 501,
+      text: 'A reply from the crowd.',
+      upvotes: 1,
+    })
+    const topLevelComment = buildSceneCommentResponse({
+      commentId: 501,
+      replies: [replyResponse],
+      replyCount: 1,
+    })
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      if (input === buildApiUrl('/users/me')) {
+        return jsonResponse(storedUser)
+      }
+
+      if (input === buildApiUrl('/scenes/12')) {
+        return jsonResponse(sceneResponse)
+      }
+
+      if (input === buildApiUrl('/scenes')) {
+        return jsonResponse([sceneResponse])
+      }
+
+      if (input === buildApiUrl('/scenes/12/comments')) {
+        if (init?.method === 'POST') {
+          const payload = JSON.parse(String(init.body)) as Record<string, unknown>
+
+          expect(payload).toEqual({
+            parentCommentId: 501,
+            text: 'New reply from UI',
+          })
+
+          return jsonResponse(
+            buildSceneCommentResponse({
+              authorDisplayName: storedUser.displayName,
+              authorUserId: storedUser.userId,
+              commentId: 503,
+              parentCommentId: 501,
+              text: 'New reply from UI',
+            }),
+          )
+        }
+
+        return jsonResponse([topLevelComment])
+      }
+
+      if (input === buildApiUrl('/scenes/12/comments/501/vote')) {
+        if (init?.method === 'DELETE') {
+          return jsonResponse(topLevelComment)
+        }
+
+        expect(init?.method).toBe('PUT')
+        expect(init?.body).toBe(JSON.stringify({ vote: 'up' }))
+
+        return jsonResponse({
+          ...topLevelComment,
+          currentUserVote: 'up',
+          upvotes: 3,
+        })
+      }
+
+      throw new Error(`Unexpected request: ${String(input)}`)
+    })
+
+    renderSceneDetailPage()
+
+    expect(await screen.findByText('This scene has a great pulse.')).toBeInTheDocument()
+    expect(screen.getByText('A reply from the crowd.')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /upvote 2/i }))
+    expect(await screen.findByRole('button', { name: /upvote 3/i })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+
+    await user.click(screen.getByRole('button', { name: /upvote 3/i }))
+    expect(await screen.findByRole('button', { name: /upvote 2/i })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    )
+
+    await user.click(screen.getByRole('button', { name: /^reply$/i }))
+
+    const replyTextbox = screen.getByRole('textbox', { name: /reply to comment artist/i })
+    await user.type(replyTextbox, 'New reply from UI')
+
+    const replyForm = replyTextbox.closest('form')
+
+    expect(replyForm).not.toBeNull()
+
+    await user.click(within(replyForm as HTMLFormElement).getByRole('button', { name: /^reply$/i }))
+
+    expect(await screen.findByText('New reply from UI')).toBeInTheDocument()
   })
 
   it('shows an empty description state when no description is stored', async () => {

--- a/src/modules/scene-detail/SceneDetailPage.tsx
+++ b/src/modules/scene-detail/SceneDetailPage.tsx
@@ -2,13 +2,16 @@ import { useEffect, useRef, useState, type CSSProperties } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useAuth } from '@auth'
 import { MagePlayer } from '@modules/player'
-import { buildSceneComments } from './fixtures'
 import {
+  clearSceneCommentVote,
   clearSceneVote,
+  createSceneComment,
   fetchRecommendedSceneGroups,
+  fetchSceneComments,
   fetchSceneDetail,
   recordSceneView,
   SceneDetailRequestError,
+  updateSceneCommentVote,
   updateSceneSave,
   updateSceneVote,
 } from './loaders'
@@ -17,6 +20,7 @@ import { readErrorCopy, readInitial, readSceneId } from './selectors'
 import type {
   RecommendationFilter,
   RecommendedSceneGroups,
+  SceneComment,
   SceneDetail,
   SceneDetailErrorCode,
   SceneEngagementSummary,
@@ -26,6 +30,61 @@ import { SceneCommentsPanel, SceneDescriptionCard, SceneDetailState, SceneRecomm
 import { useScenePlaylistState } from './useScenePlaylistState'
 import { buildCreatorProfile, buildSceneDescription, buildSceneEngagement } from './viewModels'
 
+function mergeSceneCommentUpdate(currentComment: SceneComment, updatedComment: SceneComment) {
+  const preservedReplies =
+    updatedComment.replies.length > 0 ? updatedComment.replies : currentComment.replies
+
+  return {
+    ...updatedComment,
+    replies: preservedReplies,
+    replyCount: Math.max(updatedComment.replyCount, preservedReplies.length),
+  }
+}
+
+function appendSceneComment(comments: SceneComment[], nextComment: SceneComment): SceneComment[] {
+  if (nextComment.parentCommentId === null) {
+    return [...comments, nextComment]
+  }
+
+  return comments.map((comment) => {
+    if (comment.commentId === nextComment.parentCommentId) {
+      const replies = [...comment.replies, nextComment]
+
+      return {
+        ...comment,
+        replies,
+        replyCount: Math.max(comment.replyCount + 1, replies.length),
+      }
+    }
+
+    if (comment.replies.length === 0) {
+      return comment
+    }
+
+    return {
+      ...comment,
+      replies: appendSceneComment(comment.replies, nextComment),
+    }
+  })
+}
+
+function replaceSceneComment(comments: SceneComment[], updatedComment: SceneComment): SceneComment[] {
+  return comments.map((comment) => {
+    if (comment.commentId === updatedComment.commentId) {
+      return mergeSceneCommentUpdate(comment, updatedComment)
+    }
+
+    if (comment.replies.length === 0) {
+      return comment
+    }
+
+    return {
+      ...comment,
+      replies: replaceSceneComment(comment.replies, updatedComment),
+    }
+  })
+}
+
 export function SceneDetailPage() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
@@ -34,6 +93,13 @@ export function SceneDetailPage() {
   const [errorCode, setErrorCode] = useState<SceneDetailErrorCode | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [engagementActionError, setEngagementActionError] = useState<string | null>(null)
+  const [comments, setComments] = useState<SceneComment[]>([])
+  const [isCommentsLoading, setIsCommentsLoading] = useState(false)
+  const [commentsError, setCommentsError] = useState<string | null>(null)
+  const [commentActionError, setCommentActionError] = useState<string | null>(null)
+  const [isSubmittingComment, setIsSubmittingComment] = useState(false)
+  const [submittingReplyCommentId, setSubmittingReplyCommentId] = useState<number | null>(null)
+  const [pendingCommentVoteId, setPendingCommentVoteId] = useState<number | null>(null)
   const [recommendedSceneGroups, setRecommendedSceneGroups] = useState<RecommendedSceneGroups>(
     createEmptyRecommendedSceneGroups(),
   )
@@ -42,6 +108,7 @@ export function SceneDetailPage() {
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
   const recordedViewSceneIds = useRef<Set<number>>(new Set())
   const sceneId = readSceneId(id)
+  const loadedSceneId = scene?.id ?? null
   const {
     handlePlaylistChange,
     handleRemoveTrack,
@@ -106,7 +173,11 @@ export function SceneDetailPage() {
     setIsDescriptionExpanded(false)
     setRecommendationFilter('all')
     setEngagementActionError(null)
-  }, [scene?.id])
+    setCommentActionError(null)
+    setCommentsError(null)
+    setPendingCommentVoteId(null)
+    setSubmittingReplyCommentId(null)
+  }, [loadedSceneId])
 
   useEffect(() => {
     if (!scene || recordedViewSceneIds.current.has(scene.id)) {
@@ -146,6 +217,54 @@ export function SceneDetailPage() {
       isCurrent = false
     }
   }, [authenticatedFetch, isAuthenticated, scene])
+
+  useEffect(() => {
+    if (loadedSceneId === null) {
+      setComments([])
+      setIsCommentsLoading(false)
+      setCommentsError(null)
+      return
+    }
+
+    const currentSceneId = loadedSceneId
+    let isCurrent = true
+
+    async function loadComments() {
+      setIsCommentsLoading(true)
+      setCommentsError(null)
+
+      try {
+        const nextComments = await fetchSceneComments(
+          authenticatedFetch,
+          isAuthenticated,
+          currentSceneId,
+        )
+
+        if (!isCurrent) {
+          return
+        }
+
+        setComments(nextComments)
+      } catch {
+        if (!isCurrent) {
+          return
+        }
+
+        setComments([])
+        setCommentsError('Unable to load comments right now.')
+      } finally {
+        if (isCurrent) {
+          setIsCommentsLoading(false)
+        }
+      }
+    }
+
+    void loadComments()
+
+    return () => {
+      isCurrent = false
+    }
+  }, [authenticatedFetch, isAuthenticated, loadedSceneId])
 
   useEffect(() => {
     if (!scene) {
@@ -261,7 +380,6 @@ export function SceneDetailPage() {
   const creatorProfile = buildCreatorProfile(loadedScene, user?.displayName, user?.userId)
   const engagement = buildSceneEngagement(loadedScene)
   const sceneDescription = buildSceneDescription(loadedScene)
-  const sceneComments = buildSceneComments()
   const filteredRecommendedScenes = selectRecommendedScenes(
     recommendedSceneGroups,
     recommendationFilter,
@@ -314,6 +432,93 @@ export function SceneDetailPage() {
     void runAuthenticatedEngagementAction(() =>
       updateSceneSave(authenticatedFetch, loadedScene.id, !engagement.currentUserSaved),
     )
+  }
+
+  async function handleSubmitComment(text: string, parentCommentId: number | null = null) {
+    const trimmedText = text.trim()
+
+    if (!trimmedText) {
+      return false
+    }
+
+    if (!isAuthenticated) {
+      navigate('/login')
+      return false
+    }
+
+    setCommentActionError(null)
+
+    if (parentCommentId === null) {
+      setIsSubmittingComment(true)
+    } else {
+      setSubmittingReplyCommentId(parentCommentId)
+    }
+
+    try {
+      const createdComment = await createSceneComment(
+        authenticatedFetch,
+        loadedScene.id,
+        trimmedText,
+        parentCommentId,
+      )
+
+      setComments((currentComments) => appendSceneComment(currentComments, createdComment))
+      return true
+    } catch (error) {
+      if (error instanceof SceneDetailRequestError && error.code === 'auth-required') {
+        navigate('/login')
+        return false
+      }
+
+      setCommentActionError(
+        parentCommentId === null
+          ? 'Unable to post this comment right now.'
+          : 'Unable to post this reply right now.',
+      )
+      return false
+    } finally {
+      if (parentCommentId === null) {
+        setIsSubmittingComment(false)
+      } else {
+        setSubmittingReplyCommentId(null)
+      }
+    }
+  }
+
+  function handleCommentVoteClick(comment: SceneComment, vote: SceneVoteState) {
+    if (!isAuthenticated) {
+      navigate('/login')
+      return
+    }
+
+    if (pendingCommentVoteId !== null) {
+      return
+    }
+
+    setCommentActionError(null)
+    setPendingCommentVoteId(comment.commentId)
+
+    async function updateCommentVote() {
+      try {
+        const updatedComment =
+          comment.currentUserVote === vote
+            ? await clearSceneCommentVote(authenticatedFetch, loadedScene.id, comment.commentId)
+            : await updateSceneCommentVote(authenticatedFetch, loadedScene.id, comment.commentId, vote)
+
+        setComments((currentComments) => replaceSceneComment(currentComments, updatedComment))
+      } catch (error) {
+        if (error instanceof SceneDetailRequestError && error.code === 'auth-required') {
+          navigate('/login')
+          return
+        }
+
+        setCommentActionError('Unable to update this comment vote right now.')
+      } finally {
+        setPendingCommentVoteId(null)
+      }
+    }
+
+    void updateCommentVote()
   }
 
   return (
@@ -417,9 +622,21 @@ export function SceneDetailPage() {
           />
 
           <SceneCommentsPanel
-            comments={sceneComments}
+            actionError={commentActionError}
+            comments={comments}
             composerInitial={composerInitial}
             composerPrompt={composerPrompt}
+            isAuthenticated={isAuthenticated}
+            isLoading={isCommentsLoading}
+            isSubmittingComment={isSubmittingComment}
+            loadingError={commentsError}
+            pendingVoteCommentId={pendingCommentVoteId}
+            submittingReplyCommentId={submittingReplyCommentId}
+            onRequestSignIn={() => {
+              navigate('/login')
+            }}
+            onSubmitComment={handleSubmitComment}
+            onVoteComment={handleCommentVoteClick}
           />
         </div>
 

--- a/src/modules/scene-detail/dto.ts
+++ b/src/modules/scene-detail/dto.ts
@@ -1,5 +1,5 @@
 import { normalizeSceneListEngagement } from '@shared/lib'
-import type { SceneDetail, SceneEngagementSummary, SceneVoteState } from './types'
+import type { SceneComment, SceneDetail, SceneEngagementSummary, SceneVoteState } from './types'
 
 type SceneDetailResponse = {
   sceneId?: number
@@ -21,6 +21,21 @@ type SceneEngagementResponse = {
   saves?: unknown
   currentUserVote?: unknown
   currentUserSaved?: unknown
+}
+
+type SceneCommentResponse = {
+  commentId?: unknown
+  sceneId?: unknown
+  parentCommentId?: unknown
+  authorUserId?: unknown
+  authorDisplayName?: unknown
+  text?: unknown
+  createdAt?: unknown
+  replyCount?: unknown
+  upvotes?: unknown
+  downvotes?: unknown
+  currentUserVote?: unknown
+  replies?: unknown
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -50,6 +65,69 @@ function normalizeSceneTags(tags: unknown) {
 
 function normalizeCurrentUserVote(value: unknown): SceneVoteState | null {
   return value === 'up' || value === 'down' ? value : null
+}
+
+function normalizeCount(value: unknown) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    return 0
+  }
+
+  return Math.trunc(value)
+}
+
+export function normalizeSceneComment(payload: unknown): SceneComment | null {
+  if (!isRecord(payload)) {
+    return null
+  }
+
+  const resolvedPayload = payload as SceneCommentResponse
+  const commentId = typeof resolvedPayload.commentId === 'number' ? resolvedPayload.commentId : null
+  const sceneId = typeof resolvedPayload.sceneId === 'number' ? resolvedPayload.sceneId : null
+  const text = typeof resolvedPayload.text === 'string' ? resolvedPayload.text.trim() : ''
+
+  if (commentId === null || sceneId === null || !text) {
+    return null
+  }
+
+  const replies = normalizeSceneComments(resolvedPayload.replies)
+
+  return {
+    commentId,
+    sceneId,
+    parentCommentId:
+      typeof resolvedPayload.parentCommentId === 'number' ? resolvedPayload.parentCommentId : null,
+    authorUserId: typeof resolvedPayload.authorUserId === 'number' ? resolvedPayload.authorUserId : null,
+    authorDisplayName:
+      typeof resolvedPayload.authorDisplayName === 'string' && resolvedPayload.authorDisplayName.trim()
+        ? resolvedPayload.authorDisplayName.trim()
+        : 'Mage user',
+    createdAt:
+      typeof resolvedPayload.createdAt === 'string' && resolvedPayload.createdAt.trim()
+        ? resolvedPayload.createdAt
+        : null,
+    text,
+    replyCount: Math.max(normalizeCount(resolvedPayload.replyCount), replies.length),
+    upvotes: normalizeCount(resolvedPayload.upvotes),
+    downvotes: normalizeCount(resolvedPayload.downvotes),
+    currentUserVote: normalizeCurrentUserVote(resolvedPayload.currentUserVote),
+    replies,
+  }
+}
+
+export function normalizeSceneComments(payload: unknown): SceneComment[] {
+  if (!Array.isArray(payload)) {
+    return []
+  }
+
+  return payload.reduce<SceneComment[]>((comments, item) => {
+    const comment = normalizeSceneComment(item)
+
+    if (comment) {
+      comments.push(comment)
+    }
+
+    return comments
+  }, [])
 }
 
 export function normalizeSceneEngagement(engagement: unknown): SceneEngagementSummary {

--- a/src/modules/scene-detail/loaders.ts
+++ b/src/modules/scene-detail/loaders.ts
@@ -1,5 +1,10 @@
 import { buildApiUrl, fetchScenes } from '@shared/lib'
-import { normalizeSceneDetail, normalizeSceneEngagement } from './dto'
+import {
+  normalizeSceneComment,
+  normalizeSceneComments,
+  normalizeSceneDetail,
+  normalizeSceneEngagement,
+} from './dto'
 import { buildRecommendedSceneGroups } from './recommendations'
 import type {
   AuthenticatedFetch,
@@ -7,6 +12,7 @@ import type {
   SceneDetail,
   SceneDetailErrorCode,
   SceneEngagementSummary,
+  SceneComment,
   SceneVoteState,
 } from './types'
 
@@ -70,6 +76,96 @@ async function readSceneEngagementResponse(response: Response): Promise<SceneEng
 
   const payload = await response.json().catch(() => null)
   return normalizeSceneEngagement(payload)
+}
+
+async function readSceneCommentResponse(response: Response): Promise<SceneComment> {
+  if (!response.ok) {
+    throw new SceneDetailRequestError(
+      readErrorCode(response.status),
+      `Scene comment request failed with status ${response.status}.`,
+    )
+  }
+
+  const payload = await response.json().catch(() => null)
+  const comment = normalizeSceneComment(payload)
+
+  if (!comment) {
+    throw new SceneDetailRequestError(
+      'invalid-payload',
+      'Scene comment response is missing required fields.',
+    )
+  }
+
+  return comment
+}
+
+export async function fetchSceneComments(
+  authenticatedFetch: AuthenticatedFetch,
+  isAuthenticated: boolean,
+  sceneId: number,
+) {
+  const response = isAuthenticated
+    ? await authenticatedFetch(`/scenes/${sceneId}/comments`)
+    : await fetch(buildApiUrl(`/scenes/${sceneId}/comments`))
+
+  if (!response.ok) {
+    throw new SceneDetailRequestError(
+      readErrorCode(response.status),
+      `Scene comments request failed with status ${response.status}.`,
+    )
+  }
+
+  const payload = await response.json().catch(() => [])
+  return normalizeSceneComments(payload)
+}
+
+export async function createSceneComment(
+  authenticatedFetch: AuthenticatedFetch,
+  sceneId: number,
+  text: string,
+  parentCommentId?: number | null,
+) {
+  const response = await authenticatedFetch(`/scenes/${sceneId}/comments`, {
+    body: JSON.stringify({
+      text,
+      parentCommentId: parentCommentId ?? null,
+    }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    method: 'POST',
+  })
+
+  return readSceneCommentResponse(response)
+}
+
+export async function updateSceneCommentVote(
+  authenticatedFetch: AuthenticatedFetch,
+  sceneId: number,
+  commentId: number,
+  vote: SceneVoteState,
+) {
+  const response = await authenticatedFetch(`/scenes/${sceneId}/comments/${commentId}/vote`, {
+    body: JSON.stringify({ vote }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    method: 'PUT',
+  })
+
+  return readSceneCommentResponse(response)
+}
+
+export async function clearSceneCommentVote(
+  authenticatedFetch: AuthenticatedFetch,
+  sceneId: number,
+  commentId: number,
+) {
+  const response = await authenticatedFetch(`/scenes/${sceneId}/comments/${commentId}/vote`, {
+    method: 'DELETE',
+  })
+
+  return readSceneCommentResponse(response)
 }
 
 export async function recordSceneView(

--- a/src/modules/scene-detail/test-fixtures.tsx
+++ b/src/modules/scene-detail/test-fixtures.tsx
@@ -50,6 +50,31 @@ export function buildSceneDetailResponse(
   }
 }
 
+export function buildSceneCommentResponse(
+  overrides: Partial<Record<string, unknown>> = {},
+) {
+  const commentId =
+    typeof overrides.commentId === 'number' ? overrides.commentId : 501
+  const sceneId =
+    typeof overrides.sceneId === 'number' ? overrides.sceneId : 12
+
+  return {
+    authorDisplayName: 'Comment Artist',
+    authorUserId: 31,
+    commentId,
+    createdAt: '2026-04-10T14:00:00Z',
+    currentUserVote: null,
+    downvotes: 0,
+    parentCommentId: null,
+    replies: [],
+    replyCount: 0,
+    sceneId,
+    text: 'This scene has a great pulse.',
+    upvotes: 2,
+    ...overrides,
+  }
+}
+
 export function renderSceneDetailPage(initialEntries = ['/scenes/12']) {
   function ScenesRouteProbe() {
     const location = useLocation()

--- a/src/modules/scene-detail/types.ts
+++ b/src/modules/scene-detail/types.ts
@@ -23,12 +23,18 @@ export type SceneDetailErrorCode =
   | 'unavailable'
 
 export type SceneComment = {
-  author: string
-  handle: string
-  posted: string
+  commentId: number
+  sceneId: number
+  parentCommentId: number | null
+  authorUserId: number | null
+  authorDisplayName: string
+  createdAt: string | null
   text: string
-  upvotes: string
-  downvotes: string
+  replyCount: number
+  upvotes: number
+  downvotes: number
+  currentUserVote: SceneVoteState | null
+  replies: SceneComment[]
 }
 
 export type CreatorProfile = {

--- a/src/modules/scene-detail/ui/SceneCommentsPanel.tsx
+++ b/src/modules/scene-detail/ui/SceneCommentsPanel.tsx
@@ -1,24 +1,222 @@
+import { useState, type FormEvent } from 'react'
+import { formatCompactCount, formatRelativeTime } from '@shared/lib'
 import { readInitial } from '../selectors'
-import type { SceneComment } from '../types'
+import type { SceneComment, SceneVoteState } from '../types'
 import { VoteButton } from './VoteButton'
 
 type SceneCommentsPanelProps = {
+  actionError: string | null
   composerInitial: string
   composerPrompt: string
   comments: SceneComment[]
+  isAuthenticated: boolean
+  isLoading: boolean
+  isSubmittingComment: boolean
+  loadingError: string | null
+  pendingVoteCommentId: number | null
+  submittingReplyCommentId: number | null
+  onRequestSignIn: () => void
+  onSubmitComment: (text: string, parentCommentId?: number | null) => Promise<boolean>
+  onVoteComment: (comment: SceneComment, vote: SceneVoteState) => void
+}
+
+function countComments(comments: SceneComment[]): number {
+  return comments.reduce((count, comment) => count + 1 + countComments(comment.replies), 0)
+}
+
+function buildCommentHandle(comment: SceneComment) {
+  const slug = comment.authorDisplayName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '')
+
+  if (slug) {
+    return `@${slug}`
+  }
+
+  return comment.authorUserId ? `@user${comment.authorUserId}` : '@mageuser'
+}
+
+function formatCommentTimestamp(createdAt: string | null) {
+  return createdAt ? formatRelativeTime(createdAt) : 'Recently'
 }
 
 export function SceneCommentsPanel({
+  actionError,
   composerInitial,
   composerPrompt,
   comments,
+  isAuthenticated,
+  isLoading,
+  isSubmittingComment,
+  loadingError,
+  pendingVoteCommentId,
+  submittingReplyCommentId,
+  onRequestSignIn,
+  onSubmitComment,
+  onVoteComment,
 }: SceneCommentsPanelProps) {
+  const [commentDraft, setCommentDraft] = useState('')
+  const [activeReplyCommentId, setActiveReplyCommentId] = useState<number | null>(null)
+  const [replyDrafts, setReplyDrafts] = useState<Record<number, string>>({})
+  const commentsCount = countComments(comments)
+  const trimmedCommentDraft = commentDraft.trim()
+
+  async function handleSubmitComment(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    if (!trimmedCommentDraft) {
+      return
+    }
+
+    const wasCreated = await onSubmitComment(trimmedCommentDraft)
+
+    if (wasCreated) {
+      setCommentDraft('')
+    }
+  }
+
+  async function handleSubmitReply(event: FormEvent<HTMLFormElement>, comment: SceneComment) {
+    event.preventDefault()
+
+    const replyDraft = replyDrafts[comment.commentId]?.trim() ?? ''
+
+    if (!replyDraft) {
+      return
+    }
+
+    const wasCreated = await onSubmitComment(replyDraft, comment.commentId)
+
+    if (wasCreated) {
+      setReplyDrafts((currentDrafts) => ({
+        ...currentDrafts,
+        [comment.commentId]: '',
+      }))
+      setActiveReplyCommentId(null)
+    }
+  }
+
+  function renderComment(comment: SceneComment, isReply = false) {
+    const replyDraft = replyDrafts[comment.commentId] ?? ''
+    const trimmedReplyDraft = replyDraft.trim()
+    const isReplyFormOpen = activeReplyCommentId === comment.commentId
+    const isReplySubmitting = submittingReplyCommentId === comment.commentId
+    const isVotePending = pendingVoteCommentId === comment.commentId
+
+    return (
+      <article
+        key={comment.commentId}
+        className={`mage-comment${isReply ? ' mage-comment--reply' : ''}`}
+      >
+        <div className="mage-comment__avatar" aria-hidden="true">
+          {readInitial(comment.authorDisplayName)}
+        </div>
+        <div className="mage-comment__body">
+          <div className="scene-detail-comment__header">
+            <strong>{comment.authorDisplayName}</strong>
+            <span>{buildCommentHandle(comment)}</span>
+            <span>{formatCommentTimestamp(comment.createdAt)}</span>
+          </div>
+          <p>{comment.text}</p>
+          <div className="scene-detail-comment__actions">
+            <VoteButton
+              className="scene-detail-comment__action"
+              count={formatCompactCount(comment.upvotes)}
+              direction="up"
+              disabled={isVotePending}
+              isSelected={comment.currentUserVote === 'up'}
+              onClick={() => {
+                onVoteComment(comment, 'up')
+              }}
+            />
+            <VoteButton
+              className="scene-detail-comment__action"
+              count={formatCompactCount(comment.downvotes)}
+              direction="down"
+              disabled={isVotePending}
+              isSelected={comment.currentUserVote === 'down'}
+              onClick={() => {
+                onVoteComment(comment, 'down')
+              }}
+            />
+            {!isReply ? (
+              <button
+                className="scene-detail-comment__action"
+                onClick={() => {
+                  if (!isAuthenticated) {
+                    onRequestSignIn()
+                    return
+                  }
+
+                  setActiveReplyCommentId((currentCommentId) =>
+                    currentCommentId === comment.commentId ? null : comment.commentId,
+                  )
+                }}
+                type="button"
+              >
+                Reply
+              </button>
+            ) : null}
+          </div>
+
+          {!isReply && isReplyFormOpen ? (
+            <form
+              className="scene-detail-reply-composer"
+              onSubmit={(event) => {
+                void handleSubmitReply(event, comment)
+              }}
+            >
+              <textarea
+                aria-label={`Reply to ${comment.authorDisplayName}`}
+                className="scene-detail-comment-composer__textarea"
+                maxLength={2000}
+                onChange={(event) => {
+                  setReplyDrafts((currentDrafts) => ({
+                    ...currentDrafts,
+                    [comment.commentId]: event.target.value,
+                  }))
+                }}
+                placeholder={`Reply to ${comment.authorDisplayName}...`}
+                rows={2}
+                value={replyDraft}
+              />
+              <div className="scene-detail-comment-form__actions">
+                <button
+                  className="scene-detail-comment-cancel-button"
+                  onClick={() => {
+                    setActiveReplyCommentId(null)
+                  }}
+                  type="button"
+                >
+                  Cancel
+                </button>
+                <button
+                  className="scene-detail-comment-submit-button"
+                  disabled={!trimmedReplyDraft || isReplySubmitting}
+                  type="submit"
+                >
+                  {isReplySubmitting ? 'Replying...' : 'Reply'}
+                </button>
+              </div>
+            </form>
+          ) : null}
+
+          {!isReply && comment.replies.length > 0 ? (
+            <div className="mage-comment__replies">
+              {comment.replies.map((reply) => renderComment(reply, true))}
+            </div>
+          ) : null}
+        </div>
+      </article>
+    )
+  }
+
   return (
     <section className="scene-detail-comments-panel">
       <div className="scene-detail-comments-toolbar">
         <div className="mage-comments__header">
           <h2>Comments</h2>
-          <span>{comments.length}</span>
+          <span>{commentsCount}</span>
         </div>
         <button className="scene-detail-sort-chip" type="button">
           Top comments
@@ -29,44 +227,56 @@ export function SceneCommentsPanel({
         <div className="scene-detail-comment-composer__avatar" aria-hidden="true">
           {composerInitial}
         </div>
-        <div className="scene-detail-comment-composer__field">
-          <span>{composerPrompt}</span>
-        </div>
+        {isAuthenticated ? (
+          <form className="scene-detail-comment-form" onSubmit={handleSubmitComment}>
+            <textarea
+              aria-label="Add a public comment"
+              className="scene-detail-comment-composer__textarea"
+              maxLength={2000}
+              onChange={(event) => {
+                setCommentDraft(event.target.value)
+              }}
+              placeholder={composerPrompt}
+              rows={2}
+              value={commentDraft}
+            />
+            <div className="scene-detail-comment-form__actions">
+              <button
+                className="scene-detail-comment-submit-button"
+                disabled={!trimmedCommentDraft || isSubmittingComment}
+                type="submit"
+              >
+                {isSubmittingComment ? 'Commenting...' : 'Comment'}
+              </button>
+            </div>
+          </form>
+        ) : (
+          <button
+            className="scene-detail-comment-composer__field scene-detail-comment-composer__field--button"
+            onClick={onRequestSignIn}
+            type="button"
+          >
+            {composerPrompt}
+          </button>
+        )}
       </div>
 
-      {comments.length > 0 ? (
-        <div className="mage-comments__list">
-          {comments.map((comment) => (
-            <article key={`${comment.author}-${comment.posted}`} className="mage-comment">
-              <div className="mage-comment__avatar" aria-hidden="true">
-                {readInitial(comment.author)}
-              </div>
-              <div className="mage-comment__body">
-                <div className="scene-detail-comment__header">
-                  <strong>{comment.author}</strong>
-                  <span>{comment.handle}</span>
-                  <span>{comment.posted}</span>
-                </div>
-                <p>{comment.text}</p>
-                <div className="scene-detail-comment__actions">
-                  <VoteButton
-                    className="scene-detail-comment__action"
-                    count={comment.upvotes}
-                    direction="up"
-                  />
-                  <VoteButton
-                    className="scene-detail-comment__action"
-                    count={comment.downvotes}
-                    direction="down"
-                  />
-                  <button className="scene-detail-comment__action" type="button">
-                    Reply
-                  </button>
-                </div>
-              </div>
-            </article>
-          ))}
-        </div>
+      {actionError ? (
+        <p className="scene-detail-comments-status" role="status">
+          {actionError}
+        </p>
+      ) : null}
+
+      {isLoading ? (
+        <p className="scene-detail-comments-status" role="status">
+          Loading comments...
+        </p>
+      ) : loadingError ? (
+        <p className="scene-detail-comments-status" role="status">
+          {loadingError}
+        </p>
+      ) : comments.length > 0 ? (
+        <div className="mage-comments__list">{comments.map((comment) => renderComment(comment))}</div>
       ) : (
         <p className="scene-detail-comments-empty">No comments yet.</p>
       )}

--- a/src/modules/scene-detail/ui/VoteButton.tsx
+++ b/src/modules/scene-detail/ui/VoteButton.tsx
@@ -23,12 +23,14 @@ function DownvoteIcon() {
 export function VoteButton({
   className,
   count,
+  disabled = false,
   direction,
   isSelected = false,
   onClick,
 }: {
   className: string
   count: string
+  disabled?: boolean
   direction: 'up' | 'down'
   isSelected?: boolean
   onClick?: () => void
@@ -41,6 +43,7 @@ export function VoteButton({
       aria-label={`${label} ${count}`}
       aria-pressed={isSelected}
       className={`${className}${isSelected ? ' is-selected' : ''}`}
+      disabled={disabled}
       onClick={onClick}
       type="button"
     >


### PR DESCRIPTION
## Summary

- Add typed scene comment API loaders and response normalization.
- Load live comments on the scene detail page.
- Support posting top-level comments and replies.
- Support comment upvote/downvote, vote switching, and vote clearing.
- Add interactive comment composer, reply composer, loading/error states, and selected vote styling.
- Update My Scenes comments column to use real backend comment totals, including replies.

## Testing

- `npm run lint`
- `npm test`
- `npm run build`

Build passes with the existing Vite warnings for `@notrac/mage` eval usage and large chunks.
****