### PR TITLE
Frontend edit scenes from my scenes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1934,31 +1934,86 @@
 
 .my-scenes-row__title-link:focus-visible,
 .my-scenes-row__thumb-link:focus-visible,
-.my-scenes-row__description:focus-visible {
+.my-scenes-row__menu-button:focus-visible {
   outline: none;
 }
 
+.my-scenes-row__description-slot {
+  position: relative;
+  display: grid;
+  align-items: center;
+  min-height: 32px;
+  min-width: 0;
+}
+
 .my-scenes-row__description {
-  width: fit-content;
+  display: block;
   max-width: 100%;
   padding: 0;
-  border: 0;
-  background: transparent;
   color: var(--table-description-color);
   font-size: 0.88rem;
   line-height: 1.45;
   text-align: left;
-  cursor: pointer;
   text-decoration: none;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  transition:
+    opacity 160ms ease,
+    transform 160ms ease,
+    color 160ms ease;
 }
 
-.my-scenes-row__description:hover,
-.my-scenes-row__description:focus-visible {
+.my-scenes-row__menu {
+  position: absolute;
+  inset: 0 auto 0 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(2px);
+  transition:
+    opacity 160ms ease,
+    transform 160ms ease;
+}
+
+.my-scenes-row:hover .my-scenes-row__description,
+.my-scenes-row:focus-within .my-scenes-row__description {
+  opacity: 0;
+  transform: translateY(-2px);
+}
+
+.my-scenes-row:hover .my-scenes-row__menu,
+.my-scenes-row:focus-within .my-scenes-row__menu {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.my-scenes-row__menu-button {
+  display: inline-grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: 1px solid var(--table-status-border);
+  background: var(--table-status-background);
+  color: var(--table-description-color);
+  text-decoration: none;
+  box-shadow: var(--table-thumbnail-shadow);
+}
+
+.my-scenes-row__menu-button:hover,
+.my-scenes-row__menu-button:focus-visible {
+  border-color: var(--table-thumbnail-border);
+  background: var(--table-thumbnail-background);
   color: var(--table-description-hover-color);
-  text-decoration: underline;
+}
+
+.my-scenes-row__menu-button svg {
+  width: 17px;
+  height: 17px;
 }
 
 .my-scenes-row__cell span {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -37,6 +37,7 @@ vi.mock('@modules/scene-detail', () => ({
 
 vi.mock('@modules/scene-editor', () => ({
   CreateScenePage: () => <div>Create scene page</div>,
+  EditScenePage: () => <div>Edit scene page</div>,
 }))
 
 vi.mock('@modules/settings', () => ({

--- a/src/app/routes/AppRoutes.tsx
+++ b/src/app/routes/AppRoutes.tsx
@@ -4,7 +4,7 @@ import { GuestOnlyRoute, LoginPage, RegisterPage } from '@modules/auth'
 import { ScenesPage } from '@modules/discovery'
 import { HomePage } from '@modules/home'
 import { MyScenesPage } from '@modules/my-scenes'
-import { CreateScenePage } from '@modules/scene-editor'
+import { CreateScenePage, EditScenePage } from '@modules/scene-editor'
 import { SceneDetailPage } from '@modules/scene-detail'
 import { SettingsPage } from '@modules/settings'
 import { ProtectedRoute } from '@modules/auth'
@@ -32,6 +32,14 @@ export function AppRoutes() {
           }
         />
         <Route path="/scenes/:id" element={<SceneDetailPage />} />
+        <Route
+          path="/scenes/:id/edit"
+          element={
+            <ProtectedRoute>
+              <EditScenePage />
+            </ProtectedRoute>
+          }
+        />
         <Route
           path="/register"
           element={

--- a/src/modules/my-scenes/MyScenesPage.table.test.tsx
+++ b/src/modules/my-scenes/MyScenesPage.table.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react'
+import { screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { buildApiUrl } from '@shared/lib'
@@ -97,9 +97,15 @@ describe('MyScenesPage table behavior', () => {
     expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Public' })).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: /soft teal bloom with low-end drift\./i }),
+      screen.getByText(/soft teal bloom with low-end drift\./i),
     ).toBeInTheDocument()
-    expect(screen.getAllByRole('button', { name: /add description/i })).toHaveLength(2)
+    expect(screen.getAllByText(/add description/i)).toHaveLength(2)
+    expect(
+      within(screen.getByRole('group', { name: /actions for aurora drift/i })).getByRole(
+        'link',
+        { name: /edit scene/i },
+      ),
+    ).toHaveAttribute('href', '/scenes/1/edit')
     expect(screen.getByAltText('Aurora Drift thumbnail')).toBeInTheDocument()
     expect(screen.getByText('1.2K')).toBeInTheDocument()
     expect(screen.getByText('75%')).toBeInTheDocument()

--- a/src/modules/my-scenes/MyScenesPage.test.tsx
+++ b/src/modules/my-scenes/MyScenesPage.test.tsx
@@ -211,7 +211,7 @@ describe('MyScenesPage states', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(2)
   })
 
-  it('shows an add-description action when no description is stored', async () => {
+  it('shows an edit action when no description is stored', async () => {
     storeMyScenesSession()
 
     const storedUser = buildMyScenesStoredUser()
@@ -247,7 +247,13 @@ describe('MyScenesPage states', () => {
     renderMyScenesPage()
 
     expect(await screen.findByText('Custom Shader Scene')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /add description/i })).toBeInTheDocument()
+    expect(screen.getByText(/add description/i)).toBeInTheDocument()
+    expect(
+      within(screen.getByRole('group', { name: /actions for custom shader scene/i })).getByRole(
+        'link',
+        { name: /edit scene/i },
+      ),
+    ).toHaveAttribute('href', '/scenes/31/edit')
     expect(screen.queryByText(/let size = input/i)).not.toBeInTheDocument()
   })
 })

--- a/src/modules/my-scenes/ui/MyScenesTable.tsx
+++ b/src/modules/my-scenes/ui/MyScenesTable.tsx
@@ -44,6 +44,26 @@ function SortButton({
   )
 }
 
+function EditSceneIcon() {
+  return (
+    <svg aria-hidden="true" fill="none" viewBox="0 0 24 24">
+      <path
+        d="M4.75 19.25h3.6L18.7 8.9a2.12 2.12 0 0 0 0-3L18.1 5.3a2.12 2.12 0 0 0-3 0L4.75 15.65v3.6Z"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.8"
+      />
+      <path
+        d="m13.75 6.65 3.6 3.6"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="1.8"
+      />
+    </svg>
+  )
+}
+
 export function MyScenesTable({
   allPageScenesSelected,
   pagedScenes,
@@ -132,9 +152,25 @@ export function MyScenesTable({
                 <Link className="my-scenes-row__title-link" to={`/scenes/${scene.id}`}>
                   <strong>{scene.name}</strong>
                 </Link>
-                <button className="my-scenes-row__description" type="button">
-                  {scene.description ?? 'Add description'}
-                </button>
+                <div className="my-scenes-row__description-slot">
+                  <span className="my-scenes-row__description">
+                    {scene.description ?? 'Add description'}
+                  </span>
+                  <div
+                    aria-label={`Actions for ${scene.name}`}
+                    className="my-scenes-row__menu"
+                    role="group"
+                  >
+                    <Link
+                      aria-label="Edit scene"
+                      className="my-scenes-row__menu-button"
+                      title="Edit scene"
+                      to={`/scenes/${scene.id}/edit`}
+                    >
+                      <EditSceneIcon />
+                    </Link>
+                  </div>
+                </div>
               </div>
             </div>
 

--- a/src/modules/scene-editor/EditScenePage.test.tsx
+++ b/src/modules/scene-editor/EditScenePage.test.tsx
@@ -1,0 +1,214 @@
+import { screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { buildApiUrl } from '@shared/lib'
+import { jsonResponse } from '@shared/test/http'
+import {
+  buildSceneEditorApiScene,
+  mockCreateScenePageFetch,
+  renderEditScenePage,
+  selectExistingTag,
+  storeSceneEditorSession,
+} from './test-fixtures'
+
+const mockCaptureFramePreview = vi.fn(async (): Promise<string | null> => null)
+
+vi.mock('@modules/player', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@modules/player')>()
+  const React = await import('react')
+
+  return {
+    ...actual,
+    MagePlayer: ({
+      initialPlayback,
+      onCaptureFramePreviewChange,
+      sceneBlob,
+    }: {
+      initialPlayback?: string
+      onCaptureFramePreviewChange?: (
+        captureFramePreview: (() => Promise<string | null>) | null,
+      ) => void
+      sceneBlob: unknown
+    }) => {
+      React.useEffect(() => {
+        onCaptureFramePreviewChange?.(
+          sceneBlob ? () => mockCaptureFramePreview() : null,
+        )
+
+        return () => {
+          onCaptureFramePreviewChange?.(null)
+        }
+      }, [onCaptureFramePreviewChange, sceneBlob])
+
+      return (
+        <div data-playback={initialPlayback} data-testid="mage-player">
+          {sceneBlob ? 'preview-ready' : 'no-preview'}
+        </div>
+      )
+    },
+  }
+})
+
+beforeEach(() => {
+  mockCaptureFramePreview.mockReset()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  window.localStorage.clear()
+})
+
+describe('EditScenePage workflow', () => {
+  it('loads the saved scene into the editor and updates details, tags, and thumbnail', async () => {
+    storeSceneEditorSession()
+    mockCaptureFramePreview.mockResolvedValue('data:image/png;base64,dXBkYXRlZA==')
+
+    const scene = buildSceneEditorApiScene({
+      tags: ['ambient'],
+    })
+    let updateSceneBody: Record<string, unknown> | null = null
+    let replaceTagsBody: Record<string, unknown> | null = null
+    let finalizeThumbnailBody: Record<string, unknown> | null = null
+    let replacementUploadRequested = false
+
+    mockCreateScenePageFetch((input, init) => {
+      const method =
+        typeof init?.method === 'string' ? init.method.toUpperCase() : 'GET'
+
+      if (input === buildApiUrl('/scenes/12') && method === 'GET') {
+        return jsonResponse(scene)
+      }
+
+      if (input === buildApiUrl('/scenes/12') && method === 'PUT') {
+        const nextSubmittedBody = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
+        updateSceneBody = nextSubmittedBody
+        return jsonResponse({
+          ...scene,
+          description: nextSubmittedBody.description,
+          name: nextSubmittedBody.name,
+          sceneData: nextSubmittedBody.sceneData,
+        })
+      }
+
+      if (input === buildApiUrl('/scenes/12/tags') && method === 'PUT') {
+        replaceTagsBody = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
+        return jsonResponse([
+          { sceneId: 12, tagId: 1 },
+          { sceneId: 12, tagId: 2 },
+        ])
+      }
+
+      if (input === buildApiUrl('/scenes/12/thumbnail/presign') && method === 'POST') {
+        return jsonResponse({
+          headers: {
+            'Content-Type': 'image/png',
+          },
+          method: 'PUT',
+          objectKey: 'scenes/12/thumbnails/replacement.png',
+          uploadUrl: 'https://upload.example.com/scenes/12/thumbnails/replacement.png',
+        })
+      }
+
+      if (
+        input === 'https://upload.example.com/scenes/12/thumbnails/replacement.png' &&
+        method === 'PUT'
+      ) {
+        replacementUploadRequested = true
+        return new Response(null, { status: 200 })
+      }
+
+      if (input === buildApiUrl('/scenes/12/thumbnail/finalize') && method === 'POST') {
+        finalizeThumbnailBody = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
+        return jsonResponse({
+          ...scene,
+          thumbnailRef: 'https://cdn.example.com/scenes/12/thumbnails/replacement.png',
+        })
+      }
+    })
+
+    const user = userEvent.setup()
+
+    renderEditScenePage()
+
+    expect(await screen.findByRole('heading', { name: /edit scene/i })).toBeInTheDocument()
+    expect(screen.getByLabelText(/scene name/i)).toHaveValue('Aurora Drift')
+    expect(screen.getByLabelText(/description/i)).toHaveValue(
+      'Soft teal bloom with low-end drift.',
+    )
+    expect(screen.getByAltText(/captured thumbnail preview/i)).toHaveAttribute(
+      'src',
+      'thumbnails/scene-12.png',
+    )
+    expect(screen.getByTestId('mage-player')).toHaveAttribute('data-playback', 'playing')
+    expect(screen.queryByRole('button', { name: /create scene/i })).not.toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: /^ambient$/i })).toBeInTheDocument()
+
+    await user.clear(screen.getByLabelText(/scene name/i))
+    await user.type(screen.getByLabelText(/scene name/i), ' Updated Scene ')
+    await user.clear(screen.getByLabelText(/description/i))
+    await user.type(screen.getByLabelText(/description/i), ' Updated from My Scenes. ')
+    await selectExistingTag(user, 'focus-friendly')
+    await user.click(screen.getByRole('button', { name: /capture again/i }))
+    await user.click(screen.getByRole('button', { name: /update scene/i }))
+
+    await waitFor(() =>
+      expect(updateSceneBody).toMatchObject({
+        description: 'Updated from My Scenes.',
+        name: 'Updated Scene',
+        sceneData: {
+          visualizer: {
+            shader: 'nebula',
+          },
+        },
+      }),
+    )
+    await waitFor(() =>
+      expect(finalizeThumbnailBody).toEqual({
+        objectKey: 'scenes/12/thumbnails/replacement.png',
+      }),
+    )
+    expect(replaceTagsBody).toEqual({
+      tagIds: [1, 2],
+    })
+    expect(replacementUploadRequested).toBe(true)
+    expect(mockCaptureFramePreview).toHaveBeenCalledTimes(1)
+    expect(await screen.findByText('My Scenes')).toBeInTheDocument()
+  })
+
+  it('does not clear tags when the initial tag list has not loaded yet', async () => {
+    storeSceneEditorSession()
+
+    const scene = buildSceneEditorApiScene({
+      tags: ['ambient'],
+    })
+    let updateSceneRequested = false
+
+    mockCreateScenePageFetch((input, init) => {
+      const method =
+        typeof init?.method === 'string' ? init.method.toUpperCase() : 'GET'
+
+      if (input === buildApiUrl('/scenes/12') && method === 'GET') {
+        return jsonResponse(scene)
+      }
+
+      if (input === buildApiUrl('/tags') && method === 'GET') {
+        return jsonResponse({ message: 'Tag service unavailable.' }, 500)
+      }
+
+      if (input === buildApiUrl('/scenes/12') && method === 'PUT') {
+        updateSceneRequested = true
+        return jsonResponse(scene)
+      }
+    })
+
+    const user = userEvent.setup()
+
+    renderEditScenePage()
+
+    expect(await screen.findByRole('heading', { name: /edit scene/i })).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /update scene/i }))
+
+    expect(await screen.findAllByText(/failed to fetch tags/i)).not.toHaveLength(0)
+    expect(updateSceneRequested).toBe(false)
+  })
+})

--- a/src/modules/scene-editor/EditScenePage.tsx
+++ b/src/modules/scene-editor/EditScenePage.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useState } from 'react'
+import { Navigate, useNavigate, useParams } from 'react-router-dom'
+import { useAuth } from '@auth'
+import { normalizeSceneListItem, parseApiError, type SceneListResponse } from '@shared/lib'
+import { SceneEditorShell } from './SceneEditorShell'
+
+type EditableScene = SceneListResponse & {
+  tagNames: string[]
+}
+
+function readSceneIdParam(sceneIdParam: string | undefined) {
+  if (!sceneIdParam || !/^\d+$/.test(sceneIdParam)) {
+    return null
+  }
+
+  const sceneId = Number(sceneIdParam)
+  return Number.isSafeInteger(sceneId) && sceneId > 0 ? sceneId : null
+}
+
+function EditSceneState({
+  description,
+  title,
+}: {
+  description: string
+  title: string
+}) {
+  return (
+    <main className="surface surface--hero">
+      <div className="eyebrow">Scene Studio</div>
+      <h1>{title}</h1>
+      <p className="page-lead">{description}</p>
+    </main>
+  )
+}
+
+function normalizeSceneTagNames(payload: unknown) {
+  if (!payload || typeof payload !== 'object' || !Array.isArray((payload as { tags?: unknown }).tags)) {
+    return []
+  }
+
+  return (payload as { tags: unknown[] }).tags
+    .filter((tag): tag is string => typeof tag === 'string' && tag.trim().length > 0)
+    .map((tag) => tag.trim())
+}
+
+export function EditScenePage() {
+  const { authenticatedFetch, isAuthenticated, isRestoringSession, user } = useAuth()
+  const navigate = useNavigate()
+  const { id } = useParams()
+  const sceneId = readSceneIdParam(id)
+  const [scene, setScene] = useState<EditableScene | null>(null)
+  const [errorMessage, setErrorMessage] = useState('')
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    if (isRestoringSession || !isAuthenticated || sceneId === null) {
+      return
+    }
+
+    let isCurrent = true
+
+    async function loadScene() {
+      setIsLoading(true)
+      setErrorMessage('')
+
+      try {
+        const response = await authenticatedFetch(`/scenes/${sceneId}`)
+
+        if (!response.ok) {
+          const apiError = await parseApiError(response)
+          throw new Error(apiError?.message ?? 'Unable to load scene for editing.')
+        }
+
+        const payload = await response.json().catch(() => null)
+        const normalizedScene = normalizeSceneListItem(payload)
+
+        if (!normalizedScene) {
+          throw new Error('Scene response is missing the fields required for editing.')
+        }
+
+        if (
+          typeof user?.userId === 'number' &&
+          normalizedScene.ownerUserId !== user.userId
+        ) {
+          throw new Error('You can only edit scenes created by your account.')
+        }
+
+        if (isCurrent) {
+          setScene({
+            ...normalizedScene,
+            tagNames: normalizeSceneTagNames(payload),
+          })
+        }
+      } catch (error) {
+        if (isCurrent) {
+          setScene(null)
+          setErrorMessage(
+            error instanceof Error && error.message.trim()
+              ? error.message
+              : 'Unable to load scene for editing.',
+          )
+        }
+      } finally {
+        if (isCurrent) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    void loadScene()
+
+    return () => {
+      isCurrent = false
+    }
+  }, [authenticatedFetch, isAuthenticated, isRestoringSession, sceneId, user?.userId])
+
+  if (isRestoringSession) {
+    return (
+      <EditSceneState
+        description="MAGE is restoring your session before opening the editor."
+        title="Loading scene..."
+      />
+    )
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate replace to="/login" />
+  }
+
+  if (sceneId === null) {
+    return (
+      <EditSceneState
+        description="This edit route is missing a valid scene id. Check the URL and try again."
+        title="Unable to edit scene"
+      />
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <EditSceneState
+        description="MAGE is loading the saved scene before opening the editor."
+        title="Loading scene..."
+      />
+    )
+  }
+
+  if (errorMessage || !scene) {
+    return (
+      <EditSceneState
+        description={errorMessage || 'Unable to load scene for editing.'}
+        title="Unable to edit scene"
+      />
+    )
+  }
+
+  return (
+    <SceneEditorShell
+      authenticatedFetch={authenticatedFetch}
+      initialState={{
+        description: scene.description,
+        name: scene.name,
+        sceneData: scene.sceneData,
+        tagNames: scene.tagNames,
+        thumbnailPreviewUrl: scene.thumbnailRef,
+      }}
+      mode={{ sceneId, type: 'edit' }}
+      onComplete={() => navigate('/my-scenes')}
+    />
+  )
+}

--- a/src/modules/scene-editor/SceneEditorShell.tsx
+++ b/src/modules/scene-editor/SceneEditorShell.tsx
@@ -463,6 +463,7 @@ export function SceneEditorShell({
     description,
     isCameraAdvancedEnabled,
     isMotionAdvancedEnabled,
+    mode,
     name,
     onComplete,
     pendingTagAttachment,
@@ -472,6 +473,8 @@ export function SceneEditorShell({
     setErrors,
     setIsSubmitting,
     setPendingTagAttachment,
+    tagsError,
+    tagsLoading,
     thumbnailFile,
   });
 

--- a/src/modules/scene-editor/SceneEditorShell.tsx
+++ b/src/modules/scene-editor/SceneEditorShell.tsx
@@ -36,6 +36,7 @@ import { SceneEditorStepper } from "./ui/SceneEditorStepper";
 import { useSceneEditorPreview } from "./useSceneEditorPreview";
 import { useSceneEditorState } from "./useSceneEditorState";
 import { useSceneEditorSubmission } from "./useSceneEditorSubmission";
+import type { SceneEditorInitialState, SceneEditorSubmissionMode } from "./types";
 import {
   buildCapturedThumbnailFile,
   describePassState,
@@ -52,13 +53,18 @@ function formatDegrees(value: number) {
 
 type SceneEditorShellProps = {
   authenticatedFetch: AuthenticatedFetch;
+  initialState?: SceneEditorInitialState;
+  mode?: SceneEditorSubmissionMode;
   onComplete: () => void;
 };
 
 export function SceneEditorShell({
   authenticatedFetch,
+  initialState,
+  mode = { type: "create" },
   onComplete,
 }: SceneEditorShellProps) {
+  const isEditMode = mode.type === "edit";
   const {
     actionBarSentinelRef,
     availableTags,
@@ -120,7 +126,11 @@ export function SceneEditorShell({
     titleId,
     toggleTagSelection,
     updateBranch,
-  } = useSceneEditorState({ authenticatedFetch });
+  } = useSceneEditorState({
+    authenticatedFetch,
+    initialState,
+    titleId: isEditMode ? "edit-scene-title" : "create-scene-title",
+  });
   const {
     previewSceneData,
     sceneModel,
@@ -472,9 +482,13 @@ export function SceneEditorShell({
       titleId={titleId}
     >
       <AuthPageHeader
-        description="Build a scene with curated controls and effect shaping."
+        description={
+          isEditMode
+            ? "Refine the saved scene details and preview the current scene configuration."
+            : "Build a scene with curated controls and effect shaping."
+        }
         eyebrow="Scene Studio"
-        title="Create Scene"
+        title={isEditMode ? "Edit Scene" : "Create Scene"}
         titleId={titleId}
       />
 
@@ -1321,7 +1335,11 @@ export function SceneEditorShell({
 
             {sectionMenuValue === "confirm" ? (
               <SceneSection
-                description="Review the scene setup before creating it and expand the raw JSON only if you need a final low-level check."
+                description={
+                  isEditMode
+                    ? "Review the scene setup before updating it and expand the raw JSON only if you need a final low-level check."
+                    : "Review the scene setup before creating it and expand the raw JSON only if you need a final low-level check."
+                }
                 title="Confirm"
               >
                 <div className="scene-editor-stack">
@@ -1511,6 +1529,8 @@ export function SceneEditorShell({
             nextSection={nextSection}
             pendingTagAttachment={pendingTagAttachment}
             previousSection={previousSection}
+            submitLabel={isEditMode ? "Update scene" : "Create scene"}
+            submittingLabel={isEditMode ? "Updating scene..." : "Creating scene..."}
             onSectionStep={handleSectionStep}
           />
 

--- a/src/modules/scene-editor/index.ts
+++ b/src/modules/scene-editor/index.ts
@@ -1,1 +1,2 @@
 export { CreateScenePage } from './CreateScenePage'
+export { EditScenePage } from './EditScenePage'

--- a/src/modules/scene-editor/sceneThumbnailUpload.ts
+++ b/src/modules/scene-editor/sceneThumbnailUpload.ts
@@ -12,11 +12,12 @@ type PresignedThumbnailUploadResponse = {
   headers?: Record<string, string>;
 };
 
-export async function uploadNewSceneThumbnail(
+async function uploadSceneThumbnail(
   authenticatedFetch: AuthenticatedFetch,
   file: File,
+  presignPath: string,
 ) {
-  const presignResponse = await authenticatedFetch("/scenes/thumbnail/presign", {
+  const presignResponse = await authenticatedFetch(presignPath, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -51,4 +52,35 @@ export async function uploadNewSceneThumbnail(
   }
 
   return presignedUpload.objectKey;
+}
+
+export async function uploadNewSceneThumbnail(
+  authenticatedFetch: AuthenticatedFetch,
+  file: File,
+) {
+  return uploadSceneThumbnail(authenticatedFetch, file, "/scenes/thumbnail/presign");
+}
+
+export async function replaceSceneThumbnail(
+  authenticatedFetch: AuthenticatedFetch,
+  sceneId: number,
+  file: File,
+) {
+  const objectKey = await uploadSceneThumbnail(
+    authenticatedFetch,
+    file,
+    `/scenes/${sceneId}/thumbnail/presign`,
+  );
+  const finalizeResponse = await authenticatedFetch(`/scenes/${sceneId}/thumbnail/finalize`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ objectKey }),
+  });
+
+  if (!finalizeResponse.ok) {
+    const apiError = await parseApiError(finalizeResponse);
+    throw new Error(
+      apiError?.message ?? "Failed to replace the scene thumbnail.",
+    );
+  }
 }

--- a/src/modules/scene-editor/test-fixtures.tsx
+++ b/src/modules/scene-editor/test-fixtures.tsx
@@ -7,6 +7,7 @@ import { buildApiUrl } from '@shared/lib'
 import { buildAuthenticatedUser, storeAuthenticatedSession } from '@shared/test/auth'
 import { jsonResponse } from '@shared/test/http'
 import { CreateScenePage } from './CreateScenePage'
+import { EditScenePage } from './EditScenePage'
 
 export type SceneEditorFetchHandler = (
   input: RequestInfo | URL,
@@ -52,10 +53,15 @@ export function mockCreateScenePageFetch(
 ) {
   const defaultThumbnailUploadUrl =
     'https://upload.example.com/scenes/pending/default/thumbnails/scene-preview-thumbnail.png'
+  const sceneThumbnailUploadPattern =
+    /^\/api\/scenes\/(?<sceneId>\d+)\/thumbnail\/presign$/
+  const sceneThumbnailFinalizePattern =
+    /^\/api\/scenes\/(?<sceneId>\d+)\/thumbnail\/finalize$/
 
   return vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
     const method =
       typeof init?.method === 'string' ? init.method.toUpperCase() : 'GET'
+    const inputString = String(input)
 
     if (input === buildApiUrl('/users/me')) {
       return Promise.resolve(jsonResponse(storedUser))
@@ -85,7 +91,37 @@ export function mockCreateScenePageFetch(
       )
     }
 
-    if (input === defaultThumbnailUploadUrl && method === 'PUT') {
+    const sceneThumbnailUploadMatch = inputString.match(sceneThumbnailUploadPattern)
+    if (sceneThumbnailUploadMatch?.groups?.sceneId && method === 'POST') {
+      const { sceneId } = sceneThumbnailUploadMatch.groups
+      return Promise.resolve(
+        jsonResponse({
+          headers: {
+            'Content-Type': 'image/png',
+          },
+          method: 'PUT',
+          objectKey: `scenes/${sceneId}/thumbnails/scene-preview-thumbnail.png`,
+          uploadUrl: `https://upload.example.com/scenes/${sceneId}/thumbnails/scene-preview-thumbnail.png`,
+        }),
+      )
+    }
+
+    const sceneThumbnailFinalizeMatch = inputString.match(sceneThumbnailFinalizePattern)
+    if (sceneThumbnailFinalizeMatch?.groups?.sceneId && method === 'POST') {
+      const sceneId = Number(sceneThumbnailFinalizeMatch.groups.sceneId)
+      return Promise.resolve(
+        jsonResponse(buildSceneEditorApiScene({
+          sceneId,
+          thumbnailRef: `https://cdn.example.com/scenes/${sceneId}/thumbnails/scene-preview-thumbnail.png`,
+        })),
+      )
+    }
+
+    if (
+      (input === defaultThumbnailUploadUrl ||
+        inputString.startsWith('https://upload.example.com/scenes/')) &&
+      method === 'PUT'
+    ) {
       return Promise.resolve(new Response(null, { status: 200 }))
     }
 
@@ -100,6 +136,56 @@ export function renderCreateScenePage() {
         <Routes>
           <Route path="/create-scene" element={<CreateScenePage />} />
           <Route path="/my-scenes" element={<div>My Scenes</div>} />
+        </Routes>
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+export function buildSceneEditorApiScene(
+  overrides: Partial<Record<string, unknown>> = {},
+) {
+  const sceneId = typeof overrides.sceneId === 'number' ? overrides.sceneId : 12
+
+  return {
+    createdAt: '2026-04-06T14:00:00Z',
+    creatorDisplayName: 'Scene Artist',
+    description: 'Soft teal bloom with low-end drift.',
+    engagement: {
+      currentUserSaved: false,
+      currentUserVote: null,
+      downvotes: 0,
+      saves: 0,
+      upvotes: 0,
+      views: 0,
+    },
+    name: 'Aurora Drift',
+    ownerUserId: 8,
+    sceneData: {
+      controls: {
+        position0: { x: 0, y: 0, z: 7 },
+        target0: { x: 0, y: 0, z: 0 },
+        zoom0: 1,
+      },
+      visualizer: {
+        shader: 'nebula',
+        skyboxPreset: 4,
+      },
+    },
+    sceneId,
+    thumbnailRef: `thumbnails/scene-${sceneId}.png`,
+    ...overrides,
+  }
+}
+
+export function renderEditScenePage(initialEntries = ['/scenes/12/edit']) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <AuthProvider>
+        <Routes>
+          <Route path="/login" element={<div>Login</div>} />
+          <Route path="/my-scenes" element={<div>My Scenes</div>} />
+          <Route path="/scenes/:id/edit" element={<EditScenePage />} />
         </Routes>
       </AuthProvider>
     </MemoryRouter>,

--- a/src/modules/scene-editor/types.ts
+++ b/src/modules/scene-editor/types.ts
@@ -50,6 +50,23 @@ export type SceneEditorStateSnapshot = {
   thumbnailFile: File | null
 }
 
+export type SceneEditorInitialState = {
+  description?: string | null
+  name?: string
+  sceneData?: SceneData
+  tagNames?: string[]
+  thumbnailPreviewUrl?: string | null
+}
+
+export type SceneEditorSubmissionMode =
+  | {
+      type: 'create'
+    }
+  | {
+      sceneId: number
+      type: 'edit'
+    }
+
 export type SceneEditorStateBranchUpdater = <K extends keyof SceneEditorModel>(
   branch: K,
   recipe: (currentBranch: SceneEditorModel[K]) => SceneEditorModel[K],

--- a/src/modules/scene-editor/types.ts
+++ b/src/modules/scene-editor/types.ts
@@ -47,6 +47,8 @@ export type SceneEditorStateSnapshot = {
   sceneData: SceneData
   sceneDataText: string
   selectedTagIds: number[]
+  tagsError: string | null
+  tagsLoading: boolean
   thumbnailFile: File | null
 }
 

--- a/src/modules/scene-editor/ui/SceneEditorActionBar.tsx
+++ b/src/modules/scene-editor/ui/SceneEditorActionBar.tsx
@@ -9,6 +9,8 @@ type SceneEditorActionBarProps = {
   nextSection: EditorSectionConfig | null
   pendingTagAttachment: { sceneId: number; tagIds: number[] } | null
   previousSection: EditorSectionConfig | null
+  submitLabel?: string
+  submittingLabel?: string
   onSectionStep: (direction: -1 | 1) => void
 }
 
@@ -20,6 +22,8 @@ export function SceneEditorActionBar({
   nextSection,
   pendingTagAttachment,
   previousSection,
+  submitLabel = 'Create scene',
+  submittingLabel = 'Creating scene...',
   onSectionStep,
 }: SceneEditorActionBarProps) {
   return (
@@ -61,10 +65,10 @@ export function SceneEditorActionBar({
           {isSubmitting
             ? pendingTagAttachment
               ? 'Retrying tag attachment...'
-              : 'Creating scene...'
+              : submittingLabel
             : pendingTagAttachment
               ? 'Retry tag attachment'
-              : 'Create scene'}
+              : submitLabel}
         </button>
       </div>
     </div>

--- a/src/modules/scene-editor/ui/SceneEditorDetailsSection.tsx
+++ b/src/modules/scene-editor/ui/SceneEditorDetailsSection.tsx
@@ -332,6 +332,12 @@ function TagEditor({
         </p>
       ) : null}
 
+      {errors.tags ? (
+        <p className="field-error" role="alert">
+          {errors.tags}
+        </p>
+      ) : null}
+
       {pendingRetryTags.length > 0 ? (
         <p className="field-hint">
           Waiting to retry attachment for:{' '}

--- a/src/modules/scene-editor/useSceneEditorState.ts
+++ b/src/modules/scene-editor/useSceneEditorState.ts
@@ -9,7 +9,12 @@ import {
   type ScenePassId,
 } from './sceneEditor'
 import { initialSceneData, initialSceneModel } from './fixtures'
-import type { CreateSceneFormErrors, EditorSectionId, PendingTagAttachment } from './types'
+import type {
+  CreateSceneFormErrors,
+  EditorSectionId,
+  PendingTagAttachment,
+  SceneEditorInitialState,
+} from './types'
 import {
   buildEffectiveSceneData,
   prettyPrintEditorSceneData,
@@ -23,10 +28,14 @@ import { useSceneTagEditor } from './useSceneTagEditor'
 
 type UseSceneEditorStateArgs = {
   authenticatedFetch: AuthenticatedFetch
+  initialState?: SceneEditorInitialState
+  titleId?: string
 }
 
 export function useSceneEditorState({
   authenticatedFetch,
+  initialState,
+  titleId: providedTitleId = 'create-scene-title',
 }: UseSceneEditorStateArgs) {
   const {
     currentSection,
@@ -38,16 +47,18 @@ export function useSceneEditorState({
     sectionMenuValue,
   } = useSceneEditorNavigation()
   const { actionBarSentinelRef, isActionBarStuck } = useSceneEditorActionBarState()
-  const [name, setName] = useState('')
-  const [description, setDescription] = useState('')
+  const [name, setName] = useState(() => initialState?.name ?? '')
+  const [description, setDescription] = useState(() => initialState?.description ?? '')
   const [thumbnailFile, setThumbnailFile] = useState<File | null>(null)
   const [thumbnailPreviewUrl, setThumbnailPreviewUrl] = useState<string | null>(
-    null,
+    () => initialState?.thumbnailPreviewUrl ?? null,
   )
   const [playlistValue, setPlaylistValue] = useState('')
-  const [sceneData, setSceneData] = useState<SceneData>(initialSceneData)
+  const [sceneData, setSceneData] = useState<SceneData>(
+    () => initialState?.sceneData ?? initialSceneData,
+  )
   const [sceneDataText, setSceneDataText] = useState(() =>
-    prettyPrintEditorSceneData(initialSceneData),
+    prettyPrintEditorSceneData(initialState?.sceneData ?? initialSceneData),
   )
   const [errors, setErrors] = useState<CreateSceneFormErrors>({})
   const [isCameraAdvancedEnabled, setIsCameraAdvancedEnabled] = useState(false)
@@ -65,7 +76,7 @@ export function useSceneEditorState({
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const formErrorId = useId()
-  const titleId = 'create-scene-title'
+  const titleId = providedTitleId
 
   const detailsSectionIssueMessages = [
     validateSceneName(name),
@@ -122,6 +133,7 @@ export function useSceneEditorState({
   } = useSceneTagEditor({
     authenticatedFetch,
     clearErrors,
+    initialSelectedTagNames: initialState?.tagNames,
     pendingTagAttachment,
     setErrors,
   })

--- a/src/modules/scene-editor/useSceneEditorSubmission.ts
+++ b/src/modules/scene-editor/useSceneEditorSubmission.ts
@@ -5,6 +5,7 @@ import { uploadNewSceneThumbnail } from './sceneThumbnailUpload'
 import type {
   CreateSceneFormErrors,
   PendingTagAttachment,
+  SceneEditorSubmissionMode,
   SceneEditorStateSnapshot,
   TagAttachmentFailure,
 } from './types'
@@ -13,6 +14,7 @@ import { buildEffectiveSceneData, parseCreatedSceneId, validateForm } from './ut
 type UseSceneEditorSubmissionArgs = SceneEditorStateSnapshot & {
   authenticatedFetch: AuthenticatedFetch
   captureThumbnailIfMissing: () => Promise<File>
+  mode: SceneEditorSubmissionMode
   onComplete: () => void
   setErrors: Dispatch<SetStateAction<CreateSceneFormErrors>>
   setIsSubmitting: Dispatch<SetStateAction<boolean>>
@@ -75,6 +77,32 @@ async function attachTagsToScene(
   return failures
 }
 
+async function replaceTagsForScene(
+  authenticatedFetch: AuthenticatedFetch,
+  sceneId: number,
+  tagIds: number[],
+) {
+  const response = await authenticatedFetch(`/scenes/${sceneId}/tags`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ tagIds }),
+  })
+
+  if (!response.ok) {
+    const apiError = await parseApiError(response)
+
+    return {
+      details: apiError?.details ?? {},
+      message: apiError?.message ?? 'Failed to update scene tags. Please try again.',
+      ok: false as const,
+    }
+  }
+
+  return {
+    ok: true as const,
+  }
+}
+
 export function useSceneEditorSubmission({
   authenticatedFetch,
   availableTags,
@@ -82,6 +110,7 @@ export function useSceneEditorSubmission({
   description,
   isCameraAdvancedEnabled,
   isMotionAdvancedEnabled,
+  mode,
   name,
   onComplete,
   pendingTagAttachment,
@@ -91,10 +120,99 @@ export function useSceneEditorSubmission({
   setErrors,
   setIsSubmitting,
   setPendingTagAttachment,
+  tagsError,
+  tagsLoading,
   thumbnailFile,
 }: UseSceneEditorSubmissionArgs) {
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
+
+    if (mode.type === 'edit') {
+      if (tagsLoading || tagsError) {
+        setErrors({
+          tags:
+            tagsError ??
+            'Wait for tags to finish loading before updating the scene.',
+        })
+        return
+      }
+
+      const trimmedName = name.trim()
+      const trimmedDescription = description.trim()
+      const { errors: nextErrors, parsedSceneData } = validateForm(
+        trimmedName,
+        sceneDataText,
+      )
+
+      if (Object.keys(nextErrors).length > 0) {
+        setErrors(nextErrors)
+        return
+      }
+
+      const sanitizedSceneData = buildEffectiveSceneData(
+        parsedSceneData ?? sceneData,
+        {
+          isCameraAdvancedEnabled,
+          isMotionAdvancedEnabled,
+        },
+      )
+
+      setIsSubmitting(true)
+      setErrors({})
+
+      try {
+        const response = await authenticatedFetch(`/scenes/${mode.sceneId}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: trimmedName,
+            description: trimmedDescription || null,
+            sceneData: sanitizedSceneData,
+          }),
+        })
+
+        if (!response.ok) {
+          const apiError = await parseApiError(response)
+          const backendDetails = apiError?.details ?? {}
+
+          setErrors({
+            description: backendDetails.description,
+            name: backendDetails.name,
+            sceneData: backendDetails.sceneData,
+            form:
+              apiError?.message ?? 'Failed to update scene. Please try again.',
+          })
+          return
+        }
+
+        const tagResult = await replaceTagsForScene(
+          authenticatedFetch,
+          mode.sceneId,
+          selectedTagIds,
+        )
+
+        if (!tagResult.ok) {
+          setErrors({
+            tags: tagResult.details.tagIds,
+            form: tagResult.message,
+          })
+          return
+        }
+
+        onComplete()
+      } catch (error) {
+        setErrors({
+          form:
+            error instanceof Error && error.message.trim()
+              ? error.message
+              : 'Scene update is unavailable right now. Please try again in a moment.',
+        })
+      } finally {
+        setIsSubmitting(false)
+      }
+
+      return
+    }
 
     if (pendingTagAttachment) {
       setIsSubmitting(true)

--- a/src/modules/scene-editor/useSceneEditorSubmission.ts
+++ b/src/modules/scene-editor/useSceneEditorSubmission.ts
@@ -1,7 +1,7 @@
 import type { Dispatch, FormEvent, SetStateAction } from 'react'
 import type { AuthenticatedFetch } from '@auth'
 import { parseApiError } from '@shared/lib'
-import { uploadNewSceneThumbnail } from './sceneThumbnailUpload'
+import { replaceSceneThumbnail, uploadNewSceneThumbnail } from './sceneThumbnailUpload'
 import type {
   CreateSceneFormErrors,
   PendingTagAttachment,
@@ -197,6 +197,10 @@ export function useSceneEditorSubmission({
             form: tagResult.message,
           })
           return
+        }
+
+        if (thumbnailFile) {
+          await replaceSceneThumbnail(authenticatedFetch, mode.sceneId, thumbnailFile)
         }
 
         onComplete()

--- a/src/modules/scene-editor/useSceneTagEditor.ts
+++ b/src/modules/scene-editor/useSceneTagEditor.ts
@@ -8,6 +8,7 @@ import { loadAvailableTagsFromBackend, normalizeTagName, sortTags, upsertTag } f
 type UseSceneTagEditorArgs = {
   authenticatedFetch: AuthenticatedFetch
   clearErrors: (...fields: Array<keyof CreateSceneFormErrors>) => void
+  initialSelectedTagNames?: string[]
   pendingTagAttachment: PendingTagAttachment | null
   setErrors: Dispatch<SetStateAction<CreateSceneFormErrors>>
 }
@@ -15,6 +16,7 @@ type UseSceneTagEditorArgs = {
 export function useSceneTagEditor({
   authenticatedFetch,
   clearErrors,
+  initialSelectedTagNames = [],
   pendingTagAttachment,
   setErrors,
 }: UseSceneTagEditorArgs) {
@@ -26,6 +28,10 @@ export function useSceneTagEditor({
   const [tagsError, setTagsError] = useState<string | null>(null)
   const [isCreatingTag, setIsCreatingTag] = useState(false)
   const tagDropdownRef = useRef<HTMLDivElement | null>(null)
+  const hasAppliedInitialSelectedTagsRef = useRef(false)
+  const initialSelectedTagNameSetRef = useRef(
+    new Set(initialSelectedTagNames.map((tagName) => normalizeTagName(tagName))),
+  )
   const tagSearchInputId = useId()
   const normalizedTagSearchValue = normalizeTagName(tagSearchValue)
   const selectedTags = useMemo(
@@ -96,6 +102,24 @@ export function useSceneTagEditor({
       isCurrent = false
     }
   }, [])
+
+  useEffect(() => {
+    if (hasAppliedInitialSelectedTagsRef.current || tagsLoading) {
+      return
+    }
+
+    hasAppliedInitialSelectedTagsRef.current = true
+
+    if (initialSelectedTagNameSetRef.current.size === 0) {
+      return
+    }
+
+    setSelectedTagIds(
+      availableTags
+        .filter((tag) => initialSelectedTagNameSetRef.current.has(normalizeTagName(tag.name)))
+        .map((tag) => tag.tagId),
+    )
+  }, [availableTags, tagsLoading])
 
   useEffect(() => {
     if (!isTagDropdownOpen) {


### PR DESCRIPTION
## Summary
- Add a My Scenes row hover action that opens the edit scene page
- Add `/scenes/:id/edit` using the shared scene editor UI with an Update Scene action
- Wire edit submission to update scene details, replace tags, and replace thumbnails
- Add edit scene test fixtures and workflow coverage

## Testing
- `npm test -- --runInBand`
- `npm run build`
- `npm run lint`
