### PR TITLE
58 replace the login page reset button with a real forgot password flow

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -857,10 +857,6 @@
   border: 1px solid rgba(99, 240, 214, 0.18);
 }
 
-.settings-reset-button {
-  justify-self: auto;
-}
-
 .scene-empty-state {
   display: grid;
   gap: 14px;

--- a/src/app/routes/AppRoutes.tsx
+++ b/src/app/routes/AppRoutes.tsx
@@ -1,6 +1,6 @@
 import { Navigate, Route, Routes } from 'react-router-dom'
 import { Layout } from '@app/Layout'
-import { GuestOnlyRoute, LoginPage, RegisterPage } from '@modules/auth'
+import { ForgotPasswordPage, GuestOnlyRoute, LoginPage, RegisterPage } from '@modules/auth'
 import { ScenesPage } from '@modules/discovery'
 import { HomePage } from '@modules/home'
 import { MyScenesPage } from '@modules/my-scenes'
@@ -20,6 +20,14 @@ export function AppRoutes() {
           element={
             <GuestOnlyRoute>
               <LoginPage />
+            </GuestOnlyRoute>
+          }
+        />
+        <Route
+          path="/forgot-password"
+          element={
+            <GuestOnlyRoute>
+              <ForgotPasswordPage />
             </GuestOnlyRoute>
           }
         />

--- a/src/modules/auth/ForgotPasswordPage.test.tsx
+++ b/src/modules/auth/ForgotPasswordPage.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+import { buildApiUrl } from '@shared/lib'
+import { AuthProvider } from '@auth'
+import { ForgotPasswordPage } from './ForgotPasswordPage'
+
+function renderForgotPasswordPage(initialState?: { loginEmail?: string }) {
+  return render(
+    <MemoryRouter
+      initialEntries={[
+        {
+          pathname: '/forgot-password',
+          state: initialState,
+        },
+      ]}
+    >
+      <AuthProvider>
+        <Routes>
+          <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+          <Route path="/login" element={<div>Login page</div>} />
+          <Route path="/" element={<div>Home page</div>} />
+        </Routes>
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('ForgotPasswordPage', () => {
+  it('renders the recovery form and prefills email from login state', () => {
+    renderForgotPasswordPage({ loginEmail: 'artist@example.com' })
+
+    expect(screen.getByRole('heading', { name: /forgot password/i })).toBeInTheDocument()
+    expect(screen.getByLabelText(/^email$/i)).toHaveValue('artist@example.com')
+    expect(screen.getByRole('button', { name: /send reset link/i })).toBeInTheDocument()
+  })
+
+  it('shows client-side validation for blank and malformed email values', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    const user = userEvent.setup()
+
+    renderForgotPasswordPage()
+
+    await user.click(screen.getByRole('button', { name: /send reset link/i }))
+    expect(await screen.findByText('Email is required.')).toBeInTheDocument()
+
+    await user.type(screen.getByLabelText(/^email$/i), 'not-an-email')
+    await user.click(screen.getByRole('button', { name: /send reset link/i }))
+
+    expect(await screen.findByText('Enter a valid email address.')).toBeInTheDocument()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('submits the email and shows a neutral success state', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          message: 'If an account with that email exists, a password reset link has been sent.',
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      ),
+    )
+    const user = userEvent.setup()
+
+    renderForgotPasswordPage()
+
+    await user.type(screen.getByLabelText(/^email$/i), ' user@example.com ')
+    await user.click(screen.getByRole('button', { name: /send reset link/i }))
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      buildApiUrl('/auth/reset-password/request'),
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: 'user@example.com',
+        }),
+      }),
+    )
+
+    expect(
+      await screen.findByText(
+        'If an account with that email exists, a password reset link has been sent.',
+      ),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Sent to:')).toBeInTheDocument()
+    expect(screen.getByText('user@example.com')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /back to login/i })).toBeInTheDocument()
+  })
+
+  it('surfaces backend validation details when the request is rejected', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          message: 'Request validation failed.',
+          details: {
+            email: 'email must be a well-formed email address',
+          },
+        }),
+        {
+          status: 400,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      ),
+    )
+    const user = userEvent.setup()
+
+    renderForgotPasswordPage()
+
+    await user.type(screen.getByLabelText(/^email$/i), 'user@example.com')
+    await user.click(screen.getByRole('button', { name: /send reset link/i }))
+
+    expect(
+      await screen.findByText('email must be a well-formed email address'),
+    ).toBeInTheDocument()
+  })
+
+  it('shows a generic failure notice when the request throws', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network down'))
+    const user = userEvent.setup()
+
+    renderForgotPasswordPage()
+
+    await user.type(screen.getByLabelText(/^email$/i), 'user@example.com')
+    await user.click(screen.getByRole('button', { name: /send reset link/i }))
+
+    expect(
+      await screen.findByText(
+        'Password reset is unavailable right now. Please try again in a moment.',
+      ),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/modules/auth/ForgotPasswordPage.tsx
+++ b/src/modules/auth/ForgotPasswordPage.tsx
@@ -1,0 +1,204 @@
+import { useId, useState } from 'react'
+import type { FormEvent } from 'react'
+import { Link, Navigate, useLocation } from 'react-router-dom'
+import { AuthPage, AuthPageHeader, FormNotice, TextInputField } from '@shared/ui'
+import { emailPattern, parseApiError } from '@shared/lib'
+import { requestPasswordReset } from './client'
+import { useAuth } from './authContext'
+
+type ForgotPasswordFormValues = {
+  email: string
+}
+
+type ForgotPasswordFormErrors = Partial<Record<keyof ForgotPasswordFormValues | 'form', string>>
+
+type ForgotPasswordLocationState = {
+  loginEmail?: string
+}
+
+type PasswordResetResponse = {
+  message?: string
+}
+
+const initialValues: ForgotPasswordFormValues = {
+  email: '',
+}
+
+const fallbackSuccessMessage =
+  'If an account with that email exists, a password reset link has been sent.'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function readForgotPasswordLocationState(state: unknown): ForgotPasswordLocationState {
+  if (!isRecord(state)) {
+    return {}
+  }
+
+  return {
+    loginEmail: typeof state.loginEmail === 'string' ? state.loginEmail : undefined,
+  }
+}
+
+function validateForgotPasswordForm(values: ForgotPasswordFormValues): ForgotPasswordFormErrors {
+  const errors: ForgotPasswordFormErrors = {}
+
+  if (!values.email.trim()) {
+    errors.email = 'Email is required.'
+  } else if (!emailPattern.test(values.email.trim())) {
+    errors.email = 'Enter a valid email address.'
+  }
+
+  return errors
+}
+
+export function ForgotPasswordPage() {
+  const { isAuthenticated } = useAuth()
+  const location = useLocation()
+  const forgotPasswordLocationState = readForgotPasswordLocationState(location.state)
+  const [values, setValues] = useState<ForgotPasswordFormValues>(() => ({
+    ...initialValues,
+    email: forgotPasswordLocationState.loginEmail ?? '',
+  }))
+  const [errors, setErrors] = useState<ForgotPasswordFormErrors>({})
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [confirmationMessage, setConfirmationMessage] = useState('')
+  const [submittedEmail, setSubmittedEmail] = useState('')
+
+  const formNoticeId = useId()
+  const titleId = 'forgot-password-title'
+
+  if (isAuthenticated) {
+    return <Navigate replace to="/" />
+  }
+
+  function handleChange(nextValue: string) {
+    setValues({ email: nextValue })
+
+    setErrors((currentErrors) => {
+      if (!currentErrors.email && !currentErrors.form) {
+        return currentErrors
+      }
+
+      return {
+        ...currentErrors,
+        email: undefined,
+        form: undefined,
+      }
+    })
+
+    if (confirmationMessage) {
+      setConfirmationMessage('')
+      setSubmittedEmail('')
+    }
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    const trimmedValues = {
+      email: values.email.trim(),
+    }
+
+    const nextErrors = validateForgotPasswordForm(trimmedValues)
+
+    if (Object.keys(nextErrors).length > 0) {
+      setErrors(nextErrors)
+      return
+    }
+
+    setIsSubmitting(true)
+    setErrors({})
+
+    try {
+      const response = await requestPasswordReset(trimmedValues)
+
+      if (!response.ok) {
+        const apiError = await parseApiError(response)
+        const backendDetails = apiError?.details ?? {}
+
+        setErrors({
+          email: backendDetails.email,
+          form:
+            apiError?.message ??
+            'Password reset is unavailable right now. Please try again in a moment.',
+        })
+        return
+      }
+
+      const payload = (await response.json().catch(() => null)) as PasswordResetResponse | null
+
+      setConfirmationMessage(payload?.message?.trim() || fallbackSuccessMessage)
+      setSubmittedEmail(trimmedValues.email)
+    } catch {
+      setErrors({
+        form: 'Password reset is unavailable right now. Please try again in a moment.',
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <AuthPage titleId={titleId}>
+      <AuthPageHeader
+        description="Enter your email address and MAGE will start the password recovery process."
+        eyebrow="Account Recovery"
+        title="Forgot password"
+        titleId={titleId}
+      />
+
+      {confirmationMessage ? (
+        <>
+          <FormNotice tone="note">{confirmationMessage}</FormNotice>
+          <p className="auth-footnote">
+            If the address is registered, use the reset link from that recovery message to continue.
+          </p>
+          <p className="auth-footnote">
+            Sent to: <strong>{submittedEmail}</strong>
+          </p>
+          <p className="auth-footnote">
+            <Link className="secondary-link" to="/login">
+              Back to login
+            </Link>
+          </p>
+        </>
+      ) : (
+        <>
+          <form className="auth-form" noValidate onSubmit={handleSubmit}>
+            <TextInputField
+              autoComplete="email"
+              error={errors.email}
+              id="email"
+              label="Email"
+              name="email"
+              onChange={(event) => handleChange(event.target.value)}
+              placeholder="you@example.com"
+              required
+              type="email"
+              value={values.email}
+            />
+
+            {errors.form ? (
+              <FormNotice id={formNoticeId} tone="error">
+                {errors.form}
+              </FormNotice>
+            ) : null}
+
+            <button className="demo-link auth-submit" type="submit" disabled={isSubmitting}>
+              {isSubmitting ? 'Sending reset link...' : 'Send reset link'}
+            </button>
+          </form>
+
+          <p className="auth-footnote">
+            Remembered your password?{' '}
+            <Link className="secondary-link" to="/login">
+              Back to login
+            </Link>
+          </p>
+        </>
+      )}
+    </AuthPage>
+  )
+}

--- a/src/modules/auth/LoginPage.test.tsx
+++ b/src/modules/auth/LoginPage.test.tsx
@@ -26,6 +26,7 @@ function renderLoginPage(options: RenderLoginPageOptions = {}) {
       <AuthProvider>
         <Routes>
           <Route path="/login" element={<LoginPage />} />
+          <Route path="/forgot-password" element={<div>Forgot password page</div>} />
           <Route path="/" element={<div>Home page</div>} />
           <Route path="/settings" element={<div>Settings page</div>} />
         </Routes>
@@ -125,6 +126,17 @@ describe('LoginPage', () => {
     expect(
       screen.getByText('Account created. Sign in to open your profile.'),
     ).toBeInTheDocument()
+  })
+
+  it('routes the reset-password action into the forgot-password flow', async () => {
+    const user = userEvent.setup()
+
+    renderLoginPage()
+
+    await user.type(screen.getByLabelText(/^email$/i), 'artist@example.com')
+    await user.click(screen.getByRole('link', { name: /reset it here/i }))
+
+    expect(await screen.findByText('Forgot password page')).toBeInTheDocument()
   })
 
   it('shows backend invalid-credential errors clearly to the user', async () => {

--- a/src/modules/auth/LoginPage.tsx
+++ b/src/modules/auth/LoginPage.tsx
@@ -79,7 +79,6 @@ export function LoginPage() {
   }))
   const [errors, setErrors] = useState<LoginFormErrors>({})
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [resetPasswordNotice, setResetPasswordNotice] = useState('')
   const [registrationNotice, setRegistrationNotice] = useState(
     loginLocationState.registrationNotice ?? '',
   )
@@ -106,10 +105,6 @@ export function LoginPage() {
         form: undefined,
       }
     })
-
-    if (resetPasswordNotice) {
-      setResetPasswordNotice('')
-    }
 
     if (registrationNotice) {
       setRegistrationNotice('')
@@ -249,8 +244,6 @@ export function LoginPage() {
 
             {registrationNotice ? <FormNotice tone="note">{registrationNotice}</FormNotice> : null}
 
-            {resetPasswordNotice ? <FormNotice tone="note">{resetPasswordNotice}</FormNotice> : null}
-
             <button className="demo-link auth-submit" type="submit" disabled={isSubmitDisabled}>
               {isSubmitting ? 'Signing in...' : 'Sign in'}
             </button>
@@ -258,17 +251,15 @@ export function LoginPage() {
 
           <p className="auth-footnote">
             Forgot your password?{' '}
-            <button
+            <Link
               className="auth-link-button"
-              type="button"
-              onClick={() =>
-                setResetPasswordNotice(
-                  'Password reset is not connected yet, but this option is now available in the frontend.',
-                )
-              }
+              to="/forgot-password"
+              state={{
+                loginEmail: values.email.trim() || undefined,
+              }}
             >
               Reset it here
-            </button>
+            </Link>
           </p>
 
           <p className="auth-footnote">

--- a/src/modules/auth/README.md
+++ b/src/modules/auth/README.md
@@ -14,6 +14,7 @@ Exports:
 - `ProtectedRoute`
 - `GuestOnlyRoute`
 - `LoginPage`
+- `ForgotPasswordPage`
 - `RegisterPage`
 
 ## Internal Responsibilities
@@ -28,6 +29,8 @@ Exports:
   Protected-route and guest-route behavior.
 - `LoginPage.tsx` and `RegisterPage.tsx`
   Route-facing auth UI.
+- `ForgotPasswordPage.tsx`
+  Password-recovery request UI.
 
 ## Integration Rules
 
@@ -82,6 +85,7 @@ User-facing behavior:
 - redirects to `/` after a successful login
 - shows field-level and form-level backend errors when available
 - shows a registration success notice when arriving from the registration flow
+- links to `/forgot-password` for password recovery
 
 Failure modes:
 
@@ -89,6 +93,39 @@ Failure modes:
 - missing `accessToken` in an otherwise successful response is treated as a frontend error
 - network failures show a generic unavailable message
 - invalid stored sessions are removed automatically during auth bootstrap
+
+### `/forgot-password`
+
+Access:
+
+- guest-only
+- authenticated users are redirected to `/`
+
+Request flow:
+
+- `POST /api/auth/reset-password/request`
+
+Expected request body:
+
+```json
+{
+  "email": "user@example.com"
+}
+```
+
+User-facing behavior:
+
+- validates required input and email format on the client
+- pre-fills the email field when arriving from the login page with a typed address
+- disables submit while the request is in flight
+- shows a neutral confirmation state after a successful request
+- links back to `/login` after the request is submitted
+
+Failure modes:
+
+- backend validation details are surfaced on the email field when available
+- network or server failures show a generic unavailable message
+- successful responses do not reveal whether the submitted email exists
 
 ### `/register`
 

--- a/src/modules/auth/client.ts
+++ b/src/modules/auth/client.ts
@@ -13,6 +13,10 @@ type RegisterRequest = {
   password: string
 }
 
+type PasswordResetRequest = {
+  email: string
+}
+
 export function buildAuthorizationHeaders(headers: HeadersInit | undefined, accessToken: string) {
   const nextHeaders = new Headers(headers)
   nextHeaders.set('Authorization', `Bearer ${accessToken}`)
@@ -48,6 +52,16 @@ export async function loginWithCredentials(payload: LoginRequest) {
 
 export async function registerLocalAccount(payload: RegisterRequest) {
   return fetch(buildApiUrl('/auth/register'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  })
+}
+
+export async function requestPasswordReset(payload: PasswordResetRequest) {
+  return fetch(buildApiUrl('/auth/reset-password/request'), {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -1,4 +1,5 @@
 export { AuthProvider } from './AuthProvider'
+export { ForgotPasswordPage } from './ForgotPasswordPage'
 export { GuestOnlyRoute, ProtectedRoute } from './guards'
 export { LoginPage } from './LoginPage'
 export { RegisterPage } from './RegisterPage'

--- a/src/modules/settings/README.md
+++ b/src/modules/settings/README.md
@@ -16,8 +16,12 @@ Exports:
   Route-facing React boundary for settings.
 - `profile.ts`
   Profile save behavior layered on top of `authenticatedFetch()`.
+- `password.ts`
+  Password change behavior layered on top of `authenticatedFetch()`.
 - `ui/ProfileDetailsForm.tsx`
   Settings-owned profile form UI and field-level messages.
+- `ui/PasswordChangeForm.tsx`
+  Settings-owned password change UI and field-level messages.
 - `ui/ThemeSettingsSection.tsx`
   Settings-owned theme selection surface that consumes the theme module API.
 
@@ -38,6 +42,7 @@ Access:
 Request flow:
 
 - `PUT /api/users/me`
+- `PUT /api/users/me/password`
 
 Expected request body:
 
@@ -46,6 +51,15 @@ Expected request body:
   "firstName": "Scene",
   "lastName": "Artist",
   "displayName": "Scene Artist"
+}
+```
+
+Expected password-change body:
+
+```json
+{
+  "currentPassword": "current-password",
+  "newPassword": "new-password"
 }
 ```
 
@@ -59,16 +73,16 @@ User-facing behavior:
 - disables the save button until a name field changes
 - surfaces backend field validation details when present
 - updates the shared auth session after a successful save
+- renders a password section for local-auth-capable users
+- requires current password, new password, and new password verification before saving
+- shows a clear unsupported message for Google-only accounts
+- surfaces invalid-current-password and backend validation errors when present
 
 Theme notes:
 
 - the settings module does not manage theme CSS directly
 - theme selection UI talks to the shared theme provider through `@theme`
 - current built-in themes are `MAGE Pulse` and `Classic Blue`
-
-Current limitations:
-
-- the page edits profile names and theme choice only; broader account-management flows are not wired yet
 
 ## Tests
 

--- a/src/modules/settings/SettingsPage.test.tsx
+++ b/src/modules/settings/SettingsPage.test.tsx
@@ -70,6 +70,7 @@ describe('SettingsPage', () => {
     expect(screen.getByRole('heading', { name: /^settings$/i, level: 1 })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: /theme/i, level: 2 })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: /profile details/i, level: 2 })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /password/i, level: 2 })).toBeInTheDocument()
     expect(
       screen.getByText(
         /manage your mage profile details and choose the interface theme that fits this device/i,
@@ -82,7 +83,11 @@ describe('SettingsPage', () => {
     expect(screen.getByLabelText(/last name/i)).toHaveValue('Artist')
     expect(screen.queryByText('LOCAL')).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: /save changes/i })).toBeDisabled()
-    expect(screen.getByRole('button', { name: /reset password/i })).toBeInTheDocument()
+    expect(screen.getByLabelText(/current password/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/^new password$/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/verify new password/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /save password/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /reset password/i })).not.toBeInTheDocument()
   })
 
   it('persists the selected theme on this device', async () => {
@@ -265,6 +270,215 @@ describe('SettingsPage', () => {
     ).toBeInTheDocument()
     expect(authState.updateAuthenticatedUser).not.toHaveBeenCalled()
     expect(screen.getByRole('button', { name: /save changes/i })).toBeEnabled()
+  })
+
+  it('changes a local account password through the authenticated backend flow', async () => {
+    authState = {
+      ...authState,
+      accessToken: 'token',
+      authenticatedFetch: vi.fn().mockResolvedValue(new Response(null, { status: 204 })),
+      isAuthenticated: true,
+      user: {
+        authProvider: 'LOCAL',
+        displayName: 'Scene Artist',
+        email: 'artist@example.com',
+        firstName: 'Scene',
+        lastName: 'Artist',
+        userId: 8,
+      },
+    }
+
+    const user = userEvent.setup()
+
+    renderSettingsPage()
+
+    await user.type(screen.getByLabelText(/current password/i), 'current-secret')
+    await user.type(screen.getByLabelText(/^new password$/i), 'new-secret-value')
+    await user.type(screen.getByLabelText(/verify new password/i), 'new-secret-value')
+    await user.click(screen.getByRole('button', { name: /save password/i }))
+
+    await waitFor(() =>
+      expect(authState.authenticatedFetch).toHaveBeenCalledWith(
+        '/users/me/password',
+        expect.objectContaining({
+          method: 'PUT',
+          body: JSON.stringify({
+            currentPassword: 'current-secret',
+            newPassword: 'new-secret-value',
+          }),
+        }),
+      ),
+    )
+
+    expect(await screen.findByText('Password updated.')).toBeInTheDocument()
+    expect(screen.getByLabelText(/current password/i)).toHaveValue('')
+    expect(screen.getByLabelText(/^new password$/i)).toHaveValue('')
+    expect(screen.getByLabelText(/verify new password/i)).toHaveValue('')
+  })
+
+  it('validates password change fields before submitting', async () => {
+    authState = {
+      ...authState,
+      accessToken: 'token',
+      authenticatedFetch: vi.fn(),
+      isAuthenticated: true,
+      user: {
+        authProvider: 'LOCAL',
+        displayName: 'Scene Artist',
+        email: 'artist@example.com',
+        firstName: 'Scene',
+        lastName: 'Artist',
+        userId: 8,
+      },
+    }
+
+    const user = userEvent.setup()
+
+    renderSettingsPage()
+
+    await user.click(screen.getByRole('button', { name: /save password/i }))
+
+    expect(await screen.findByText('Current password is required.')).toBeInTheDocument()
+    expect(screen.getByText('New password is required.')).toBeInTheDocument()
+    expect(screen.getByText('Verify your new password.')).toBeInTheDocument()
+    expect(authState.authenticatedFetch).not.toHaveBeenCalled()
+
+    await user.type(screen.getByLabelText(/current password/i), 'current-secret')
+    await user.type(screen.getByLabelText(/^new password$/i), 'short')
+    await user.type(screen.getByLabelText(/verify new password/i), 'different-value')
+    await user.click(screen.getByRole('button', { name: /save password/i }))
+
+    expect(
+      await screen.findByText('New password must be between 8 and 72 characters.'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('New passwords must match.')).toBeInTheDocument()
+    expect(authState.authenticatedFetch).not.toHaveBeenCalled()
+  })
+
+  it('shows invalid current password errors on the current password field', async () => {
+    authState = {
+      ...authState,
+      accessToken: 'token',
+      authenticatedFetch: vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            code: 'INVALID_CURRENT_PASSWORD',
+            message: 'Current password is incorrect.',
+          }),
+          {
+            status: 400,
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          },
+        ),
+      ),
+      isAuthenticated: true,
+      user: {
+        authProvider: 'LOCAL',
+        displayName: 'Scene Artist',
+        email: 'artist@example.com',
+        firstName: 'Scene',
+        lastName: 'Artist',
+        userId: 8,
+      },
+    }
+
+    const user = userEvent.setup()
+
+    renderSettingsPage()
+
+    await user.type(screen.getByLabelText(/current password/i), 'wrong-secret')
+    await user.type(screen.getByLabelText(/^new password$/i), 'new-secret-value')
+    await user.type(screen.getByLabelText(/verify new password/i), 'new-secret-value')
+    await user.click(screen.getByRole('button', { name: /save password/i }))
+
+    expect(await screen.findByText('Current password is incorrect.')).toBeInTheDocument()
+  })
+
+  it('shows backend password validation and request failure messages clearly', async () => {
+    authState = {
+      ...authState,
+      accessToken: 'token',
+      authenticatedFetch: vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              message: 'Request validation failed.',
+              details: {
+                newPassword: 'newPassword must be between 8 and 72 characters',
+              },
+            }),
+            {
+              status: 400,
+              headers: {
+                'Content-Type': 'application/json',
+              },
+            },
+          ),
+        )
+        .mockRejectedValueOnce(new Error('network down')),
+      isAuthenticated: true,
+      user: {
+        authProvider: 'LOCAL',
+        displayName: 'Scene Artist',
+        email: 'artist@example.com',
+        firstName: 'Scene',
+        lastName: 'Artist',
+        userId: 8,
+      },
+    }
+
+    const user = userEvent.setup()
+
+    renderSettingsPage()
+
+    await user.type(screen.getByLabelText(/current password/i), 'current-secret')
+    await user.type(screen.getByLabelText(/^new password$/i), 'new-secret-value')
+    await user.type(screen.getByLabelText(/verify new password/i), 'new-secret-value')
+    await user.click(screen.getByRole('button', { name: /save password/i }))
+
+    expect(
+      await screen.findByText('newPassword must be between 8 and 72 characters'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Request validation failed.')).toBeInTheDocument()
+
+    await user.clear(screen.getByLabelText(/current password/i))
+    await user.type(screen.getByLabelText(/current password/i), 'current-secret')
+    await user.click(screen.getByRole('button', { name: /save password/i }))
+
+    expect(
+      await screen.findByText(
+        'Password changes are unavailable right now. Please try again in a moment.',
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it('shows an unsupported password state for Google-only users', () => {
+    authState = {
+      ...authState,
+      accessToken: 'token',
+      authenticatedFetch: vi.fn(),
+      isAuthenticated: true,
+      user: {
+        authProvider: 'GOOGLE',
+        displayName: 'Scene Artist',
+        email: 'artist@example.com',
+        firstName: 'Scene',
+        lastName: 'Artist',
+        userId: 8,
+      },
+    }
+
+    renderSettingsPage()
+
+    expect(
+      screen.getByText('Password changes are managed by Google for this account.'),
+    ).toBeInTheDocument()
+    expect(screen.queryByLabelText(/current password/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /save password/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /reset password/i })).not.toBeInTheDocument()
   })
 
   it('shows a fallback state when the page cannot read a signed-in user', () => {

--- a/src/modules/settings/SettingsPage.tsx
+++ b/src/modules/settings/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useAuth } from '@auth'
+import { changePassword } from './password'
 import { saveUserProfile } from './profile'
-import { ProfileDetailsForm, ThemeSettingsSection } from './ui'
+import { PasswordChangeForm, ProfileDetailsForm, ThemeSettingsSection } from './ui'
 
 export function SettingsPage() {
   const { authenticatedFetch, updateAuthenticatedUser, user } = useAuth()
@@ -42,6 +43,11 @@ export function SettingsPage() {
 
             return result
           }}
+        />
+
+        <PasswordChangeForm
+          authProvider={user.authProvider}
+          onSave={(passwordFields) => changePassword(authenticatedFetch, passwordFields)}
         />
       </section>
     </main>

--- a/src/modules/settings/password.ts
+++ b/src/modules/settings/password.ts
@@ -1,0 +1,40 @@
+import { parseApiError } from '@shared/lib'
+import type { AuthenticatedFetch } from '@auth'
+import type { PasswordChangeFields, PasswordChangeResult } from './types'
+
+export const PASSWORD_CHANGE_UNAVAILABLE_MESSAGE =
+  'Password changes are unavailable right now. Please try again in a moment.'
+
+export async function changePassword(
+  authenticatedFetch: AuthenticatedFetch,
+  fields: PasswordChangeFields,
+): Promise<PasswordChangeResult> {
+  try {
+    const response = await authenticatedFetch('/users/me/password', {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(fields),
+    })
+
+    if (!response.ok) {
+      const apiError = await parseApiError(response)
+
+      return {
+        ok: false,
+        code: apiError?.code,
+        details: apiError?.details ?? {},
+        message: apiError?.message ?? PASSWORD_CHANGE_UNAVAILABLE_MESSAGE,
+      }
+    }
+
+    return { ok: true }
+  } catch {
+    return {
+      ok: false,
+      details: {},
+      message: PASSWORD_CHANGE_UNAVAILABLE_MESSAGE,
+    }
+  }
+}

--- a/src/modules/settings/types.ts
+++ b/src/modules/settings/types.ts
@@ -17,3 +17,12 @@ export type UserProfileResponse = {
 export type ProfileSaveResult =
   | { ok: true }
   | { ok: false; details: Record<string, string>; message: string }
+
+export type PasswordChangeFields = {
+  currentPassword: string
+  newPassword: string
+}
+
+export type PasswordChangeResult =
+  | { ok: true }
+  | { ok: false; code?: string; details: Record<string, string>; message: string }

--- a/src/modules/settings/ui/PasswordChangeForm.tsx
+++ b/src/modules/settings/ui/PasswordChangeForm.tsx
@@ -1,0 +1,174 @@
+import { useId, useState, type FormEvent } from 'react'
+import { FormNotice, SurfaceCard, TextInputField } from '@shared/ui'
+import type { PasswordChangeFields, PasswordChangeResult } from '../types'
+
+type PasswordChangeFormProps = {
+  authProvider: string
+  onSave: (fields: PasswordChangeFields) => Promise<PasswordChangeResult>
+}
+
+type PasswordFormValues = PasswordChangeFields & {
+  confirmNewPassword: string
+}
+
+type PasswordFormErrors = Partial<Record<keyof PasswordFormValues | 'form', string>>
+
+const initialValues: PasswordFormValues = {
+  currentPassword: '',
+  newPassword: '',
+  confirmNewPassword: '',
+}
+
+function supportsLocalPassword(authProvider: string) {
+  return authProvider === 'LOCAL' || authProvider === 'LOCAL_GOOGLE'
+}
+
+function validatePasswordForm(values: PasswordFormValues): PasswordFormErrors {
+  const errors: PasswordFormErrors = {}
+
+  if (!values.currentPassword.trim()) {
+    errors.currentPassword = 'Current password is required.'
+  }
+
+  if (!values.newPassword.trim()) {
+    errors.newPassword = 'New password is required.'
+  } else if (values.newPassword.length < 8 || values.newPassword.length > 72) {
+    errors.newPassword = 'New password must be between 8 and 72 characters.'
+  }
+
+  if (!values.confirmNewPassword.trim()) {
+    errors.confirmNewPassword = 'Verify your new password.'
+  } else if (values.confirmNewPassword !== values.newPassword) {
+    errors.confirmNewPassword = 'New passwords must match.'
+  }
+
+  return errors
+}
+
+export function PasswordChangeForm({ authProvider, onSave }: PasswordChangeFormProps) {
+  const [values, setValues] = useState<PasswordFormValues>(initialValues)
+  const [errors, setErrors] = useState<PasswordFormErrors>({})
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [successMessage, setSuccessMessage] = useState('')
+  const formNoticeId = useId()
+
+  function handleChange(field: keyof PasswordFormValues, value: string) {
+    setValues((currentValues) => ({
+      ...currentValues,
+      [field]: value,
+    }))
+    setErrors({})
+    setSuccessMessage('')
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    const nextErrors = validatePasswordForm(values)
+
+    if (Object.keys(nextErrors).length > 0) {
+      setErrors(nextErrors)
+      setSuccessMessage('')
+      return
+    }
+
+    setIsSubmitting(true)
+    setErrors({})
+    setSuccessMessage('')
+
+    try {
+      const result = await onSave({
+        currentPassword: values.currentPassword,
+        newPassword: values.newPassword,
+      })
+
+      if (!result.ok) {
+        const currentPasswordError =
+          result.details.currentPassword ??
+          (result.code === 'INVALID_CURRENT_PASSWORD' ? result.message : undefined)
+
+        setErrors({
+          currentPassword: currentPasswordError,
+          newPassword: result.details.newPassword,
+          form: currentPasswordError ? undefined : result.message,
+        })
+        return
+      }
+
+      setValues(initialValues)
+      setSuccessMessage('Password updated.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <SurfaceCard as="section" className="settings-section" tone="soft" aria-label="Password">
+      <div className="settings-section__header">
+        <h2>Password</h2>
+        <p>Change the password used to sign in with this MAGE account.</p>
+      </div>
+
+      {!supportsLocalPassword(authProvider) ? (
+        <FormNotice tone="note">
+          Password changes are managed by Google for this account.
+        </FormNotice>
+      ) : (
+        <form className="settings-fields" noValidate onSubmit={handleSubmit}>
+          <TextInputField
+            autoComplete="current-password"
+            error={errors.currentPassword}
+            id="settings-current-password"
+            label="Current password"
+            name="currentPassword"
+            onChange={(event) => handleChange('currentPassword', event.target.value)}
+            required
+            type="password"
+            value={values.currentPassword}
+          />
+          <TextInputField
+            autoComplete="new-password"
+            error={errors.newPassword}
+            hint="Use 8 to 72 characters."
+            id="settings-new-password"
+            label="New password"
+            name="newPassword"
+            onChange={(event) => handleChange('newPassword', event.target.value)}
+            required
+            type="password"
+            value={values.newPassword}
+          />
+          <TextInputField
+            autoComplete="new-password"
+            error={errors.confirmNewPassword}
+            id="settings-confirm-new-password"
+            label="Verify new password"
+            name="confirmNewPassword"
+            onChange={(event) => handleChange('confirmNewPassword', event.target.value)}
+            required
+            type="password"
+            value={values.confirmNewPassword}
+          />
+
+          {errors.form ? (
+            <FormNotice id={formNoticeId} tone="error">
+              {errors.form}
+            </FormNotice>
+          ) : null}
+
+          {successMessage ? <FormNotice tone="note">{successMessage}</FormNotice> : null}
+
+          <div className="settings-actions">
+            <button
+              className="demo-link auth-submit settings-action-button settings-save-button"
+              disabled={isSubmitting}
+              type="submit"
+            >
+              {isSubmitting ? 'Saving password...' : 'Save password'}
+            </button>
+          </div>
+        </form>
+      )}
+    </SurfaceCard>
+  )
+}

--- a/src/modules/settings/ui/ProfileDetailsForm.tsx
+++ b/src/modules/settings/ui/ProfileDetailsForm.tsx
@@ -137,13 +137,6 @@ export function ProfileDetailsForm({
           >
             {isSubmitting ? 'Saving...' : 'Save changes'}
           </button>
-
-          <button
-            className="scene-secondary-button settings-action-button settings-reset-button"
-            type="button"
-          >
-            Reset password
-          </button>
         </div>
       </form>
     </SurfaceCard>

--- a/src/modules/settings/ui/index.ts
+++ b/src/modules/settings/ui/index.ts
@@ -1,2 +1,3 @@
+export { PasswordChangeForm } from './PasswordChangeForm'
 export { ProfileDetailsForm } from './ProfileDetailsForm'
 export { ThemeSettingsSection } from './ThemeSettingsSection'


### PR DESCRIPTION
## Summary
- Add a real forgot-password recovery flow from the login page
- Add `/forgot-password` with email collection, backend submission, neutral success messaging, and error handling
- Replace the settings reset-password placeholder with a real password change section
- Require current password, new password, and new password verification before saving
- Hide the local password form for Google-only users with a clear unsupported message
- Update auth/settings docs and test coverage

## Testing
- `npm test -- --runInBand`
- `npm run lint`
- `npm run build`
